### PR TITLE
use `TcpStream::split` in `Session::manage` on `rt_tokio` & omit `Vec` from `Path.params`

### DIFF
--- a/benches/.gitignore
+++ b/benches/.gitignore
@@ -1,3 +1,3 @@
-flamegraph.svg
+*flamegraph.svg
 perf.data
 perf.data.old

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -11,7 +11,7 @@ default = ["DEBUG"]
 
 [dependencies]
 ohkami             = { path = "../ohkami", default-features = false, features = ["rt_tokio"] }
-ohkami_lib         = { version = "0.2.3", path = "../ohkami_lib" }
+ohkami_lib         = { path = "../ohkami_lib" }
 http               = "1.0.0"
 rustc-hash         = "1.1"
 bytes              = "1.5.0"

--- a/benches/benches/imf_fixdate.rs
+++ b/benches/benches/imf_fixdate.rs
@@ -1,0 +1,14 @@
+#![feature(test)]
+extern crate test;
+
+use ohkami_lib::time::UTCDateTime;
+use ohkami::utils::unix_timestamp;
+
+
+#[bench] fn format_imf_fixdate(b: &mut test::Bencher) {
+    b.iter(|| {
+        UTCDateTime::from_duration_since_unix_epoch(
+            std::time::Duration::from_secs(unix_timestamp())
+        ).into_imf_fixdate();
+    })
+}

--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -18,7 +18,7 @@ features      = ["rt_tokio", "nightly", "sse"]
 
 
 [dependencies]
-ohkami_lib    = { version = "=0.2.4", path = "../ohkami_lib" }
+ohkami_lib    = { version = "=0.2.5", path = "../ohkami_lib" }
 ohkami_macros = { version = "=0.8.0", path = "../ohkami_macros" }
 
 tokio         = { version = "1",   optional = true, features = ["net", "rt", "io-util", "sync", "time"] }

--- a/ohkami/src/lib.rs
+++ b/ohkami/src/lib.rs
@@ -121,9 +121,7 @@ pub mod utils {
     pub use crate::fangs::util::FangAction;
 
     #[cfg(feature="sse")]
-    pub use ohkami_lib::stream;
-    #[cfg(feature="sse")]
-    pub use ohkami_lib::stream::{Stream, StreamExt};
+    pub use ohkami_lib::stream::{self, Stream, StreamExt};
 
     #[cfg(not(feature="rt_worker"))]
     /// ```

--- a/ohkami/src/request/headers.rs
+++ b/ohkami/src/request/headers.rs
@@ -403,7 +403,7 @@ impl Headers {
     pub(crate) fn init() -> Self {
         Self {
             standard: Box::new([const {None}; N_CLIENT_HEADERS]),
-            custom: None,
+            custom:   None,
         }
     }
     #[cfg(feature="DEBUG")]

--- a/ohkami/src/request/headers.rs
+++ b/ohkami/src/request/headers.rs
@@ -330,7 +330,7 @@ impl Headers {
     }
     #[cfg(feature="DEBUG")]
     #[inline(always)] pub fn _insert(&mut self, name: Header, value: CowSlice) {
-        unsafe {*self.standard.get_unchecked_mut(name as usize) = Some(value)}
+        self.insert(name, value)
     }
 
     pub(crate) fn remove(&mut self, name: Header) {
@@ -352,10 +352,10 @@ impl Headers {
 
         match target {
             None => *target = Some(value),
-            Some(v) => (|| unsafe {
+            Some(v) => (|slice| unsafe {
                 v.extend_from_slice(b", ");
-                v.extend_from_slice(value.as_bytes());
-            })()
+                v.extend_from_slice(slice);
+            })(unsafe {value.as_bytes()})
         }
     }
 }

--- a/ohkami/src/request/mod.rs
+++ b/ohkami/src/request/mod.rs
@@ -190,6 +190,7 @@ impl Request {
     }
 
     #[cfg(any(feature="rt_tokio",feature="rt_async-std"))]
+    #[inline]
     pub(crate) async fn read(
         mut self: Pin<&mut Self>,
         stream:   &mut (impl AsyncReader + Unpin),

--- a/ohkami/src/request/mod.rs
+++ b/ohkami/src/request/mod.rs
@@ -40,7 +40,7 @@ use {
 
 
 #[cfg(any(feature="rt_tokio",feature="rt_async-std"))]
-pub(crate) const BUF_SIZE: usize = 1024;
+pub(crate) const BUF_SIZE: usize = 1 << 10;
 #[cfg(any(feature="rt_tokio",feature="rt_async-std"))]
 pub(crate) const PAYLOAD_LIMIT: usize = 1 << 32;
 
@@ -200,10 +200,10 @@ impl Request {
             Ok (0) => return Ok(None),
             Err(e) => return match e.kind() {
                 std::io::ErrorKind::ConnectionReset => Ok(None),
-                _ => Err((|| {
-                    crate::warning!("Failed to read stream: {e}");
+                _ => Err((|err| {
+                    crate::warning!("Failed to read stream: {err}");
                     Response::InternalServerError()
-                })())
+                })(e))
             },
             _ => ()
         }
@@ -263,19 +263,22 @@ impl Request {
     }
 
     #[cfg(any(feature="rt_tokio", feature="rt_async-std"))]
+    #[inline]
     async fn read_payload(
         stream:        &mut (impl AsyncReader + Unpin),
         remaining_buf: &[u8],
         size:          usize,
     ) -> CowSlice {
-        if remaining_buf.is_empty() || remaining_buf[0] == 0 {
+        let remaining_buf_len = remaining_buf.len();
+
+        if remaining_buf_len == 0 || *unsafe {remaining_buf.get_unchecked(0)} == 0 {
             #[cfg(feature="DEBUG")] println!("\n[read_payload] case: remaining_buf.is_empty() || remaining_buf[0] == 0\n");
 
             let mut bytes = vec![0; size].into_boxed_slice();
             stream.read_exact(&mut bytes).await.unwrap();
             CowSlice::Own(bytes)
 
-        } else if size <= remaining_buf.len() {
+        } else if size <= remaining_buf_len {
             #[cfg(feature="DEBUG")] println!("\n[read_payload] case: starts_at + size <= BUF_SIZE\n");
 
             #[allow(unused_unsafe/* I don't know why but rustc sometimes put warnings to this unsafe as unnecessary */)]
@@ -287,7 +290,6 @@ impl Request {
             #[cfg(feature="DEBUG")] println!("\n[read_payload] case: else\n");
 
             let mut bytes = vec![0; size].into_boxed_slice();
-            let remaining_buf_len = remaining_buf.len();
             unsafe {// SAFETY: Here size > remaining_buf_len
                 bytes.get_unchecked_mut(..remaining_buf_len).copy_from_slice(remaining_buf);
                 stream.read_exact(bytes.get_unchecked_mut(remaining_buf_len..)).await.unwrap();

--- a/ohkami/src/request/path.rs
+++ b/ohkami/src/request/path.rs
@@ -67,7 +67,7 @@ impl Path {
 
     #[inline(always)]
     pub(crate) fn init_with_request_bytes(&mut self, bytes: &[u8]) -> Result<(), crate::Response> {
-        bytes.starts_with(b"/").then_some(())
+        (bytes.first() == Some(&b'/')).then_some(())
             .ok_or_else(crate::Response::NotImplemented)?;
 
         /*

--- a/ohkami/src/response/mod.rs
+++ b/ohkami/src/response/mod.rs
@@ -105,7 +105,7 @@ pub struct Response {
     /// - `append({value})` to append
     /// 
     /// `{value}`: `String`, `&'static str`, `Cow<&'static, str>`
-    pub headers:        ResponseHeaders,
+    pub headers: ResponseHeaders,
 
     pub(crate) content: Content,
 }

--- a/ohkami/src/response/mod.rs
+++ b/ohkami/src/response/mod.rs
@@ -153,22 +153,30 @@ impl Response {
     pub(crate) async fn send(mut self, conn: &mut (impl AsyncWriter + Unpin)) {
         self.complete();
 
-        let mut buf = Vec::<u8>::with_capacity(self.status.line().len() + self.headers.size);
-        crate::push_unchecked!(buf <- self.status.line());
-        unsafe {self.headers.write_unchecked_to(&mut buf)}
-
         match self.content {
             Content::None => {
+                let mut buf = Vec::<u8>::with_capacity(self.status.line().len() + self.headers.size);
+                crate::push_unchecked!(buf <- self.status.line());
+                unsafe {self.headers.write_unchecked_to(&mut buf)}
+        
                 conn.write_all(&buf).await.expect("Failed to send response");
             }
 
             Content::Payload(bytes) => {
-                buf.extend_from_slice(&bytes);
+                let mut buf = Vec::<u8>::with_capacity(self.status.line().len() + self.headers.size + bytes.len());
+                crate::push_unchecked!(buf <- self.status.line());
+                unsafe {self.headers.write_unchecked_to(&mut buf)}
+                crate::push_unchecked!(buf <- bytes);
+
                 conn.write_all(&buf).await.expect("Failed to send response");
             }
 
             #[cfg(feature="sse")]
             Content::Stream(mut stream) => {
+                let mut buf = Vec::<u8>::with_capacity(self.status.line().len() + self.headers.size);
+                crate::push_unchecked!(buf <- self.status.line());
+                unsafe {self.headers.write_unchecked_to(&mut buf)}
+        
                 conn.write_all(&buf).await.expect("Failed to send response");
                 while let Some(chunk) = stream.next().await {
                     match chunk {

--- a/ohkami/src/session/mod.rs
+++ b/ohkami/src/session/mod.rs
@@ -57,33 +57,48 @@ impl Session {
             Timeout { sleep: sleep(Duration::from_secs(secs)), proc }
         }
 
-        let connection = &mut self.connection;
+        /* async-std doesn't provide split */
+        #[cfg(feature="rt_tokio")]
+        let (mut r, mut w) = self.connection.split();
+        #[cfg(feature="rt_async-std")]
+        let c = &mut self.connection;
+
+        #[cfg(feature="rt_tokio")]
+        macro_rules! read {($req:ident) => {$req.as_mut().read(&mut r)};}
+        #[cfg(feature="rt_async-std")]
+        macro_rules! read {($req:ident) => {$req.as_mut().read(c)};}
+
+        #[cfg(feature="rt_tokio")]
+        macro_rules! send {($res:ident) => {$res.send(&mut w)};}
+        #[cfg(feature="rt_async-std")]
+        macro_rules! send {($res:ident) => {$res.send(c)};}
+
         timeout_in(42/* TODO: make this configurable by user */, async {
             loop {
                 let mut req = Request::init();
                 let mut req = unsafe {Pin::new_unchecked(&mut req)};
-                match req.as_mut().read(connection).await {
+                match read!(req).await {
                     Ok(Some(())) => {
                         let close = matches!(req.headers.Connection(), Some("close" | "Close"));
                         let res = match catch_unwind(AssertUnwindSafe(|| self.router.handle(req.get_mut()))) {
                             Ok(future) => future.await,
                             Err(panic) => panicking(panic),
                         };
-                        res.send(connection).await;
+                        send!(res).await;
                         if close {break}
                     }
                     Ok(None) => break,
-                    Err(res) => res.send(connection).await,
+                    Err(res) => send!(res).await,
                 };
             }
         }).await;
 
         if let Some(err) = {
             #[cfg(feature="rt_tokio")] {use crate::__rt__::AsyncWriter;
-                connection.shutdown().await
+                self.connection.shutdown().await
             }
             #[cfg(feature="rt_async-std")] {
-                connection.shutdown(std::net::Shutdown::Both)
+                self.connection.shutdown(std::net::Shutdown::Both)
             }
         }.err() {
             match err.kind() {

--- a/ohkami_lib/Cargo.toml
+++ b/ohkami_lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "ohkami_lib"
-version       = "0.2.4"
+version       = "0.2.5"
 edition       = "2021"
 authors       = ["kanarus <kanarus786@gmail.com>"]
 description   = "Internal library for Ohkami - intuitive and declarative web framework"

--- a/ohkami_lib/src/lib.rs
+++ b/ohkami_lib/src/lib.rs
@@ -4,7 +4,7 @@ pub mod mime;
 
 pub mod num;
 
-mod time;
+pub mod time;
 pub use time::imf_fixdate;
 
 mod slice;

--- a/ohkami_lib/src/slice.rs
+++ b/ohkami_lib/src/slice.rs
@@ -66,12 +66,15 @@ pub enum CowSlice {
     Own(Box<[u8]>),
 }
 impl CowSlice {
-    #[inline(always)] pub unsafe fn as_bytes(&self) -> &[u8] {
+    #[inline(always)]
+    pub unsafe fn as_bytes(&self) -> &[u8] {
         match self {
             Self::Own(array) => &array,
             Self::Ref(slice) => unsafe {slice.as_bytes()},
         }
     }
+
+    #[cold]
     pub unsafe fn extend_from_slice(&mut self, bytes: &[u8]) {
         match self {
             Self::Own(array) => {
@@ -90,6 +93,7 @@ impl CowSlice {
             }
         }
     }
+
     #[inline]
     pub unsafe fn into_cow_static_bytes_uncheked(self) -> Cow<'static, [u8]> {
         match self {

--- a/ohkami_lib/src/slice.rs
+++ b/ohkami_lib/src/slice.rs
@@ -90,6 +90,7 @@ impl CowSlice {
             }
         }
     }
+    #[inline]
     pub unsafe fn into_cow_static_bytes_uncheked(self) -> Cow<'static, [u8]> {
         match self {
             Self::Own(array) => Cow::Owned(array.into()),

--- a/ohkami_lib/src/time.rs
+++ b/ohkami_lib/src/time.rs
@@ -37,43 +37,67 @@ struct UTCDateTime {
                 n < 100, "Called `push_hundreds` for `n` that's 100 or greater"
             }
 
-            buf.push((n/10 + b'0') as char);
-            buf.push((n%10 + b'0') as char);
+            unsafe {
+                let (len, ptr) = (buf.len(), buf.as_mut_ptr());
+                std::ptr::write(ptr.add(len), n/10 + b'0');
+                std::ptr::write(ptr.add(len + 1), n%10 + b'0');
+                buf.as_mut_vec().set_len(len + 2)
+            }
         }
 
         let mut buf = String::with_capacity(IMF_FIXDATE_LEN);
+        macro_rules! push_unchecked {
+            ($s:expr) => {
+                unsafe {
+                    let (buf_len, s_len) = (buf.len(), $s.len());
+                    std::ptr::copy_nonoverlapping(
+                        $s.as_ptr(),
+                        buf.as_mut_ptr().add(buf_len),
+                        s_len
+                    );
+                    buf.as_mut_vec().set_len(buf_len + s_len);
+                }
+            };
+            (@ $s:expr) => {
+                unsafe {
+                    let buf_len = buf.len();
+                    std::ptr::write(buf.as_mut_ptr().add(buf_len), $s);
+                    buf.as_mut_vec().set_len(buf_len + 1);
+                }
+            };
+        }
         {
             let Self { date, time } = self;
 
-            buf.push_str(unsafe {SHORT_WEEKDAYS.get_unchecked(date.weekday().num_days_from_sunday() as usize)});
-            buf.push_str(", ");
+            push_unchecked!(SHORT_WEEKDAYS.get_unchecked(date.weekday().num_days_from_sunday() as usize));
+            push_unchecked!(", ");
 
             let day = date.day() as u8;
             if day < 10 {
-                buf.push('0');
-                buf.push((day + b'0') as char);
+                push_unchecked!(@ b'0');
+                push_unchecked!(@ day + b'0');
             } else {
                 push_hundreds(&mut buf, day);
             }
 
-            buf.push(' ');
-            buf.push_str(unsafe {SHORT_MONTHS.get_unchecked(date.month_index() as usize)});
+            push_unchecked!(@ b' ');
+            push_unchecked!(SHORT_MONTHS.get_unchecked(date.month_index() as usize));
 
-            buf.push(' ');
+            push_unchecked!(@ b' ');
             let year = date.year();
             push_hundreds(&mut buf, (year / 100) as u8);
             push_hundreds(&mut buf, (year % 100) as u8);
 
-            buf.push(' ');
+            push_unchecked!(@ b' ');
             let (hour, min, sec) = time.hms();
             push_hundreds(&mut buf, hour as u8);
-            buf.push(':');
+            push_unchecked!(@ b':');
             push_hundreds(&mut buf, min as u8);
-            buf.push(':');
+            push_unchecked!(@ b':');
             let sec = sec + time.nanosecond() / 1_000_000_000;
             push_hundreds(&mut buf, sec as u8);
             
-            buf.push_str(" GMT");
+            push_unchecked!(" GMT");
         }
         buf
     }


### PR DESCRIPTION
( as far as I know `async-std` doesn't provide `split` functionaluty like `tokio`'s one )