### PR TITLE
feat: set keep-alive timeout by environment variable

### DIFF
--- a/ohkami/src/lib.rs
+++ b/ohkami/src/lib.rs
@@ -64,6 +64,23 @@ mod __rt__ {
 }
 
 
+#[allow(non_snake_case)]
+mod env {
+    #[allow(unused)]
+    use std::sync::OnceLock;
+
+    #[cfg(any(feature="rt_tokio",feature="rt_async-std"))]
+    pub(crate) fn OHKAMI_KEEPALIVE_TIMEOUT() -> u64 {
+        static OHKAMI_KEEPALIVE_TIMEOUT: OnceLock<u64> = OnceLock::new();
+        *OHKAMI_KEEPALIVE_TIMEOUT.get_or_init(|| {
+            std::env::var("OHKAMI_KEEPALIVE_TIMEOUT").ok()
+                .map(|v| v.parse().ok()).flatten()
+                .unwrap_or(42)
+        })
+    }
+}
+
+
 mod request;
 pub use request::{Request, Method, FromRequest, FromParam, Memory};
 pub use ::ohkami_macros::FromRequest;

--- a/ohkami/src/session/mod.rs
+++ b/ohkami/src/session/mod.rs
@@ -35,6 +35,7 @@ impl Session {
             crate::Response::InternalServerError()
         }
 
+        #[inline]
         fn timeout_in(
             secs: u64,
             proc: impl Future<Output = ()>,
@@ -73,7 +74,7 @@ impl Session {
         #[cfg(feature="rt_async-std")]
         macro_rules! send {($res:ident) => {$res.send(c)};}
 
-        timeout_in(42/* TODO: make this configurable by user */, async {
+        timeout_in(crate::env::OHKAMI_KEEPALIVE_TIMEOUT(), async {
             loop {
                 let mut req = Request::init();
                 let mut req = unsafe {Pin::new_unchecked(&mut req)};


### PR DESCRIPTION
Before ohkami uses 42 secs for Keep-Alive timeout. This PR makes this configurable by environment variable `OHKAMI_KEEPALIVE_TIMEOUT` and default to 42 secs.