### PR TITLE
perf: lightweight headers map

### DIFF
--- a/benches/benches/atoi.rs
+++ b/benches/benches/atoi.rs
@@ -1,0 +1,28 @@
+#![feature(test)] extern crate test;
+
+
+mod candiate {#![allow(unused)]
+    pub fn to_string(n: usize) -> String {
+        n.to_string()
+    }
+
+    #[inline(always)]
+    pub fn atoi_01(mut n: usize) -> String {
+        ohkami_lib::num::atoi(n)
+    }
+}
+
+
+macro_rules! benchmark {
+    ($( $target:ident )*) => {$(
+        #[bench]
+        fn $target(b: &mut test::Bencher) {
+            b.iter(|| for n in 0..42 {
+                let _ = candiate::$target(test::black_box(n));
+            })
+        }
+    )*};
+} benchmark! {
+    to_string
+    atoi_01
+}

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod light_ohkami;
 pub mod header_map;
 pub mod header_hashbrown;
 pub mod request_headers;

--- a/benches/src/light_ohkami.rs
+++ b/benches/src/light_ohkami.rs
@@ -1,0 +1,96 @@
+// use std::borrow::Cow;
+// use rustc_hash::FxHashMap;
+// use ohkami_lib::Slice;
+// 
+// 
+// pub struct LightHeaders {
+//     //standard: ,
+//     custom:   Option<Box<FxHashMap<Slice, Cow<'static, str>>>>,
+// }
+// 
+// macro_rules! Header {
+//     ( $N:literal; $($name:ident = $name_pascal:literal)* ) => {
+//         const N_HEADERS: usize = $N;
+//         const _: [Header; N_HEADERS] = [$( Header::$name )*];
+// 
+//         enum Header {
+//             $( $name, )*
+//         }
+//     };
+// } Header! {0;
+//     CacheControl         = b"Cache-Control" | b"cache-control"
+//     Connection           = b"Connection" | b"connection"
+//     ContentDisposition   = b"Content-Disposition" | b"content-disposition"
+//     ContentEncoding      = b"Content-Encoding" | b"content-encoding"
+//     ContentLanguage      = b"Content-Language" | b"content-language"
+//     ContentLength        = b"Content-Length" | b"content-length"
+//     ContentLocation      = b"Content-Location" | b"content-location"
+//     ContentType          = b"Content-Type" | b"content-type"
+//     Date                 = b"Date" | b"date"
+//     Link                 = b"Link" | b"link"
+//     SecWebSocketProtocol = b"Sec-WebSocket-Protocol" | b"sec-websocket-protocol"
+//     SecWebSocketVersion  = b"Sec-WebSocket-Version" | b"sec-websocket-version"
+//     Trailer              = b"Trailer" | b"trailer"
+//     TransferEncoding     = b"Transfer-Encoding" | b"transfer-encoding"
+//     Upgrade              = b"Upgrade" | b"upgrade"
+//     Via                  = b"Via" | b"via"
+// 
+//     Accept                      = b"Accept" | b"accept"
+//     AcceptEncoding              = b"Accept-Encoding" | b"accept-encoding"
+//     AcceptLanguage              = b"Accept-Language" | b"accept-language"
+//     AccessControlRequestHeaders = b"Access-Control-Request-Headers" | b"access-control-request-headers"
+//     AccessControlRequestMethod  = b"Access-Control-Request-Method" | b"access-control-request-method"
+//     Authorization               = b"Authorization" | b"authorization"
+//     Cookie                      = b"Cookie" | b"cookie"
+//     Expect                      = b"Expect" | b"expect"
+//     Forwarded                   = b"Forwarded" | b"forwarded"
+//     From                        = b"From" | b"from"
+//     Host                        = b"Host" | b"host"
+//     IfMatch                     = b"If-Match" | b"if-match"
+//     IfModifiedSince             = b"If-Modified-Since" | b"if-modified-since"
+//     IfNoneMatch                 = b"If-None-Match" | b"rf-none-match"
+//     IfRange                     = b"If-Range" | b"if-range"
+//     IfUnmodifiedSince           = b"If-Unmodified-Since" | b"if-unmodified-since"
+//     MaxForwards                 = b"Max-Forwards" | b"max-forwards"
+//     Origin                      = b"Origin" | b"origin" 
+//     ProxyAuthorization          = b"Proxy-Authorization" | b"proxy-authorization"
+//     Range                       = b"Range" | b"range"
+//     Referer                     = b"Referer" | b"referer"
+//     SecWebSocketExtensions      = b"Sec-WebSocket-Extensions" | b"sec-websocket-extensions"
+//     SecWebSocketKey             = b"Sec-WebSocket-Key" | b"sec-websocket-key"
+//     TE                          = b"TE" | b"te"
+//     UserAgent                   = b"User-Agent" | b"user-agent"
+//     UpgradeInsecureRequests     = b"Upgrade-Insecure-Requests" | b"upgrade-insecure-requests"
+// 
+//     AcceptRange                     = b"Accept-Range"
+//     AcceptRanges                    = b"Accept-Ranges"
+//     AccessControlAllowCredentials   = b"Access-Control-Allow-Credentials"
+//     AccessControlAllowHeaders       = b"Access-Control-Allow-Headers"
+//     AccessControlAllowMethods       = b"Access-Control-Allow-Methods"
+//     AccessControlAllowOrigin        = b"Access-Control-Allow-Origin"
+//     AccessControlExposeHeaders      = b"Access-Control-Expose-Headers"
+//     AccessControlMaxAge             = b"Access-Control-MaxAge"
+//     Age                             = b"Age"
+//     Allow                           = b"Allow"
+//     AltSvc                          = b"Alt-Svc"
+//     CacheStatus                     = b"Cache-Status"
+//     CDNCacheControl                 = b"CDN-Cache-Control"
+//     ContentRange                    = b"Content-Range"
+//     ContentSecurityPolicy           = b"Content-Security-Policy"
+//     ContentSecurityPolicyReportOnly = b"Content-Security-Policy"
+//     Etag                            = b"Etag"
+//     Expires                         = b"Expires"
+//     Location                        = b"Location"
+//     ProxyAuthenticate               = b"Proxy-Auhtneticate"
+//     ReferrerPolicy                  = b"Referrer-Policy"
+//     Refresh                         = b"Refresh"
+//     RetryAfter                      = b"Retry-After"
+//     SecWebSocketAccept              = b"Sec-Sert"
+//     Server                          = b"server"
+//     SetCookie                       = b"SetCookie"
+//     StrictTransportSecurity         = b"Strict-Transport-Security"
+//     Vary                            = b"Vary"
+//     XContentTypeOptions             = b"X-Content-Type-Options"
+//     XFrameOptions                   = b"X-Frame-Options"
+// }
+// 

--- a/ohkami/src/request/headers.rs
+++ b/ohkami/src/request/headers.rs
@@ -181,6 +181,7 @@ const _: () = {
 macro_rules! Header {
     ($N:literal; $( $konst:ident: $name_bytes:literal | $lower_case:literal $(| $other_pattern:literal)* , )*) => {
         pub(crate) const N_CLIENT_HEADERS: usize = $N;
+        const _: [Header; N_CLIENT_HEADERS] = [$(Header::$konst),*];
 
         #[derive(Debug, PartialEq, Clone, Copy)]
         pub enum Header {

--- a/ohkami/src/response/_test.rs
+++ b/ohkami/src/response/_test.rs
@@ -40,16 +40,16 @@ async fn test_response_into_bytes() {
     res.headers.set().Server("ohkami");
     assert_bytes_eq!(res, format!("\
         HTTP/1.1 204 No Content\r\n\
-        Server: ohkami\r\n\
         Date: {__now__}\r\n\
+        Server: ohkami\r\n\
         \r\n\
     ").into_bytes());
 
     let res = Response::NotFound();
     assert_bytes_eq!(res, format!("\
         HTTP/1.1 404 Not Found\r\n\
-        Date: {__now__}\r\n\
         Content-Length: 0\r\n\
+        Date: {__now__}\r\n\
         \r\n\
     ").into_bytes());
 
@@ -59,9 +59,9 @@ async fn test_response_into_bytes() {
         .custom("Hoge-Header", "Something-Custom");
     assert_bytes_eq!(res, format!("\
         HTTP/1.1 404 Not Found\r\n\
-        Server: ohkami\r\n\
-        Date: {__now__}\r\n\
         Content-Length: 0\r\n\
+        Date: {__now__}\r\n\
+        Server: ohkami\r\n\
         Hoge-Header: Something-Custom\r\n\
         \r\n\
     ").into_bytes());
@@ -74,9 +74,9 @@ async fn test_response_into_bytes() {
         .SetCookie("name", "John", |d|d.Path("/where").SameSiteStrict());
     assert_bytes_eq!(res, format!("\
         HTTP/1.1 404 Not Found\r\n\
-        Server: ohkami\r\n\
-        Date: {__now__}\r\n\
         Content-Length: 0\r\n\
+        Date: {__now__}\r\n\
+        Server: ohkami\r\n\
         Hoge-Header: Something-Custom\r\n\
         Set-Cookie: id=42; Path=/; SameSite=Lax\r\n\
         Set-Cookie: name=John; Path=/where; SameSite=Strict\r\n\
@@ -91,10 +91,10 @@ async fn test_response_into_bytes() {
         .SetCookie("name", "John", |d|d.Path("/where").SameSiteStrict());
     assert_bytes_eq!(res, format!("\
         HTTP/1.1 404 Not Found\r\n\
-        Content-Type: text/plain; charset=UTF-8\r\n\
-        Server: ohkami\r\n\
-        Date: {__now__}\r\n\
         Content-Length: 11\r\n\
+        Content-Type: text/plain; charset=UTF-8\r\n\
+        Date: {__now__}\r\n\
+        Server: ohkami\r\n\
         Hoge-Header: Something-Custom\r\n\
         Set-Cookie: id=42; Path=/; SameSite=Lax\r\n\
         Set-Cookie: name=John; Path=/where; SameSite=Strict\r\n\
@@ -149,11 +149,11 @@ async fn test_stream_response() {
         );
     assert_bytes_eq!(res, format!("\
         HTTP/1.1 200 OK\r\n\
-        Content-Type: text/event-stream\r\n\
         Cache-Control: no-cache, must-revalidate\r\n\
-        Transfer-Encoding: chunked\r\n\
-        Server: ohkami\r\n\
+        Content-Type: text/event-stream\r\n\
         Date: {__now__}\r\n\
+        Server: ohkami\r\n\
+        Transfer-Encoding: chunked\r\n\
         is-stream: true\r\n\
         Set-Cookie: name=John; Path=/where; SameSite=Strict\r\n\
         \r\n\
@@ -186,11 +186,11 @@ async fn test_stream_response() {
         );
     assert_bytes_eq!(res, format!("\
         HTTP/1.1 200 OK\r\n\
-        Content-Type: text/event-stream\r\n\
         Cache-Control: no-cache, must-revalidate\r\n\
-        Transfer-Encoding: chunked\r\n\
-        Server: ohkami\r\n\
+        Content-Type: text/event-stream\r\n\
         Date: {__now__}\r\n\
+        Server: ohkami\r\n\
+        Transfer-Encoding: chunked\r\n\
         is-stream: true\r\n\
         Set-Cookie: name=John; Path=/where; SameSite=Strict\r\n\
         \r\n\

--- a/ohkami/src/response/_test_headers.rs
+++ b/ohkami/src/response/_test_headers.rs
@@ -21,9 +21,9 @@ use super::ResponseHeaders;
         let mut buf = Vec::new();
         h._write_to(&mut buf);
         assert_eq!(std::str::from_utf8(&buf).unwrap(), "\
-            Server: B\r\n\
-            Content-Type: text/html\r\n\
             Content-Length: 42\r\n\
+            Content-Type: text/html\r\n\
+            Server: B\r\n\
             \r\n\
         ");
     }

--- a/ohkami/src/response/headers.rs
+++ b/ohkami/src/response/headers.rs
@@ -16,12 +16,12 @@ struct Standard {
     index:  [u8; N_SERVER_HEADERS],
     values: Vec<Cow<'static, str>>,
 } impl Standard {
-    const INF: u8 = u8::MAX;
+    const NULL: u8 = u8::MAX;
 
     #[inline]
     fn new() -> Self {
         Self {
-            index:  [Self::INF; N_SERVER_HEADERS],
+            index:  [Self::NULL; N_SERVER_HEADERS],
             values: Vec::with_capacity(N_SERVER_HEADERS / 4)
         }
     }
@@ -29,21 +29,21 @@ struct Standard {
     #[inline(always)]
     fn get(&self, name: Header) -> Option<&Cow<'static, str>> {
         unsafe {match *self.index.get_unchecked(name as usize) {
-            Self::INF => None,
-            index     => Some(self.values.get_unchecked(index as usize))
+            Self::NULL => None,
+            index      => Some(self.values.get_unchecked(index as usize))
         }}
     }
     #[inline(always)]
     fn get_mut(&mut self, name: Header) -> Option<&mut Cow<'static, str>> {
         unsafe {match *self.index.get_unchecked(name as usize) {
-            Self::INF => None,
-            index     => Some(self.values.get_unchecked_mut(index as usize))
+            Self::NULL => None,
+            index      => Some(self.values.get_unchecked_mut(index as usize))
         }}
     }
 
     #[inline(always)]
     fn delete(&mut self, name: Header) {
-        unsafe {*self.index.get_unchecked_mut(name as usize) = Self::INF}
+        unsafe {*self.index.get_unchecked_mut(name as usize) = Self::NULL}
     }
 
     #[inline(always)]
@@ -55,7 +55,7 @@ struct Standard {
     fn iter(&self) -> impl Iterator<Item = (&str, &str)> {
         self.index.iter()
             .enumerate()
-            .filter(|(_, index)| **index != Self::INF)
+            .filter(|(_, index)| **index != Self::NULL)
             .map(|(h, index)| unsafe {(
                 std::mem::transmute::<_, Header>(h as u8).as_str(),
                 &**self.values.get_unchecked(*index as usize)

--- a/ohkami/src/response/headers.rs
+++ b/ohkami/src/response/headers.rs
@@ -230,7 +230,7 @@ const _: () = {
 macro_rules! Header {
     ($N:literal; $( $konst:ident: $name_bytes:literal, )*) => {
         pub(crate) const N_SERVER_HEADERS: usize = $N;
-        pub(crate) const SERVER_HEADERS: [Header; N_SERVER_HEADERS] = [ $( Header::$konst ),* ];
+        const _: [Header; N_SERVER_HEADERS] = [$(Header::$konst),*];
 
         #[derive(Debug, PartialEq, Clone, Copy)]
         pub enum Header {
@@ -258,7 +258,8 @@ macro_rules! Header {
 
             // Mainly used in tests
             pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
-                SERVER_HEADERS.into_iter()
+                (0..N_SERVER_HEADERS)
+                    .map(|i| unsafe {std::mem::transmute::<_, Header>(i as u8)})
                     .find(|h| h.as_bytes().eq_ignore_ascii_case(bytes))
             }
         }

--- a/ohkami/src/response/mod.rs
+++ b/ohkami/src/response/mod.rs
@@ -138,7 +138,7 @@ impl Response {
             }
 
             Content::Payload(bytes) => self.headers.set()
-                .ContentLength(bytes.len().to_string()),
+                .ContentLength(ohkami_lib::num::atoi(bytes.len())),
 
             #[cfg(feature="sse")]
             Content::Stream(_) => self.headers.set()

--- a/ohkami_lib/src/num.rs
+++ b/ohkami_lib/src/num.rs
@@ -20,7 +20,6 @@ pub fn hexized_bytes(n: usize) -> [u8; std::mem::size_of::<usize>() * 2] {
     }
 }
 
-
 #[cfg(test)]
 #[test] fn test_hexize() {
     for (n, expected) in [
@@ -32,5 +31,44 @@ pub fn hexized_bytes(n: usize) -> [u8; std::mem::size_of::<usize>() * 2] {
         (314, "13a"),
     ] {
         assert_eq!(hexized(n).trim_start_matches('0'), expected)
+    }
+}
+
+
+#[inline]
+pub fn atoi(mut n: usize) -> String {
+    let log10 = match usize::checked_ilog10(n) {
+        Some(log10) => log10 as usize,
+        None        => return String::from("0")
+    };
+    let len = 1 + log10;
+    let mut digits = vec![0u8; len];
+    {
+        for i in 0..log10 {
+            let d = 10_usize.pow((log10 - i) as u32);
+            let (div, rem) = (n / d, n % d);
+            *unsafe {digits.get_unchecked_mut(i as usize)} = b'0' + div as u8;
+            n = rem;
+        }
+        *unsafe {digits.get_unchecked_mut(log10)} = b'0' + n as u8;
+    }
+    unsafe {String::from_utf8_unchecked(digits)}
+}
+
+#[cfg(test)]
+#[test] fn test_atoi() {
+    for (n, expected) in [
+        (0, "0"),
+        (1, "1"),
+        (4, "4"),
+        (10, "10"),
+        (11, "11"),
+        (99, "99"),
+        (100, "100"),
+        (109, "109"),
+        (999, "999"),
+        (1000, "1000"),
+    ] {
+        assert_eq!(atoi(n), expected)
     }
 }


### PR DESCRIPTION
1. Introduce `ohkami::lib::num::atoi` to serialize content lengths faster, at least, than `usize::to_string`.
  - benchmark is in `benches/benches/atoi.rs`
  - more optimization is welcome

---

3. Before ohkami uses `Box<[{clone on write buffer}; {number of req/res headers}]>` to have standard header values, but this is *quite heavy to initialize on each request handling*. So this PR alters it like

```rust
struct Standard {
    index:  [u8; {number of req/res headers}],
    values: Vec<{clone on write buffer}>
}

impl Standard {
    fn new() -> Self {
        Self {
            index:  [{invlid index}; {number of req/res headers}],
            values: Vec::with_capacity( {number of req/res headers} / 4 )
        }
    }
}
```

for lightweight initialization without performance degradation.

- initial capacity `{number of req/res headers} / 4` is selected heuristically but seems good
- `index`'s item is `u8` for less struct size and always used with `as usize` conversion