### PR TITLE
Unroll `itoa` with a macro

### DIFF
--- a/benches/benches/itoa.rs
+++ b/benches/benches/itoa.rs
@@ -341,6 +341,41 @@ mod candiate {#![allow(unused)]
         
         unsafe {String::from_utf8_unchecked(buf)}
     }
+
+    #[inline(always)]
+    pub fn itoa_07(mut n: usize) -> String {
+        const MAX: usize = usize::ilog10(usize::MAX) as _;
+        let mut buf = Vec::<u8>::with_capacity(1 + MAX);
+
+        {
+            let mut push_unchecked = |byte| {
+                let len = buf.len();
+                unsafe {
+                    std::ptr::write(buf.as_mut_ptr().add(len), byte);
+                    buf.set_len(len + 1);
+                }
+            };
+
+            macro_rules! unroll {
+                () => {};
+                ($digit:expr) => {unroll!($digit,)};
+                ($digit:expr, $($tail:tt)*) => {
+                    if $digit <= MAX && n >= 10_usize.pow($digit) {
+                        unroll!($($tail)*);
+                        let q = n / 10_usize.pow($digit);
+                        push_unchecked(b'0' + q as u8);
+                        n -= 10_usize.pow($digit) * q
+                    }
+                };
+            }
+
+            unroll!(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19);
+
+            push_unchecked(b'0' + n as u8);
+        }
+        
+        unsafe {String::from_utf8_unchecked(buf)}
+    }
 }
 
 
@@ -361,4 +396,5 @@ macro_rules! benchmark {
     itoa_04
     itoa_05
     itoa_06
+    itoa_07
 }

--- a/ohkami_lib/src/num.rs
+++ b/ohkami_lib/src/num.rs
@@ -37,114 +37,34 @@ pub fn hexized_bytes(n: usize) -> [u8; std::mem::size_of::<usize>() * 2] {
 
 #[inline]
 pub fn itoa(mut n: usize) -> String {
-    let mut buf = Vec::<u8>::with_capacity(1 + usize::ilog10(usize::MAX) as usize);
+    const MAX: usize = usize::ilog10(usize::MAX) as _;
+    let mut buf = Vec::<u8>::with_capacity(1 + MAX);
 
     {
-        macro_rules! push_unchecked {
-            ($byte:expr) => {{
-                let len = buf.len();
-                std::ptr::write(buf.as_mut_ptr().add(len), $byte);
+        let mut push_unchecked = |byte| {
+            let len = buf.len();
+            unsafe {
+                std::ptr::write(buf.as_mut_ptr().add(len), byte);
                 buf.set_len(len + 1);
-            }};
+            }
+        };
+
+        macro_rules! unroll {
+            () => {};
+            ($digit:expr) => {unroll!($digit,)};
+            ($digit:expr, $($tail:tt)*) => {
+                if $digit <= MAX && n >= 10_usize.pow($digit) {
+                    unroll!($($tail)*);
+                    let q = n / 10_usize.pow($digit);
+                    push_unchecked(b'0' + q as u8);
+                    n -= 10_usize.pow($digit) * q
+                }
+            };
         }
 
-        if n >= 10_usize.pow(1) {
-            if n >= 10_usize.pow(2) {
-                if n >= 10_usize.pow(3) {
-                    if n >= 10_usize.pow(4) {
-                        if n >= 10_usize.pow(5) {
-                            if n >= 10_usize.pow(6) {
-                                if n >= 10_usize.pow(7) {
-                                    if n >= 10_usize.pow(8) {
-                                        if n >= 10_usize.pow(9) {
-                                            #[cfg(target_pointer_width="64")]
-                                            if n >= 10_usize.pow(10) {
-                                                if n >= 10_usize.pow(11) {
-                                                    if n >= 10_usize.pow(12) {
-                                                        if n >= 10_usize.pow(13) {
-                                                            if n >= 10_usize.pow(14) {
-                                                                if n >= 10_usize.pow(15) {
-                                                                    if n >= 10_usize.pow(16) {
-                                                                        if n >= 10_usize.pow(17) {
-                                                                            if n >= 10_usize.pow(18) {
-                                                                                if n >= 10_usize.pow(19) {
-                                                                                    let q = n / 10_usize.pow(19);
-                                                                                    unsafe {push_unchecked!(b'0' + q as u8)}
-                                                                                    n -= 10_usize.pow(19) * q
-                                                                                }
-                                                                                let q = n / 10_usize.pow(18);
-                                                                                unsafe {push_unchecked!(b'0' + q as u8)}
-                                                                                n -= 10_usize.pow(18) * q
-                                                                            }
-                                                                            let q = n / 10_usize.pow(17);
-                                                                            unsafe {push_unchecked!(b'0' + q as u8)}
-                                                                            n -= 10_usize.pow(17) * q
-                                                                        }
-                                                                        let q = n / 10_usize.pow(16);
-                                                                        unsafe {push_unchecked!(b'0' + q as u8)}
-                                                                        n -= 10_usize.pow(16) * q
-                                                                    }
-                                                                    let q = n / 10_usize.pow(15);
-                                                                    unsafe {push_unchecked!(b'0' + q as u8)}
-                                                                    n -= 10_usize.pow(15) * q
-                                                                }
-                                                                let q = n / 10_usize.pow(14);
-                                                                unsafe {push_unchecked!(b'0' + q as u8)}
-                                                                n -= 10_usize.pow(14) * q
-                                                            }
-                                                            let q = n / 10_usize.pow(13);
-                                                            unsafe {push_unchecked!(b'0' + q as u8)}
-                                                            n -= 10_usize.pow(13) * q
-                                                        }
-                                                        let q = n / 10_usize.pow(12);
-                                                        unsafe {push_unchecked!(b'0' + q as u8)}
-                                                        n -= 10_usize.pow(12) * q
-                                                    }
-                                                    let q = n / 10_usize.pow(11);
-                                                    unsafe {push_unchecked!(b'0' + q as u8)}
-                                                    n -= 10_usize.pow(11) * q
-                                                }
-                                                let q = n / 10_usize.pow(10);
-                                                unsafe {push_unchecked!(b'0' + q as u8)}
-                                                n -= 10_usize.pow(10) * q
-                                            }
-                                            let q = n / 10_usize.pow(9);
-                                            unsafe {push_unchecked!(b'0' + q as u8)}
-                                            n -= 10_usize.pow(9) * q
-                                        }
-                                        let q = n / 10_usize.pow(8);
-                                        unsafe {push_unchecked!(b'0' + q as u8)}
-                                        n -= 10_usize.pow(8) * q
-                                    }
-                                    let q = n / 10_usize.pow(7);
-                                    unsafe {push_unchecked!(b'0' + q as u8)}
-                                    n -= 10_usize.pow(7) * q
-                                }
-                                let q = n / 10_usize.pow(6);
-                                unsafe {push_unchecked!(b'0' + q as u8)}
-                                n -= 10_usize.pow(6) * q
-                            }
-                            let q = n / 10_usize.pow(5);
-                            unsafe {push_unchecked!(b'0' + q as u8)}
-                            n -= 10_usize.pow(5) * q
-                        }
-                        let q = n / 10_usize.pow(4);
-                        unsafe {push_unchecked!(b'0' + q as u8)}
-                        n -= 10_usize.pow(4) * q
-                    }
-                    let q = n / 10_usize.pow(3);
-                    unsafe {push_unchecked!(b'0' + q as u8)}
-                    n -= 10_usize.pow(3) * q
-                }
-                let q = n / 10_usize.pow(2);
-                unsafe {push_unchecked!(b'0' + q as u8)}
-                n -= 10_usize.pow(2) * q
-            }
-            let q = n / 10_usize.pow(1);
-            unsafe {push_unchecked!(b'0' + q as u8)}
-            n -= 10_usize.pow(1) * q
-        }
-        unsafe {push_unchecked!(b'0' + n as u8)}
+        unroll!(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19);
+
+        push_unchecked(b'0' + n as u8);
     }
     
     unsafe {String::from_utf8_unchecked(buf)}


### PR DESCRIPTION
This also makes `itoa` slightly more optimised for `#[cfg(target_pointer_width = "16")]` targets, as `usize::MAX` is used to "stop unrolling" now - specifically, to generate `if` conditions which are known to be always-false at compile time.

Benchmarking shows that this is on par with the previous `itoa`:

```
running 8 tests
test itoa_01   ... bench:       5,182.50 ns/iter (+/- 326.24)
test itoa_02   ... bench:       3,865.63 ns/iter (+/- 38.90)
test itoa_03   ... bench:       3,719.65 ns/iter (+/- 132.43)
test itoa_04   ... bench:       9,563.68 ns/iter (+/- 173.80)
test itoa_05   ... bench:       3,206.98 ns/iter (+/- 104.76)
test itoa_06   ... bench:          75.10 ns/iter (+/- 1.69)
test itoa_07   ... bench:          75.02 ns/iter (+/- 1.52)
test to_string ... bench:       6,197.77 ns/iter (+/- 109.06)
```

Compiler Explorer shows that the old and new versions compile down to the exact same x86_64 assembly: https://godbolt.org/z/4v9YTKPEo