### PR TITLE
Using random values in the `itoa` benchmark

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -21,3 +21,7 @@ tokio              = { version = "1.37.0", features = ["full"] }
 tracing            = "0.1.4"
 tracing-subscriber = "0.3.18"
 hashbrown          = { version = "0.14.5", features = ["raw"] }
+
+[dev-dependencies]
+rand = "0.8.5"
+rand_chacha = "0.3.1"

--- a/benches/benches/itoa.rs
+++ b/benches/benches/itoa.rs
@@ -8,7 +8,7 @@ mod candiate {#![allow(unused)]
     }
 
     #[inline(always)]
-    pub fn to_string(n: usize) -> String {
+    pub fn itoa_to_string(n: usize) -> String {
         n.to_string()
     }
 
@@ -383,13 +383,22 @@ macro_rules! benchmark {
     ($( $target:ident )*) => {$(
         #[bench]
         fn $target(b: &mut test::Bencher) {
-            b.iter(|| for n in 0..314 {
-                let _ = candiate::$target(test::black_box(n));
-            })
+            use rand::prelude::*;
+            let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(314159265358979);
+            let v: [usize; 10000] = std::array::from_fn(|_| rng.next_u64() as usize);
+            b.iter(||
+                v.iter().fold(String::with_capacity(v.len() * 21), |mut s, &n| {
+                    s += &candiate::$target(test::black_box(n));
+                    s.push(' ');
+                    s
+                })
+            );
         }
     )*};
-} benchmark! {
-    to_string
+}
+benchmark! {
+    itoa_to_string
+    itoa_lib
     itoa_01
     itoa_02
     itoa_03


### PR DESCRIPTION
The current benchmark did not return the generated values to the bencher, so optimization could be done assuming that the values are not returned. Also, only very few digits are benchmarked.

```
running 9 tests
test itoa_01        ... bench:   1,182,800.00 ns/iter (+/- 75,023.00)
test itoa_02        ... bench:   1,179,170.00 ns/iter (+/- 348,201.00)
test itoa_03        ... bench:   1,097,655.00 ns/iter (+/- 87,127.25)
test itoa_04        ... bench:   1,104,555.00 ns/iter (+/- 99,388.50)
test itoa_05        ... bench:   1,220,075.00 ns/iter (+/- 76,315.00)
test itoa_06        ... bench:     933,513.75 ns/iter (+/- 38,577.38)
test itoa_07        ... bench:     866,740.00 ns/iter (+/- 64,357.00)
test itoa_lib       ... bench:     853,720.00 ns/iter (+/- 59,496.00)
test itoa_to_string ... bench:     778,495.00 ns/iter (+/- 46,434.50)
```