### PR TITLE
Wrong output `itoa_03` and `itoa_04`

### DIFF
--- a/benches/benches/itoa.rs
+++ b/benches/benches/itoa.rs
@@ -386,13 +386,22 @@ macro_rules! benchmark {
             use rand::prelude::*;
             let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(314159265358979);
             let v: [usize; 10000] = std::array::from_fn(|_| rng.next_u64() as usize);
-            b.iter(||
+            let c_std = || -> String {
                 v.iter().fold(String::with_capacity(v.len() * 21), |mut s, &n| {
-                    s += &candiate::$target(test::black_box(n));
+                    s += &candiate::itoa_to_string(n);
                     s.push(' ');
                     s
                 })
-            );
+            };
+            let c_lib = || -> String {
+                v.iter().fold(String::with_capacity(v.len() * 21), |mut s, &n| {
+                    s += &candiate::$target(n);
+                    s.push(' ');
+                    s
+                })
+            };
+            assert_eq!(c_std(), c_lib());
+            b.iter(c_lib);
         }
     )*};
 }
@@ -401,8 +410,8 @@ benchmark! {
     itoa_lib
     itoa_01
     itoa_02
-    itoa_03
-    itoa_04
+//    itoa_03
+//    itoa_04
     itoa_05
     itoa_06
     itoa_07


### PR DESCRIPTION
Example output from a benchmark run on a sequence of 100 integers:

```
running 9 tests
test itoa_01        ... bench:      12,089.52 ns/iter (+/- 671.16)
test itoa_02        ... bench:      12,403.50 ns/iter (+/- 1,265.16)
test itoa_03        ... FAILED
test itoa_04        ... FAILED
test itoa_05        ... bench:      12,398.73 ns/iter (+/- 624.78)
test itoa_06        ... bench:       9,264.34 ns/iter (+/- 824.16)
test itoa_07        ... bench:       8,787.02 ns/iter (+/- 423.54)
test itoa_lib       ... bench:       8,903.81 ns/iter (+/- 401.63)
test itoa_to_string ... bench:       8,548.35 ns/iter (+/- 413.93)

failures:

---- itoa_03 stdout ----
thread 'main' panicked at benches\itoa.rs:520:1:
assertion `left == right` failed
  left: "2550941641873866984 14045253997158011582 12234951499498039406 14144613340698552384 3893774602287791714 7262022756291228268 10805615560251163809 9360854913800613499 10161600090177651887 7385752837977607525 11241537597388988725 8212628288027177099 14246957134953679460 18216354232278611760 17728853837698446624 15787148954832634538 412530000191974830 5125997292907754124 3002384987754854850 14448474374741038865 10858107895011248326 18098716621910176374 2340618640258719140 6667148567298524685 8348138865399205622 12645572036846228865 11038952981790299809 5049918673280855842 1555615606819434521 9322500223100022202 6320557967107008470 1108001653214386921 16887763351215550506 4258000469297839330 2409482336608032055 14901323987520914127 5214442692457471849 6698147715061883080 5532362225249964139 16803215575055655582 13840207114927791803 14795366437862127873 6460598711021757169 15134170476134241899 4571941359582852074 1589957243167663999 14975863448955940114 16727582141117725824 5675193701510874725 16258436399575930957 10018584249496136198 10489081606537355838 6467228933678214099 9048272671407971674 18040604533634285205 1243415492850469064 3318970417125989953 11004398056766119426 9278805157033500560 6499505141100285586 9494186491460557547 1613899550161421592 3482875941288101930 9384813862209097390 9070081691265689352 17854292619022107835 17647014729379251887 1639452519235410710 729450238210962772 4844265425957492206 819414592635890353 17004733265660103534 8249204153531978988 15233016018135298828 8356290920145914534 8571684808811994279 17229180926158688674 8146757358274411815 10189457986106996226 13003837622312694855 6242645951071479823 949965858604466492 173488457192578056 8689552670641561846 9625018244317418204 8575641939864018064 14032365412074145849 8929625919628936294 2065101444313813782 9098208704032734585 15209838232421742820 210343272923355714 12623049555059028275 3435199158733645215 3002697531840601610 180009149318023715 9324558492711301529 7588091689123183162 17665004615907600744 2226038146565803868 "
 right: "025509416418738669� 14045253997158011582 12234951499498039406 14144613340698552384 038937746022877917> 072620227562912282t 10805615560251163809 093608549138006134� 10161600090177651887 073857528379776075I 11241537597388988725 082126282880271770� 14246957134953679460 18216354232278611760 17728853837698446624 15787148954832634538 00412530000191974n 051259972929077541H 030023849877548548b 14448474374741038865 10858107895011248326 18098716621910176374 023406186402587191X 066671485672985246� 083481388653992056F 12645572036846228865 11038952981790299809 050499186732808558Z 015556156068194345E 0932250022310002222 063205579671070084v 011080016532143869E 16887763351215550506 042580004692978393N 024094823366080320g 14901323987520914127 052144426924574718a 066981477150618830� 055323622252499641W 16803215575055655582 13840207114927791803 14795366437862127873 064605987110217571u 15134170476134241899 045719413595828520z 015899572431676639� 14975863448955940114 16727582141117725824 056751937015108747I 16258436399575930957 10018584249496136198 10489081606537355838 064672289336782140� 090482726714079716z 18040604533634285205 012434154928504690p 033189704171259899e 11004398056766119426 092788051570335005l 064995051411002855� 094941864914605575_ 01613899550161421\u{320} 034828759412881019N 093848138622090973� 090700816912656893d 17854292619022107835 17647014729379251887 016394525192354107: 007294502382109624 0484426542595749226 00819414592635890� 17004733265660103534 082492041535319789� 15233016018135298828 083562909201459145R 08571684808811994\u{7f} 17229180926158688674 081467573582744118? 10189457986106996226 13003837622312694855 062426459510714798G 0094996585860446\u{1c} 00173488457192578h 086895526706415618^ 0962501824431741824 085756419398640180p 14032365412074145849 089296259196289362� 02065101444313813\u{a0} 0990982087040327345� 15209838232421742820 0021034327292335\u{a0c72}2623049555059028275 034351991587336452? 030026975318406016: 0018000914931802\u{e0c39}93245584927113015M 075880916891231831n 17665004615907600744 022260381465658038t" 
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- itoa_04 stdout ----
thread 'main' panicked at benches\itoa.rs:520:1:
assertion `left == right` failed
  left: "2550941641873866984 14045253997158011582 12234951499498039406 14144613340698552384 3893774602287791714 7262022756291228268 10805615560251163809 9360854913800613499 10161600090177651887 7385752837977607525 11241537597388988725 8212628288027177099 14246957134953679460 18216354232278611760 17728853837698446624 15787148954832634538 412530000191974830 5125997292907754124 3002384987754854850 14448474374741038865 10858107895011248326 18098716621910176374 2340618640258719140 6667148567298524685 8348138865399205622 12645572036846228865 11038952981790299809 5049918673280855842 1555615606819434521 9322500223100022202 6320557967107008470 1108001653214386921 16887763351215550506 4258000469297839330 2409482336608032055 14901323987520914127 5214442692457471849 6698147715061883080 5532362225249964139 16803215575055655582 13840207114927791803 14795366437862127873 6460598711021757169 15134170476134241899 4571941359582852074 1589957243167663999 14975863448955940114 16727582141117725824 5675193701510874725 16258436399575930957 10018584249496136198 10489081606537355838 6467228933678214099 9048272671407971674 18040604533634285205 1243415492850469064 3318970417125989953 11004398056766119426 9278805157033500560 6499505141100285586 9494186491460557547 1613899550161421592 3482875941288101930 9384813862209097390 9070081691265689352 17854292619022107835 17647014729379251887 1639452519235410710 729450238210962772 4844265425957492206 819414592635890353 17004733265660103534 8249204153531978988 15233016018135298828 8356290920145914534 8571684808811994279 17229180926158688674 8146757358274411815 10189457986106996226 13003837622312694855 6242645951071479823 949965858604466492 173488457192578056 8689552670641561846 9625018244317418204 8575641939864018064 14032365412074145849 8929625919628936294 2065101444313813782 9098208704032734585 15209838232421742820 210343272923355714 12623049555059028275 3435199158733645215 3002697531840601610 180009149318023715 9324558492711301529 7588091689123183162 17665004615907600744 2226038146565803868 "
 right: "0255094164187386698 1404525399715801158 122349514994980394 1414461334069855238 0389377460228779171 0726202275629122826 108056155602511638 0936085491380061349 1016160009017765188 0738575283797760752 1124153759738898872 0821262828802717709 1424695713495367946 1821635423227861176 1772885383769844662 1578714895483263453 0041253000019197483 0512599729290775412 0300238498775485485 1444847437474103886 1085810789501124832 1809871662191017637 0234061864025871914 0666714856729852468 0834813886539920562 1264557203684622886 110389529817902998 0504991867328085584 0155561560681943452 093225002231000222 0632055796710700847 0110800165321438692 168877633512155505 0425800046929783933 0240948233660803205 1490132398752091412 0521444269245747184 0669814771506188308 0553236222524996413 1680321557505565558 138402071149277918 1479536643786212787 0646059871102175716 1513417047613424189 0457194135958285207 0158995724316766399 1497586344895594011 1672758214111772582 0567519370151087472 1625843639957593095 1001858424949613619 1048908160653735583 0646722893367821409 0904827267140797167 180406045336342852 0124341549285046906 0331897041712598995 1100439805676611942 0927880515703350056 0649950514110028558 0949418649146055754 0161389955016142159 0348287594128810193 0938481386220909739 0907008169126568935 1785429261902210783 1764701472937925188 0163945251923541071 0072945023821096277 048442654259574922 0081941459263589035 1700473326566010353 0824920415353197898 1523301601813529882 0835629092014591453 0857168480881199427 1722918092615868867 0814675735827441181 1018945798610699622 1300383762231269485 0624264595107147982 0094996585860446649 0017348845719257805 0868955267064156184 096250182443174182 0857564193986401806 1403236541207414584 0892962591962893629 0206510144431381378 0909820870403273458 1520983823242174282 0021034327292335571 1262304955505902827 0343519915873364521 0300269753184060161 0018000914931802371 0932455849271130152 0758809168912318316 1766500461590760074 0222603814656580386 "


failures:
    itoa_03
    itoa_04
```