### PR TITLE
refactor: bench `itoa` with test cases of less than 10GB

### DIFF
--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -11,8 +11,11 @@ jobs:
   auto_approve:
     runs-on: ubuntu-latest
     steps:
-      - name: hello
-        run:  echo 'not skipped'
+      - name: check values
+        run: |
+          echo ${{ github.event.pull_request.user.login }}
+          echo ${{ github.repository_owner }}
+          echo ${{ github.event.pull_request.draft }}
 #    if: |
 #      github.event.pull_request.user.login == github.repository_owner &&
 #      !github.event.pull_request.draft

--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -1,0 +1,19 @@
+name: auto_approve
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+jobs:
+  auto_approve:
+    if: |
+      github.event.pull_request.user.login == github.repository_owner &&
+      !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: hmarr/auto-approve-action@v4

--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -9,11 +9,15 @@ on:
 
 jobs:
   auto_approve:
-    if: |
-      github.event.pull_request.user.login == github.repository_owner &&
-      !github.event.pull_request.draft
-    permissions:
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: hmarr/auto-approve-action@v4
+      - name: hello
+        run:  echo 'not skipped'
+#    if: |
+#      github.event.pull_request.user.login == github.repository_owner &&
+#      !github.event.pull_request.draft
+#    permissions:
+#      pull-requests: write
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: hmarr/auto-approve-action@v4

--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -19,3 +19,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: hmarr/auto-approve-action@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -12,8 +12,8 @@ jobs:
     if: |
       github.event.pull_request.user.login == github.repository_owner &&
       !github.event.pull_request.draft
-    runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+    runs-on: ubuntu-latest
     steps:
       - uses: hmarr/auto-approve-action@v4

--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -1,3 +1,5 @@
+# This will be removed when ohkami has more than one maintainers
+
 name: auto_approve
 on:
   pull_request:
@@ -9,18 +11,11 @@ on:
 
 jobs:
   auto_approve:
+    if: |
+      github.event.pull_request.user.login == 'kana-rus' &&
+      !github.event.pull_request.draft
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - name: check values
-        run: |
-          echo ${{ github.event.pull_request.user.login }}
-          echo ${{ github.repository_owner }}
-          echo ${{ github.event.pull_request.draft }}
-#    if: |
-#      github.event.pull_request.user.login == github.repository_owner &&
-#      !github.event.pull_request.draft
-#    permissions:
-#      pull-requests: write
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: hmarr/auto-approve-action@v4
+      - uses: hmarr/auto-approve-action@v4


### PR DESCRIPTION
- Now `itoa` is only used for serializing `Content-Length`
- In most cases, a single, non-streaming HTTP response will have Content-Length of less than 10GB