### PR TITLE
`itoa`: statically assert that the max of `MAX` is 19

### DIFF
--- a/benches/benches/itoa.rs
+++ b/benches/benches/itoa.rs
@@ -345,6 +345,8 @@ mod candiate {#![allow(unused)]
     #[inline(always)]
     pub fn itoa_07(mut n: usize) -> String {
         const MAX: usize = usize::ilog10(usize::MAX) as _;
+        const _/* static assert */: [(); 19] = [(); MAX];
+        
         let mut buf = Vec::<u8>::with_capacity(1 + MAX);
 
         {

--- a/benches/benches/itoa.rs
+++ b/benches/benches/itoa.rs
@@ -345,6 +345,8 @@ mod candiate {#![allow(unused)]
     #[inline(always)]
     pub fn itoa_07(mut n: usize) -> String {
         const MAX: usize = usize::ilog10(usize::MAX) as _;
+        
+        #[cfg(target_pointer_width = "64")]
         const _/* static assert */: [(); 19] = [(); MAX];
         
         let mut buf = Vec::<u8>::with_capacity(1 + MAX);

--- a/ohkami_lib/src/num.rs
+++ b/ohkami_lib/src/num.rs
@@ -38,6 +38,8 @@ pub fn hexized_bytes(n: usize) -> [u8; std::mem::size_of::<usize>() * 2] {
 #[inline]
 pub fn itoa(mut n: usize) -> String {
     const MAX: usize = usize::ilog10(usize::MAX) as _;
+    const _/* static assert */: [(); 19] = [(); MAX];
+    
     let mut buf = Vec::<u8>::with_capacity(1 + MAX);
 
     {

--- a/ohkami_lib/src/num.rs
+++ b/ohkami_lib/src/num.rs
@@ -38,6 +38,8 @@ pub fn hexized_bytes(n: usize) -> [u8; std::mem::size_of::<usize>() * 2] {
 #[inline]
 pub fn itoa(mut n: usize) -> String {
     const MAX: usize = usize::ilog10(usize::MAX) as _;
+
+    #[cfg(target_pointer_width = "64")]
     const _/* static assert */: [(); 19] = [(); MAX];
     
     let mut buf = Vec::<u8>::with_capacity(1 + MAX);


### PR DESCRIPTION
In current `itoa`, `unroll!` arguments is just a sequence of 1 ~ 19 :

```
unroll!(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19);
```
However, it is not explicitly clear from this code why providing up to 19 is correct.

So this adds static assertion

```rust
#[cfg(target_pointer_width = "64")]
const _/* static assert */: [(); 19] = [(); MAX];
```
to describe it.