### PR TITLE
refactor standard headers: iterate only by inserted values

### DIFF
--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -37,7 +37,7 @@ sha2          = { version = "0.10", default-features = false }
 
 
 [features]
-#default       = ["testing"]
+default       = ["testing"]
 
 rt_tokio      = ["dep:tokio"]
 rt_async-std  = ["dep:async-std"]
@@ -54,13 +54,13 @@ DEBUG = [
     "tokio?/rt-multi-thread",
     "async-std?/attributes",
 ]
-default = [
-    "nightly",
-    "testing",
-    "sse",
-    #"websocket",
-    "rt_tokio",
-    #"rt_async-std",
-    #"rt_worker",
-    "DEBUG",
-]
+#default = [
+#    "nightly",
+#    "testing",
+#    "sse",
+#    #"websocket",
+#    "rt_tokio",
+#    #"rt_async-std",
+#    #"rt_worker",
+#    "DEBUG",
+#]

--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -37,7 +37,7 @@ sha2          = { version = "0.10", default-features = false }
 
 
 [features]
-default       = ["testing"]
+#default       = ["testing"]
 
 rt_tokio      = ["dep:tokio"]
 rt_async-std  = ["dep:async-std"]
@@ -54,13 +54,13 @@ DEBUG = [
     "tokio?/rt-multi-thread",
     "async-std?/attributes",
 ]
-#default = [
-#    "nightly",
-#    "testing",
-#    "sse",
-#    #"websocket",
-#    "rt_tokio",
-#    #"rt_async-std",
-#    #"rt_worker",
-#    "DEBUG",
-#]
+default = [
+    "nightly",
+    "testing",
+    "sse",
+    #"websocket",
+    "rt_tokio",
+    #"rt_async-std",
+    #"rt_worker",
+    "DEBUG",
+]

--- a/ohkami/src/header/mod.rs
+++ b/ohkami/src/header/mod.rs
@@ -7,5 +7,5 @@ pub(crate) use append::Append;
 mod setcookie;
 pub(crate) use setcookie::*;
 
-mod standard;
-pub(crate) use standard::Standard;
+mod map;
+pub(crate) use map::IndexMap;

--- a/ohkami/src/request/headers.rs
+++ b/ohkami/src/request/headers.rs
@@ -1,11 +1,11 @@
-use crate::header::{Standard, Append};
+use crate::header::{IndexMap, Append};
 use std::borrow::Cow;
 use ohkami_lib::{CowSlice, Slice};
 use rustc_hash::FxHashMap;
 
 
 pub struct Headers {
-    standard: Standard<N_CLIENT_HEADERS, CowSlice>,
+    standard: IndexMap<N_CLIENT_HEADERS, CowSlice>,
     custom:   Option<Box<FxHashMap<Slice, CowSlice>>>,
 }
 
@@ -266,7 +266,7 @@ impl Headers {
     pub(crate) fn iter(&self) -> impl Iterator<Item = (&str, &str)> {
         self.standard.iter()
             .map(|(i, v)| (
-                unsafe {std::mem::transmute::<_, Header>(i as u8).as_str()},
+                unsafe {std::mem::transmute::<_, Header>(*i as u8).as_str()},
                 std::str::from_utf8(v).expect("Non UTF-8 header value")
             ))
             .chain(self.custom.as_ref()
@@ -350,7 +350,7 @@ impl Headers {
     #[inline]
     pub(crate) fn init() -> Self {
         Self {
-            standard: Standard::new(),
+            standard: IndexMap::new(),
             custom:   None,
         }
     }

--- a/ohkami/src/response/_test.rs
+++ b/ohkami/src/response/_test.rs
@@ -40,16 +40,16 @@ async fn test_response_into_bytes() {
     res.headers.set().Server("ohkami");
     assert_bytes_eq!(res, format!("\
         HTTP/1.1 204 No Content\r\n\
-        Date: {__now__}\r\n\
         Server: ohkami\r\n\
+        Date: {__now__}\r\n\
         \r\n\
     ").into_bytes());
 
     let res = Response::NotFound();
     assert_bytes_eq!(res, format!("\
         HTTP/1.1 404 Not Found\r\n\
-        Content-Length: 0\r\n\
         Date: {__now__}\r\n\
+        Content-Length: 0\r\n\
         \r\n\
     ").into_bytes());
 
@@ -59,9 +59,9 @@ async fn test_response_into_bytes() {
         .custom("Hoge-Header", "Something-Custom");
     assert_bytes_eq!(res, format!("\
         HTTP/1.1 404 Not Found\r\n\
-        Content-Length: 0\r\n\
-        Date: {__now__}\r\n\
         Server: ohkami\r\n\
+        Date: {__now__}\r\n\
+        Content-Length: 0\r\n\
         Hoge-Header: Something-Custom\r\n\
         \r\n\
     ").into_bytes());
@@ -74,9 +74,9 @@ async fn test_response_into_bytes() {
         .SetCookie("name", "John", |d|d.Path("/where").SameSiteStrict());
     assert_bytes_eq!(res, format!("\
         HTTP/1.1 404 Not Found\r\n\
-        Content-Length: 0\r\n\
-        Date: {__now__}\r\n\
         Server: ohkami\r\n\
+        Date: {__now__}\r\n\
+        Content-Length: 0\r\n\
         Hoge-Header: Something-Custom\r\n\
         Set-Cookie: id=42; Path=/; SameSite=Lax\r\n\
         Set-Cookie: name=John; Path=/where; SameSite=Strict\r\n\
@@ -91,10 +91,10 @@ async fn test_response_into_bytes() {
         .SetCookie("name", "John", |d|d.Path("/where").SameSiteStrict());
     assert_bytes_eq!(res, format!("\
         HTTP/1.1 404 Not Found\r\n\
-        Content-Length: 11\r\n\
         Content-Type: text/plain; charset=UTF-8\r\n\
-        Date: {__now__}\r\n\
         Server: ohkami\r\n\
+        Date: {__now__}\r\n\
+        Content-Length: 11\r\n\
         Hoge-Header: Something-Custom\r\n\
         Set-Cookie: id=42; Path=/; SameSite=Lax\r\n\
         Set-Cookie: name=John; Path=/where; SameSite=Strict\r\n\
@@ -149,11 +149,11 @@ async fn test_stream_response() {
         );
     assert_bytes_eq!(res, format!("\
         HTTP/1.1 200 OK\r\n\
-        Cache-Control: no-cache, must-revalidate\r\n\
         Content-Type: text/event-stream\r\n\
-        Date: {__now__}\r\n\
-        Server: ohkami\r\n\
+        Cache-Control: no-cache, must-revalidate\r\n\
         Transfer-Encoding: chunked\r\n\
+        Server: ohkami\r\n\
+        Date: {__now__}\r\n\
         is-stream: true\r\n\
         Set-Cookie: name=John; Path=/where; SameSite=Strict\r\n\
         \r\n\
@@ -186,11 +186,11 @@ async fn test_stream_response() {
         );
     assert_bytes_eq!(res, format!("\
         HTTP/1.1 200 OK\r\n\
-        Cache-Control: no-cache, must-revalidate\r\n\
         Content-Type: text/event-stream\r\n\
-        Date: {__now__}\r\n\
-        Server: ohkami\r\n\
+        Cache-Control: no-cache, must-revalidate\r\n\
         Transfer-Encoding: chunked\r\n\
+        Server: ohkami\r\n\
+        Date: {__now__}\r\n\
         is-stream: true\r\n\
         Set-Cookie: name=John; Path=/where; SameSite=Strict\r\n\
         \r\n\

--- a/ohkami/src/response/_test_headers.rs
+++ b/ohkami/src/response/_test_headers.rs
@@ -21,9 +21,9 @@ use super::ResponseHeaders;
         let mut buf = Vec::new();
         h._write_to(&mut buf);
         assert_eq!(std::str::from_utf8(&buf).unwrap(), "\
-            Content-Length: 42\r\n\
-            Content-Type: text/html\r\n\
             Server: B\r\n\
+            Content-Type: text/html\r\n\
+            Content-Length: 42\r\n\
             \r\n\
         ");
     }


### PR DESCRIPTION
Before `response::Headers::write` iterates all standard response header and check if the response has each of them every time.
This PR fix it to just iterate once-inserted standard headers and skip already-removed ones