### PR TITLE
`itoa`: Can be about 10 times faster

### DIFF
--- a/benches/benches/itoa.rs
+++ b/benches/benches/itoa.rs
@@ -531,26 +531,25 @@ mod candiate {#![allow(unused)]
                 }
             }
         }
-
-        pub struct U64Write(pub u64);
-        impl std::fmt::Display for U64Write {
-            // Example of performance degradation when trying to implement to_string() with std::fmt::Display
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                unsafe {
-                    let mut buf = [0u8; 20];
-                    let r = buf.as_mut_ptr();
-                    let mut p = r;
-                    raw_u64(&mut p, self.0);
-                    f.write_str(std::str::from_utf8_unchecked(&buf[..(p.offset_from(r) as usize)]))
-                }
-            }
-        }
     }
 
     #[inline(always)]
     pub fn itoa_08d(n: usize) -> String {
         // Example of performance degradation when trying to implement to_string() with std::fmt::Display
-        dec4le::U64Write(n as u64).to_string()
+        pub struct U64Write(pub u64);
+        impl std::fmt::Display for U64Write {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                unsafe {
+                    let mut buf = [0u8; 20];
+                    let r = buf.as_mut_ptr();
+                    let mut p = r;
+                    dec4le::raw_u64(&mut p, self.0);
+                    f.write_str(std::str::from_utf8_unchecked(&buf[..(p.offset_from(r) as usize)]))
+                }
+            }
+        }
+
+        U64Write(n as u64).to_string()
     }
 
     #[inline(always)]


### PR DESCRIPTION
- Instead of allocating a string area for each integer, write directly to a buffer and output.
- Generate 4-digit integers in advance, paste them together, and output.

```
$ cargo +nightly bench --package ohkami_benches --bench itoa

running 76 tests
test a_small_http_response_content_length::itoa_01                      ... bench:     144,725.37 ns/iter (+/- 2,149.23)
test a_small_http_response_content_length::itoa_02                      ... bench:     123,626.23 ns/iter (+/- 472.58)
test a_small_http_response_content_length::itoa_03                      ... bench:     133,868.24 ns/iter (+/- 452.17)
test a_small_http_response_content_length::itoa_05                      ... bench:      95,705.51 ns/iter (+/- 85.25)
test a_small_http_response_content_length::itoa_06                      ... bench:      89,689.82 ns/iter (+/- 209.65)
test a_small_http_response_content_length::itoa_07                      ... bench:      93,249.09 ns/iter (+/- 283.03)
test a_small_http_response_content_length::itoa_08                      ... bench:      93,613.29 ns/iter (+/- 99.18)
test a_small_http_response_content_length::itoa_08d                     ... bench:     171,568.78 ns/iter (+/- 163.80)
test a_small_http_response_content_length::itoa_to_string               ... bench:     188,376.78 ns/iter (+/- 296.42)
test common_json_response_content_length::itoa_01                       ... bench:     187,008.76 ns/iter (+/- 190.60)
test common_json_response_content_length::itoa_02                       ... bench:     153,398.77 ns/iter (+/- 241.32)
test common_json_response_content_length::itoa_03                       ... bench:     160,097.52 ns/iter (+/- 223.52)
test common_json_response_content_length::itoa_05                       ... bench:     108,584.23 ns/iter (+/- 343.55)
test common_json_response_content_length::itoa_06                       ... bench:     100,018.73 ns/iter (+/- 369.60)
test common_json_response_content_length::itoa_07                       ... bench:     103,019.07 ns/iter (+/- 279.34)
test common_json_response_content_length::itoa_08                       ... bench:      95,267.80 ns/iter (+/- 307.57)
test common_json_response_content_length::itoa_08d                      ... bench:     171,498.24 ns/iter (+/- 165.50)
test common_json_response_content_length::itoa_to_string                ... bench:     189,092.58 ns/iter (+/- 333.73)
test http_response_content_length::itoa_01                              ... bench:     290,901.20 ns/iter (+/- 863.62)
test http_response_content_length::itoa_02                              ... bench:     253,499.10 ns/iter (+/- 841.68)
test http_response_content_length::itoa_03                              ... bench:     233,592.35 ns/iter (+/- 809.34)
test http_response_content_length::itoa_05                              ... bench:     148,652.93 ns/iter (+/- 303.36)
test http_response_content_length::itoa_06                              ... bench:     140,731.50 ns/iter (+/- 285.31)
test http_response_content_length::itoa_07                              ... bench:     140,740.85 ns/iter (+/- 139.15)
test http_response_content_length::itoa_08                              ... bench:      96,749.12 ns/iter (+/- 126.51)
test http_response_content_length::itoa_08d                             ... bench:     174,288.02 ns/iter (+/- 202.90)
test http_response_content_length::itoa_to_string                       ... bench:     195,296.94 ns/iter (+/- 162.04)
test max::itoa_01                                                       ... bench:     548,780.00 ns/iter (+/- 1,788.81)
test max::itoa_02                                                       ... bench:     482,410.10 ns/iter (+/- 1,486.16)
test max::itoa_03                                                       ... bench:     400,019.20 ns/iter (+/- 2,942.37)
test max::itoa_05                                                       ... bench:     377,493.30 ns/iter (+/- 6,374.04)
test max::itoa_06                                                       ... bench:     293,758.00 ns/iter (+/- 922.67)
test max::itoa_07                                                       ... bench:     293,791.80 ns/iter (+/- 681.41)
test max::itoa_08                                                       ... bench:     102,619.38 ns/iter (+/- 2,035.36)
test max::itoa_08d                                                      ... bench:     188,166.41 ns/iter (+/- 315.83)
test max::itoa_to_string                                                ... bench:     236,196.40 ns/iter (+/- 578.17)
test once_a_small_http_response_content_length::iappend_07              ... bench:      15,685.59 ns/iter (+/- 11.60)
test once_a_small_http_response_content_length::iappend_08              ... bench:      10,321.75 ns/iter (+/- 17.65)
test once_a_small_http_response_content_length::iappend_08d             ... bench:      85,839.86 ns/iter (+/- 111.98)
test once_a_small_http_response_content_length::iappend_to_string       ... bench:     190,704.08 ns/iter (+/- 317.38)
test once_a_small_http_response_content_length::iappend_write           ... bench:     103,696.82 ns/iter (+/- 190.78)
test once_common_json_response_content_length::iappend_07               ... bench:      35,683.55 ns/iter (+/- 44.89)
test once_common_json_response_content_length::iappend_08               ... bench:      13,932.82 ns/iter (+/- 37.66)
test once_common_json_response_content_length::iappend_08d              ... bench:      86,786.89 ns/iter (+/- 85.17)
test once_common_json_response_content_length::iappend_to_string        ... bench:     191,590.80 ns/iter (+/- 1,980.66)
test once_common_json_response_content_length::iappend_write            ... bench:     104,152.56 ns/iter (+/- 397.43)
test once_http_response_content_length::iappend_07                      ... bench:      80,349.65 ns/iter (+/- 82.61)
test once_http_response_content_length::iappend_08                      ... bench:      17,000.33 ns/iter (+/- 17.02)
test once_http_response_content_length::iappend_08d                     ... bench:      85,168.93 ns/iter (+/- 1,009.37)
test once_http_response_content_length::iappend_to_string               ... bench:     198,420.08 ns/iter (+/- 4,462.45)
test once_http_response_content_length::iappend_write                   ... bench:     110,323.14 ns/iter (+/- 1,768.38)
test once_max::iappend_07                                               ... bench:     211,106.02 ns/iter (+/- 324.31)
test once_max::iappend_08                                               ... bench:      28,646.81 ns/iter (+/- 100.12)
test once_max::iappend_08d                                              ... bench:      93,366.27 ns/iter (+/- 692.33)
test once_max::iappend_to_string                                        ... bench:     240,141.75 ns/iter (+/- 19,572.42)
test once_max::iappend_write                                            ... bench:     148,540.19 ns/iter (+/- 2,293.19)
test slice_a_small_http_response_content_length::iappendslice_07        ... bench:      14,157.77 ns/iter (+/- 12.71)
test slice_a_small_http_response_content_length::iappendslice_08        ... bench:       9,055.38 ns/iter (+/- 23.05)
test slice_a_small_http_response_content_length::iappendslice_08d       ... bench:      85,091.48 ns/iter (+/- 184.80)
test slice_a_small_http_response_content_length::iappendslice_to_string ... bench:     185,833.28 ns/iter (+/- 240.28)
test slice_a_small_http_response_content_length::iappendslice_write     ... bench:     104,779.01 ns/iter (+/- 234.84)
test slice_common_json_response_content_length::iappendslice_07         ... bench:      38,102.33 ns/iter (+/- 50.24)
test slice_common_json_response_content_length::iappendslice_08         ... bench:      10,111.41 ns/iter (+/- 69.76)
test slice_common_json_response_content_length::iappendslice_08d        ... bench:      86,028.15 ns/iter (+/- 109.84)
test slice_common_json_response_content_length::iappendslice_to_string  ... bench:     186,874.30 ns/iter (+/- 5,214.96)
test slice_common_json_response_content_length::iappendslice_write      ... bench:     105,411.67 ns/iter (+/- 240.07)
test slice_http_response_content_length::iappendslice_07                ... bench:      76,901.68 ns/iter (+/- 164.11)
test slice_http_response_content_length::iappendslice_08                ... bench:      15,688.92 ns/iter (+/- 37.03)
test slice_http_response_content_length::iappendslice_08d               ... bench:      84,087.71 ns/iter (+/- 104.95)
test slice_http_response_content_length::iappendslice_to_string         ... bench:     192,570.04 ns/iter (+/- 320.49)
test slice_http_response_content_length::iappendslice_write             ... bench:     109,598.84 ns/iter (+/- 112.95)
test slice_max::iappendslice_07                                         ... bench:     205,486.17 ns/iter (+/- 323.30)
test slice_max::iappendslice_08                                         ... bench:      27,329.80 ns/iter (+/- 87.90)
test slice_max::iappendslice_08d                                        ... bench:      94,640.79 ns/iter (+/- 1,619.42)
test slice_max::iappendslice_to_string                                  ... bench:     229,300.10 ns/iter (+/- 980.68)
test slice_max::iappendslice_write                                      ... bench:     149,671.40 ns/iter (+/- 954.86)
```