### PR TITLE
fix headers bench: use `Vec::reserve` for reserve buf capacity

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -20,7 +20,7 @@ byte_reader        = "3.0.0"
 tokio              = { version = "1.37.0", features = ["full"] }
 tracing            = "0.1.4"
 tracing-subscriber = "0.3.18"
-hashbrown          = { version = "0.14.5", features = ["raw"] }
+hashbrown          = { version = "0.14.5", features = ["raw", "inline-more"] }
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/benches/benches/request_headers.rs
+++ b/benches/benches/request_headers.rs
@@ -171,7 +171,7 @@ fn input() -> Vec<u8> {
     b.iter(|| {
         let mut r = byte_reader::Reader::new(black_box(input.as_slice()));
         
-        let mut h = HeaderHashBrown::new();
+        let mut h = HeaderHashBrown::<false>::new();
         while r.consume("\r\n").is_none() {
             let key_bytes = r.read_while(|b| b != &b':');
             r.consume(": ").unwrap();

--- a/benches/benches/request_headers.rs
+++ b/benches/benches/request_headers.rs
@@ -15,45 +15,45 @@ use ohkami_benches::request_headers::{
 
 
 fn input() -> Vec<u8> {
-    // let input: &[u8; 819] = test::black_box(b"\
-    //     Accept-Language: fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5\r\n\
-    //     Authorization: Bearer dummy-authorization-token-sample\r\n\
-    //     Date: Wed, 21 Oct 2015 07:28:00 GMT\r\n\
-    //     Host: localhost:7777\r\n\
-    //     Origin: localhost:3333\r\n\
-    //     Referer: https://developer.mozilla.org/ja/docs/Web/JavaScript\r\n\
-    //     Referrer-Policy: no-referrer\r\n\
-    //     Via: HTTP/1.1 GWA\r\n\
-    //     User-Agent: Mozilla/5.0 (platform; rv:geckoversion) Gecko/geckotrail Firefox/firefoxversion\r\n\
-    //     Transfer-Encoding: identity\r\n\
-    //     Connection: upgrade\r\n\
-    //     Upgrade: a_protocol/1, example ,another_protocol/2.2\r\n\
-    //     Forwarded: for=192.0.2.60; proto=http; by=203.0.113.43\r\n\
-    //     Upgrade-Insecure-Requests: 1\r\n\
-    //     From: webmaster@example.org\r\n\
-    //     X-MyApp-Data: example-custom-header-value\r\n\
-    //     Some-Custom-Header: strawberry\r\n\
-    //     Expect: 100-continue\r\n\
-    //     Cookie: PHPSESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1\r\n\
-    //     Cache-Control: no-cache\r\n\
-    //     \r\n\
-    // ");
-
-    let input: &[u8; 485] = test::black_box(b"\
+    let input: &[u8; 819] = test::black_box(b"\
+        Accept-Language: fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5\r\n\
         Authorization: Bearer dummy-authorization-token-sample\r\n\
         Date: Wed, 21 Oct 2015 07:28:00 GMT\r\n\
         Host: localhost:7777\r\n\
         Origin: localhost:3333\r\n\
+        Referer: https://developer.mozilla.org/ja/docs/Web/JavaScript\r\n\
+        Referrer-Policy: no-referrer\r\n\
+        Via: HTTP/1.1 GWA\r\n\
         User-Agent: Mozilla/5.0 (platform; rv:geckoversion) Gecko/geckotrail Firefox/firefoxversion\r\n\
         Transfer-Encoding: identity\r\n\
-        Connection: Keep-Alive\r\n\
+        Connection: upgrade\r\n\
+        Upgrade: a_protocol/1, example ,another_protocol/2.2\r\n\
+        Forwarded: for=192.0.2.60; proto=http; by=203.0.113.43\r\n\
+        Upgrade-Insecure-Requests: 1\r\n\
         From: webmaster@example.org\r\n\
         X-MyApp-Data: example-custom-header-value\r\n\
         Some-Custom-Header: strawberry\r\n\
+        Expect: 100-continue\r\n\
         Cookie: PHPSESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1\r\n\
         Cache-Control: no-cache\r\n\
         \r\n\
     ");
+
+    // let input: &[u8; 485] = test::black_box(b"\
+    //     Authorization: Bearer dummy-authorization-token-sample\r\n\
+    //     Date: Wed, 21 Oct 2015 07:28:00 GMT\r\n\
+    //     Host: localhost:7777\r\n\
+    //     Origin: localhost:3333\r\n\
+    //     User-Agent: Mozilla/5.0 (platform; rv:geckoversion) Gecko/geckotrail Firefox/firefoxversion\r\n\
+    //     Transfer-Encoding: identity\r\n\
+    //     Connection: Keep-Alive\r\n\
+    //     From: webmaster@example.org\r\n\
+    //     X-MyApp-Data: example-custom-header-value\r\n\
+    //     Some-Custom-Header: strawberry\r\n\
+    //     Cookie: PHPSESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1\r\n\
+    //     Cache-Control: no-cache\r\n\
+    //     \r\n\
+    // ");
 
     // let input: &[u8; 301] = test::black_box(b"\
     //     Authorization: Bearer dummy-authorization-token-sample\r\n\

--- a/benches/benches/response_headers.rs
+++ b/benches/benches/response_headers.rs
@@ -21,11 +21,11 @@ use ohkami_benches::response_headers::{
     let mut h = ResponseHeaders::_new();
     b.iter(|| {
         h.set()
-            .AccessControlAllowCredentials(black_box("true"))
-            .AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-            .AccessControlAllowOrigin(black_box("https://foo.bar.org"))
-            .AccessControlAllowMethods(black_box("POST,GET,OPTIONS,DELETE"))
-            .AccessControlMaxAge(black_box("86400"))
+            //.AccessControlAllowCredentials(black_box("true"))
+            //.AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+            //.AccessControlAllowOrigin(black_box("https://foo.bar.org"))
+            //.AccessControlAllowMethods(black_box("POST,GET,OPTIONS,DELETE"))
+            //.AccessControlMaxAge(black_box("86400"))
             .Vary(black_box("Origin"))
             .Server(black_box("ohkami"))
             .Connection(black_box("Keep-Alive"))
@@ -36,7 +36,7 @@ use ohkami_benches::response_headers::{
             .ReferrerPolicy(black_box("same-origin"))
             .XFrameOptions(black_box("DENY"))
             .custom("x-myapp-data", black_box("myappdata; excellent"))
-            .custom("something", black_box("anything"))
+            //.custom("something", black_box("anything"))
         ;
     });
 }
@@ -112,11 +112,11 @@ use ohkami_benches::response_headers::{
 #[bench] fn insert_http_crate(b: &mut test::Bencher) {
     let mut h = HeaderMap::new();
     b.iter(|| {
-        h.insert(header::ACCESS_CONTROL_ALLOW_CREDENTIALS, HeaderValue::from_static(black_box("true")));
-        h.insert(header::ACCESS_CONTROL_ALLOW_HEADERS, HeaderValue::from_static(black_box("X-Custom-Header,Upgrade-Insecure-Requests")));
-        h.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, HeaderValue::from_static(black_box("https://foo.bar.org")));
-        h.insert(header::ACCESS_CONTROL_ALLOW_METHODS, HeaderValue::from_static(black_box("POST,GET,OPTIONS,DELETE")));
-        h.insert(header::ACCESS_CONTROL_MAX_AGE, HeaderValue::from_static(black_box("86400")));
+        //h.insert(header::ACCESS_CONTROL_ALLOW_CREDENTIALS, HeaderValue::from_static(black_box("true")));
+        //h.insert(header::ACCESS_CONTROL_ALLOW_HEADERS, HeaderValue::from_static(black_box("X-Custom-Header,Upgrade-Insecure-Requests")));
+        //h.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, HeaderValue::from_static(black_box("https://foo.bar.org")));
+        //h.insert(header::ACCESS_CONTROL_ALLOW_METHODS, HeaderValue::from_static(black_box("POST,GET,OPTIONS,DELETE")));
+        //h.insert(header::ACCESS_CONTROL_MAX_AGE, HeaderValue::from_static(black_box("86400")));
         h.insert(header::VARY, HeaderValue::from_static(black_box("Origin")));
         h.insert(header::SERVER, HeaderValue::from_static(black_box("ohkami")));
         h.insert(header::CONNECTION, HeaderValue::from_static(black_box("Keep-Alive")));
@@ -127,7 +127,7 @@ use ohkami_benches::response_headers::{
         h.insert(header::REFERRER_POLICY, HeaderValue::from_static("same-origin"));
         h.insert(header::X_FRAME_OPTIONS, HeaderValue::from_static("DENY"));
         h.insert(HeaderName::from_static("x-myapp-data"), HeaderValue::from_static(black_box("myappdata; excellent")));
-        h.insert(HeaderName::from_static("something"), HeaderValue::from_static(black_box("anything")));
+        //h.insert(HeaderName::from_static("something"), HeaderValue::from_static(black_box("anything")));
     });
 }
 
@@ -135,10 +135,10 @@ use ohkami_benches::response_headers::{
     let mut h = FxMap::new();
     b.iter(|| {
         h
-            .insert("Access-Control-Allow-Credentials", black_box("true"))
-            .insert("Access-Control-Allow-Headers", black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-            .insert("Access-Control-Allow-Origin", black_box("https://foo.bar.org"))
-            .insert("Access-Control-Max-Age", black_box("86400"))
+            //.insert("Access-Control-Allow-Credentials", black_box("true"))
+            //.insert("Access-Control-Allow-Headers", black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+            //.insert("Access-Control-Allow-Origin", black_box("https://foo.bar.org"))
+            //.insert("Access-Control-Max-Age", black_box("86400"))
             .insert("Vary", black_box("Origin"))
             .insert("Server", black_box("ohkami"))
             .insert("Connection", black_box("Keep-Alive"))
@@ -148,7 +148,7 @@ use ohkami_benches::response_headers::{
             .insert("Referer-Policy", black_box("same-origin"))
             .insert("X-Frame-Options", black_box("DEBY"))
             .insert("x-myapp-data", black_box("myappdata; excellent"))
-            .insert("something", black_box("anything"))
+            //.insert("something", black_box("anything"))
         ;
     });
 }
@@ -157,10 +157,10 @@ use ohkami_benches::response_headers::{
     let mut h = MyHeaderMap::new();
     b.iter(|| {
         h.set()
-            .AccessControlAllowCredentials(black_box("true"))
-            .AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-            .AccessControlAllowOrigin(black_box("https://foo.bar.org"))
-            .AccessControlMaxAge(black_box("86400"))
+            //.AccessControlAllowCredentials(black_box("true"))
+            //.AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+            //.AccessControlAllowOrigin(black_box("https://foo.bar.org"))
+            //.AccessControlMaxAge(black_box("86400"))
             .Vary(black_box("Origin"))
             .Server(black_box("ohkami"))
             .Connection(black_box("Keep-Alive"))
@@ -170,19 +170,19 @@ use ohkami_benches::response_headers::{
             .ReferrerPolicy(black_box("same-origin"))
             .XFrameOptions(black_box("DEBY"))
             .custom("x-myapp-data", black_box("myappdata; excellent"))
-            .custom("something", black_box("anything"))
+            //.custom("something", black_box("anything"))
         ;
     });
 }
 
 #[bench] fn insert_header_hashbrown(b: &mut test::Bencher) {
-    let mut h = HeaderHashBrown::new();
+    let mut h = HeaderHashBrown::<true>::new();
     b.iter(|| {
         h
-            .insert_standard_from_reqbytes(StandardHeader::AccessControlAllowCredentials, black_box(b"true"))
-            .insert_standard_from_reqbytes(StandardHeader::AccessControlAllowHeaders, black_box(b"X-Custom-Header,Upgrade-Insecure-Requests"))
-            .insert_standard_from_reqbytes(StandardHeader::AccessControlAllowOrigin, black_box(b"https://foo.bar.org"))
-            .insert_standard_from_reqbytes(StandardHeader::AccessControlMaxAge, black_box(b"86400"))
+            //.insert_standard_from_reqbytes(StandardHeader::AccessControlAllowCredentials, black_box(b"true"))
+            //.insert_standard_from_reqbytes(StandardHeader::AccessControlAllowHeaders, black_box(b"X-Custom-Header,Upgrade-Insecure-Requests"))
+            //.insert_standard_from_reqbytes(StandardHeader::AccessControlAllowOrigin, black_box(b"https://foo.bar.org"))
+            //.insert_standard_from_reqbytes(StandardHeader::AccessControlMaxAge, black_box(b"86400"))
             .insert_standard_from_reqbytes(StandardHeader::Vary, black_box(b"Origin"))
             .insert_standard_from_reqbytes(StandardHeader::Server, black_box(b"ohkami"))
             .insert_standard_from_reqbytes(StandardHeader::Connection, black_box(b"Keep-Alive"))
@@ -192,7 +192,7 @@ use ohkami_benches::response_headers::{
             .insert_standard_from_reqbytes(StandardHeader::ReferrerPolicy, black_box(b"same-origin"))
             .insert_standard_from_reqbytes(StandardHeader::XFrameOptions, black_box(b"DEBY"))
             .insert_from_reqbytes(b"x-myapp-data", black_box(b"myappdata; excellent"))
-            .insert_from_reqbytes(b"something", black_box(b"anything"))
+            //.insert_from_reqbytes(b"something", black_box(b"anything"))
         ;
     });
 }
@@ -203,11 +203,11 @@ use ohkami_benches::response_headers::{
 #[bench] fn remove_ohkami(b: &mut test::Bencher) {
     let mut h = ResponseHeaders::_new();
     h.set()
-        .AccessControlAllowCredentials(black_box("true"))
-        .AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-        .AccessControlAllowOrigin(black_box("https://foo.bar.org"))
-        .AccessControlAllowMethods(black_box("POST,GET,OPTIONS,DELETE"))
-        .AccessControlMaxAge(black_box("86400"))
+        //.AccessControlAllowCredentials(black_box("true"))
+        //.AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+        //.AccessControlAllowOrigin(black_box("https://foo.bar.org"))
+        //.AccessControlAllowMethods(black_box("POST,GET,OPTIONS,DELETE"))
+        //.AccessControlMaxAge(black_box("86400"))
         .Vary(black_box("Origin"))
         .Server(black_box("ohkami"))
         .Connection(black_box("Keep-Alive"))
@@ -218,16 +218,16 @@ use ohkami_benches::response_headers::{
         .ReferrerPolicy(black_box("same-origin"))
         .XFrameOptions(black_box("DENY"))
         .custom("x-myapp-data", black_box("myappdata; excellent"))
-        .custom("something", black_box("anything"))
+        //.custom("something", black_box("anything"))
     ;
 
     b.iter(|| {
         h.set()
-            .AccessControlAllowCredentials(black_box(None))
-            .AccessControlAllowHeaders(black_box(None))
-            .AccessControlAllowOrigin(black_box(None))
-            .AccessControlAllowMethods(black_box(None))
-            .AccessControlMaxAge(black_box(None))
+            //.AccessControlAllowCredentials(black_box(None))
+            //.AccessControlAllowHeaders(black_box(None))
+            //.AccessControlAllowOrigin(black_box(None))
+            //.AccessControlAllowMethods(black_box(None))
+            //.AccessControlMaxAge(black_box(None))
             .Vary(black_box(None))
             .Server(black_box(None))
             .Connection(black_box(None))
@@ -238,7 +238,7 @@ use ohkami_benches::response_headers::{
             .ReferrerPolicy(black_box(None))
             .XFrameOptions(black_box(None))
             .custom("x-myapp-data", black_box(None))
-            .custom("something", black_box(None))
+            //.custom("something", black_box(None))
         ;
     });
 }
@@ -289,11 +289,11 @@ use ohkami_benches::response_headers::{
 
 #[bench] fn remove_http_crate(b: &mut test::Bencher) {
     let mut h = HeaderMap::new();
-    h.insert(header::ACCESS_CONTROL_ALLOW_CREDENTIALS, HeaderValue::from_static(black_box("true")));
-    h.insert(header::ACCESS_CONTROL_ALLOW_HEADERS, HeaderValue::from_static(black_box("X-Custom-Header,Upgrade-Insecure-Requests")));
-    h.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, HeaderValue::from_static(black_box("https://foo.bar.org")));
-    h.insert(header::ACCESS_CONTROL_ALLOW_METHODS, HeaderValue::from_static(black_box("POST,GET,OPTIONS,DELETE")));
-    h.insert(header::ACCESS_CONTROL_MAX_AGE, HeaderValue::from_static(black_box("86400")));
+    //h.insert(header::ACCESS_CONTROL_ALLOW_CREDENTIALS, HeaderValue::from_static(black_box("true")));
+    //h.insert(header::ACCESS_CONTROL_ALLOW_HEADERS, HeaderValue::from_static(black_box("X-Custom-Header,Upgrade-Insecure-Requests")));
+    //h.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, HeaderValue::from_static(black_box("https://foo.bar.org")));
+    //h.insert(header::ACCESS_CONTROL_ALLOW_METHODS, HeaderValue::from_static(black_box("POST,GET,OPTIONS,DELETE")));
+    //h.insert(header::ACCESS_CONTROL_MAX_AGE, HeaderValue::from_static(black_box("86400")));
     h.insert(header::VARY, HeaderValue::from_static(black_box("Origin")));
     h.insert(header::SERVER, HeaderValue::from_static(black_box("ohkami")));
     h.insert(header::CONNECTION, HeaderValue::from_static(black_box("Keep-Alive")));
@@ -304,14 +304,14 @@ use ohkami_benches::response_headers::{
     h.insert(header::REFERRER_POLICY, HeaderValue::from_static("same-origin"));
     h.insert(header::X_FRAME_OPTIONS, HeaderValue::from_static("DENY"));
     h.insert(HeaderName::from_static("x-myapp-data"), HeaderValue::from_static(black_box("myappdata; excellent")));
-    h.insert(HeaderName::from_static("something"), HeaderValue::from_static(black_box("anything")));
+    //h.insert(HeaderName::from_static("something"), HeaderValue::from_static(black_box("anything")));
 
     b.iter(|| {
-        h.remove(header::ACCESS_CONTROL_ALLOW_CREDENTIALS);
-        h.remove(header::ACCESS_CONTROL_ALLOW_HEADERS);
-        h.remove(header::ACCESS_CONTROL_ALLOW_ORIGIN);
-        h.remove(header::ACCESS_CONTROL_ALLOW_METHODS);
-        h.remove(header::ACCESS_CONTROL_MAX_AGE);
+        //h.remove(header::ACCESS_CONTROL_ALLOW_CREDENTIALS);
+        //h.remove(header::ACCESS_CONTROL_ALLOW_HEADERS);
+        //h.remove(header::ACCESS_CONTROL_ALLOW_ORIGIN);
+        //h.remove(header::ACCESS_CONTROL_ALLOW_METHODS);
+        //h.remove(header::ACCESS_CONTROL_MAX_AGE);
         h.remove(header::VARY);
         h.remove(header::SERVER);
         h.remove(header::CONNECTION);
@@ -322,17 +322,18 @@ use ohkami_benches::response_headers::{
         h.remove(header::REFERRER_POLICY);
         h.remove(header::X_FRAME_OPTIONS);
         h.remove(HeaderName::from_static("x-myapp-data"));
-        h.remove(HeaderName::from_static("something"));
+        //h.remove(HeaderName::from_static("something"));
     });
 }
 
 #[bench] fn remove_fxmap(b: &mut test::Bencher) {
     let mut h = FxMap::new();
     h
-        .insert("Access-Control-Allow-Credentials", black_box("true"))
-        .insert("Access-Control-Allow-Headers", black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-        .insert("Access-Control-Allow-Origin", black_box("https://foo.bar.org"))
-        .insert("Access-Control-Max-Age", black_box("86400"))
+        //.insert("Access-Control-Allow-Credentials", black_box("true"))
+        //.insert("Access-Control-Allow-Headers", black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+        //.insert("Access-Control-Allow-Origin", black_box("https://foo.bar.org"))
+        //.insert("Access-Control-Allow-Methods", black_box("POST,GET,OPTIONS,DELETE"))
+        //.insert("Access-Control-Max-Age", black_box("86400"))
         .insert("Vary", black_box("Origin"))
         .insert("Server", black_box("ohkami"))
         .insert("Connection", black_box("Keep-Alive"))
@@ -342,15 +343,16 @@ use ohkami_benches::response_headers::{
         .insert("Referer-Policy", black_box("same-origin"))
         .insert("X-Frame-Options", black_box("DEBY"))
         .insert("x-myapp-data", black_box("myappdata; excellent"))
-        .insert("something", black_box("anything"))
+        //.insert("something", black_box("anything"))
     ;
 
     b.iter(|| {
         h
-            .remove("Access-Control-Allow-Credentials")
-            .remove("Access-Control-Allow-Headers")
-            .remove("Access-Control-Allow-Origin")
-            .remove("Access-Control-Max-Age")
+            //.remove("Access-Control-Allow-Credentials")
+            //.remove("Access-Control-Allow-Headers")
+            //.remove("Access-Control-Allow-Origin")
+            //.remove("Access-Control-Allow-Methods")
+            //.remove("Access-Control-Max-Age")
             .remove("Vary")
             .remove("Server")
             .remove("Connection")
@@ -360,7 +362,7 @@ use ohkami_benches::response_headers::{
             .remove("Referer-Policy")
             .remove("X-Frame-Options")
             .remove("x-myapp-data")
-            .remove("something")
+            //.remove("something")
         ;
     });
 }
@@ -369,10 +371,11 @@ use ohkami_benches::response_headers::{
     let mut h = MyHeaderMap::new();
     
     h.set()
-        .AccessControlAllowCredentials(black_box("true"))
-        .AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-        .AccessControlAllowOrigin(black_box("https://foo.bar.org"))
-        .AccessControlMaxAge(black_box("86400"))
+        //.AccessControlAllowCredentials(black_box("true"))
+        //.AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+        //.AccessControlAllowOrigin(black_box("https://foo.bar.org"))
+        //.AccessControlAllowMethods(black_box("POST,GET,OPTIONS,DELETE"))
+        //.AccessControlMaxAge(black_box("86400"))
         .Vary(black_box("Origin"))
         .Server(black_box("ohkami"))
         .Connection(black_box("Keep-Alive"))
@@ -382,16 +385,16 @@ use ohkami_benches::response_headers::{
         .ReferrerPolicy(black_box("same-origin"))
         .XFrameOptions(black_box("DEBY"))
         .custom("x-myapp-data", black_box("myappdata; excellent"))
-        .custom("something", black_box("anything"))
+        //.custom("something", black_box("anything"))
     ;
 
     b.iter(|| {
         h.set()
-            .AccessControlAllowCredentials(black_box(None))
-            .AccessControlAllowHeaders(black_box(None))
-            .AccessControlAllowOrigin(black_box(None))
-            .AccessControlAllowMethods(black_box(None))
-            .AccessControlMaxAge(black_box(None))
+            //.AccessControlAllowCredentials(black_box(None))
+            //.AccessControlAllowHeaders(black_box(None))
+            //.AccessControlAllowOrigin(black_box(None))
+            //.AccessControlAllowMethods(black_box(None))
+            //.AccessControlMaxAge(black_box(None))
             .Vary(black_box(None))
             .Server(black_box(None))
             .Connection(black_box(None))
@@ -402,18 +405,19 @@ use ohkami_benches::response_headers::{
             .ReferrerPolicy(black_box(None))
             .XFrameOptions(black_box(None))
             .custom("x-myapp-data", black_box(None))
-            .custom("something", black_box(None))
+            //.custom("something", black_box(None))
         ;
     });
 }
 
 #[bench] fn remove_header_hashbrown(b: &mut test::Bencher) {
-    let mut h = HeaderHashBrown::new();
+    let mut h = HeaderHashBrown::<true>::new();
     h
-        .insert_standard_from_reqbytes(StandardHeader::AccessControlAllowCredentials, black_box(b"true"))
-        .insert_standard_from_reqbytes(StandardHeader::AccessControlAllowHeaders, black_box(b"X-Custom-Header,Upgrade-Insecure-Requests"))
-        .insert_standard_from_reqbytes(StandardHeader::AccessControlAllowOrigin, black_box(b"https://foo.bar.org"))
-        .insert_standard_from_reqbytes(StandardHeader::AccessControlMaxAge, black_box(b"86400"))
+        //.insert_standard_from_reqbytes(StandardHeader::AccessControlAllowCredentials, black_box(b"true"))
+        //.insert_standard_from_reqbytes(StandardHeader::AccessControlAllowHeaders, black_box(b"X-Custom-Header,Upgrade-Insecure-Requests"))
+        //.insert_standard_from_reqbytes(StandardHeader::AccessControlAllowOrigin, black_box(b"https://foo.bar.org"))
+        //.insert_standard_from_reqbytes(StandardHeader::AccessControlAllowMethods, black_box(b"POST,GET,OPTIONS,DELETE"))
+        //.insert_standard_from_reqbytes(StandardHeader::AccessControlMaxAge, black_box(b"86400"))
         .insert_standard_from_reqbytes(StandardHeader::Vary, black_box(b"Origin"))
         .insert_standard_from_reqbytes(StandardHeader::Server, black_box(b"ohkami"))
         .insert_standard_from_reqbytes(StandardHeader::Connection, black_box(b"Keep-Alive"))
@@ -423,16 +427,16 @@ use ohkami_benches::response_headers::{
         .insert_standard_from_reqbytes(StandardHeader::ReferrerPolicy, black_box(b"same-origin"))
         .insert_standard_from_reqbytes(StandardHeader::XFrameOptions, black_box(b"DEBY"))
         .insert_from_reqbytes(b"x-myapp-data", black_box(b"myappdata; excellent"))
-        .insert_from_reqbytes(b"something", black_box(b"anything"))
+        //.insert_from_reqbytes(b"something", black_box(b"anything"))
     ;
 
     b.iter(|| {
         h
-            .remove_standard(StandardHeader::AccessControlAllowCredentials)
-            .remove_standard(StandardHeader::AccessControlAllowHeaders)
-            .remove_standard(StandardHeader::AccessControlAllowOrigin)
-            .remove_standard(StandardHeader::AccessControlAllowMethods)
-            .remove_standard(StandardHeader::AccessControlMaxAge)
+            //.remove_standard(StandardHeader::AccessControlAllowCredentials)
+            //.remove_standard(StandardHeader::AccessControlAllowHeaders)
+            //.remove_standard(StandardHeader::AccessControlAllowOrigin)
+            //.remove_standard(StandardHeader::AccessControlAllowMethods)
+            //.remove_standard(StandardHeader::AccessControlMaxAge)
             .remove_standard(StandardHeader::Vary)
             .remove_standard(StandardHeader::Server)
             .remove_standard(StandardHeader::Connection)
@@ -443,7 +447,7 @@ use ohkami_benches::response_headers::{
             .remove_standard(StandardHeader::ReferrerPolicy)
             .remove_standard(StandardHeader::XFrameOptions)
             .remove("x-myapp-data")
-            .remove("something")
+            //.remove("something")
         ;
     });
 }
@@ -468,7 +472,7 @@ use ohkami_benches::response_headers::{
         .ReferrerPolicy(black_box("same-origin"))
         .XFrameOptions(black_box("DENY"))
         .custom("x-myapp-data", black_box("myappdata; excellent"))
-        .custom("something", black_box("anything"))
+        //.custom("something", black_box("anything"))
     ;
 
     let mut buf = Vec::new();
@@ -574,7 +578,7 @@ use ohkami_benches::response_headers::{
     h.insert(header::REFERRER_POLICY, HeaderValue::from_static("same-origin"));
     h.insert(header::X_FRAME_OPTIONS, HeaderValue::from_static("DENY"));
     h.insert(HeaderName::from_static("x-myapp-data"), HeaderValue::from_static(black_box("myappdata; excellent")));
-    h.insert(HeaderName::from_static("something"), HeaderValue::from_static(black_box("anything")));
+    //h.insert(HeaderName::from_static("something"), HeaderValue::from_static(black_box("anything")));
 
     let mut buf = Vec::new();
     b.iter(|| {
@@ -605,7 +609,7 @@ use ohkami_benches::response_headers::{
         .insert("Referer-Policy", black_box("same-origin"))
         .insert("X-Frame-Options", black_box("DEBY"))
         .insert("x-myapp-data", black_box("myappdata; excellent"))
-        .insert("something", black_box("anything"))
+        //.insert("something", black_box("anything"))
     ;
 
     let mut buf = Vec::new();
@@ -631,7 +635,7 @@ use ohkami_benches::response_headers::{
         .ReferrerPolicy(black_box("same-origin"))
         .XFrameOptions(black_box("DEBY"))
         .custom("x-myapp-data", black_box("myappdata; excellent"))
-        .custom("something", black_box("anything"))
+        //.custom("something", black_box("anything"))
     ;
 
     let mut buf = Vec::new();
@@ -640,8 +644,8 @@ use ohkami_benches::response_headers::{
     });
 }
 
-#[bench] fn write_05_header_hashbrown(b: &mut test::Bencher) {
-    let mut h = HeaderHashBrown::new();
+#[bench] fn write_03_header_hashbrown(b: &mut test::Bencher) {
+    let mut h = HeaderHashBrown::<true>::new();
     h
         // .insert_standard_from_reqbytes(StandardHeader::AccessControlAllowCredentials, black_box(b"true"))
         // .insert_standard_from_reqbytes(StandardHeader::AccessControlAllowHeaders, black_box(b"X-Custom-Header,Upgrade-Insecure-Requests"))
@@ -657,8 +661,11 @@ use ohkami_benches::response_headers::{
         .insert_standard_from_reqbytes(StandardHeader::ReferrerPolicy, black_box(b"same-origin"))
         .insert_standard_from_reqbytes(StandardHeader::XFrameOptions, black_box(b"DEBY"))
         .insert_from_reqbytes(b"x-myapp-data", black_box(b"myappdata; excellent"))
-        .insert_from_reqbytes(b"something", black_box(b"anything"))
+        //.insert_from_reqbytes(b"something", black_box(b"anything"))
     ;
+
+    //assert_eq!({let mut buf = Vec::new(); h.write_to(&mut buf); String::from_utf8(buf).unwrap()}, "\
+    //");
 
     let mut buf = Vec::new();
     b.iter(|| {

--- a/benches/benches/response_headers.rs
+++ b/benches/benches/response_headers.rs
@@ -36,7 +36,7 @@ use ohkami_benches::response_headers::{
             .ReferrerPolicy(black_box("same-origin"))
             .XFrameOptions(black_box("DENY"))
             .custom("x-myapp-data", black_box("myappdata; excellent"))
-            //.custom("something", black_box("anything"))
+            .custom("something", black_box("anything"))
         ;
     });
 }
@@ -127,7 +127,7 @@ use ohkami_benches::response_headers::{
         h.insert(header::REFERRER_POLICY, HeaderValue::from_static("same-origin"));
         h.insert(header::X_FRAME_OPTIONS, HeaderValue::from_static("DENY"));
         h.insert(HeaderName::from_static("x-myapp-data"), HeaderValue::from_static(black_box("myappdata; excellent")));
-        //h.insert(HeaderName::from_static("something"), HeaderValue::from_static(black_box("anything")));
+        h.insert(HeaderName::from_static("something"), HeaderValue::from_static(black_box("anything")));
     });
 }
 
@@ -148,7 +148,7 @@ use ohkami_benches::response_headers::{
             .insert("Referer-Policy", black_box("same-origin"))
             .insert("X-Frame-Options", black_box("DEBY"))
             .insert("x-myapp-data", black_box("myappdata; excellent"))
-            //.insert("something", black_box("anything"))
+            .insert("something", black_box("anything"))
         ;
     });
 }
@@ -170,7 +170,7 @@ use ohkami_benches::response_headers::{
             .ReferrerPolicy(black_box("same-origin"))
             .XFrameOptions(black_box("DEBY"))
             .custom("x-myapp-data", black_box("myappdata; excellent"))
-            //.custom("something", black_box("anything"))
+            .custom("something", black_box("anything"))
         ;
     });
 }
@@ -192,7 +192,7 @@ use ohkami_benches::response_headers::{
             .insert_standard_from_reqbytes(StandardHeader::ReferrerPolicy, black_box(b"same-origin"))
             .insert_standard_from_reqbytes(StandardHeader::XFrameOptions, black_box(b"DEBY"))
             .insert_from_reqbytes(b"x-myapp-data", black_box(b"myappdata; excellent"))
-            //.insert_from_reqbytes(b"something", black_box(b"anything"))
+            .insert_from_reqbytes(b"something", black_box(b"anything"))
         ;
     });
 }
@@ -218,7 +218,7 @@ use ohkami_benches::response_headers::{
         .ReferrerPolicy(black_box("same-origin"))
         .XFrameOptions(black_box("DENY"))
         .custom("x-myapp-data", black_box("myappdata; excellent"))
-        //.custom("something", black_box("anything"))
+        .custom("something", black_box("anything"))
     ;
 
     b.iter(|| {
@@ -238,7 +238,7 @@ use ohkami_benches::response_headers::{
             .ReferrerPolicy(black_box(None))
             .XFrameOptions(black_box(None))
             .custom("x-myapp-data", black_box(None))
-            //.custom("something", black_box(None))
+            .custom("something", black_box(None))
         ;
     });
 }
@@ -304,7 +304,7 @@ use ohkami_benches::response_headers::{
     h.insert(header::REFERRER_POLICY, HeaderValue::from_static("same-origin"));
     h.insert(header::X_FRAME_OPTIONS, HeaderValue::from_static("DENY"));
     h.insert(HeaderName::from_static("x-myapp-data"), HeaderValue::from_static(black_box("myappdata; excellent")));
-    //h.insert(HeaderName::from_static("something"), HeaderValue::from_static(black_box("anything")));
+    h.insert(HeaderName::from_static("something"), HeaderValue::from_static(black_box("anything")));
 
     b.iter(|| {
         //h.remove(header::ACCESS_CONTROL_ALLOW_CREDENTIALS);
@@ -322,7 +322,7 @@ use ohkami_benches::response_headers::{
         h.remove(header::REFERRER_POLICY);
         h.remove(header::X_FRAME_OPTIONS);
         h.remove(HeaderName::from_static("x-myapp-data"));
-        //h.remove(HeaderName::from_static("something"));
+        h.remove(HeaderName::from_static("something"));
     });
 }
 
@@ -343,7 +343,7 @@ use ohkami_benches::response_headers::{
         .insert("Referer-Policy", black_box("same-origin"))
         .insert("X-Frame-Options", black_box("DEBY"))
         .insert("x-myapp-data", black_box("myappdata; excellent"))
-        //.insert("something", black_box("anything"))
+        .insert("something", black_box("anything"))
     ;
 
     b.iter(|| {
@@ -362,7 +362,7 @@ use ohkami_benches::response_headers::{
             .remove("Referer-Policy")
             .remove("X-Frame-Options")
             .remove("x-myapp-data")
-            //.remove("something")
+            .remove("something")
         ;
     });
 }
@@ -385,7 +385,7 @@ use ohkami_benches::response_headers::{
         .ReferrerPolicy(black_box("same-origin"))
         .XFrameOptions(black_box("DEBY"))
         .custom("x-myapp-data", black_box("myappdata; excellent"))
-        //.custom("something", black_box("anything"))
+        .custom("something", black_box("anything"))
     ;
 
     b.iter(|| {
@@ -405,7 +405,7 @@ use ohkami_benches::response_headers::{
             .ReferrerPolicy(black_box(None))
             .XFrameOptions(black_box(None))
             .custom("x-myapp-data", black_box(None))
-            //.custom("something", black_box(None))
+            .custom("something", black_box(None))
         ;
     });
 }
@@ -427,7 +427,7 @@ use ohkami_benches::response_headers::{
         .insert_standard_from_reqbytes(StandardHeader::ReferrerPolicy, black_box(b"same-origin"))
         .insert_standard_from_reqbytes(StandardHeader::XFrameOptions, black_box(b"DEBY"))
         .insert_from_reqbytes(b"x-myapp-data", black_box(b"myappdata; excellent"))
-        //.insert_from_reqbytes(b"something", black_box(b"anything"))
+        .insert_from_reqbytes(b"something", black_box(b"anything"))
     ;
 
     b.iter(|| {
@@ -447,7 +447,7 @@ use ohkami_benches::response_headers::{
             .remove_standard(StandardHeader::ReferrerPolicy)
             .remove_standard(StandardHeader::XFrameOptions)
             .remove("x-myapp-data")
-            //.remove("something")
+            .remove("something")
         ;
     });
 }
@@ -472,7 +472,7 @@ use ohkami_benches::response_headers::{
         .ReferrerPolicy(black_box("same-origin"))
         .XFrameOptions(black_box("DENY"))
         .custom("x-myapp-data", black_box("myappdata; excellent"))
-        //.custom("something", black_box("anything"))
+        .custom("something", black_box("anything"))
     ;
 
     let mut buf = Vec::new();
@@ -578,7 +578,7 @@ use ohkami_benches::response_headers::{
     h.insert(header::REFERRER_POLICY, HeaderValue::from_static("same-origin"));
     h.insert(header::X_FRAME_OPTIONS, HeaderValue::from_static("DENY"));
     h.insert(HeaderName::from_static("x-myapp-data"), HeaderValue::from_static(black_box("myappdata; excellent")));
-    //h.insert(HeaderName::from_static("something"), HeaderValue::from_static(black_box("anything")));
+    h.insert(HeaderName::from_static("something"), HeaderValue::from_static(black_box("anything")));
 
     let mut buf = Vec::new();
     b.iter(|| {
@@ -609,7 +609,7 @@ use ohkami_benches::response_headers::{
         .insert("Referer-Policy", black_box("same-origin"))
         .insert("X-Frame-Options", black_box("DEBY"))
         .insert("x-myapp-data", black_box("myappdata; excellent"))
-        //.insert("something", black_box("anything"))
+        .insert("something", black_box("anything"))
     ;
 
     let mut buf = Vec::new();
@@ -635,7 +635,7 @@ use ohkami_benches::response_headers::{
         .ReferrerPolicy(black_box("same-origin"))
         .XFrameOptions(black_box("DEBY"))
         .custom("x-myapp-data", black_box("myappdata; excellent"))
-        //.custom("something", black_box("anything"))
+        .custom("something", black_box("anything"))
     ;
 
     let mut buf = Vec::new();
@@ -661,11 +661,8 @@ use ohkami_benches::response_headers::{
         .insert_standard_from_reqbytes(StandardHeader::ReferrerPolicy, black_box(b"same-origin"))
         .insert_standard_from_reqbytes(StandardHeader::XFrameOptions, black_box(b"DEBY"))
         .insert_from_reqbytes(b"x-myapp-data", black_box(b"myappdata; excellent"))
-        //.insert_from_reqbytes(b"something", black_box(b"anything"))
+        .insert_from_reqbytes(b"something", black_box(b"anything"))
     ;
-
-    //assert_eq!({let mut buf = Vec::new(); h.write_to(&mut buf); String::from_utf8(buf).unwrap()}, "\
-    //");
 
     let mut buf = Vec::new();
     b.iter(|| {

--- a/benches/benches/response_headers.rs
+++ b/benches/benches/response_headers.rs
@@ -21,11 +21,11 @@ use ohkami_benches::response_headers::{
     let mut h = ResponseHeaders::_new();
     b.iter(|| {
         h.set()
-            //.AccessControlAllowCredentials(black_box("true"))
-            //.AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-            //.AccessControlAllowOrigin(black_box("https://foo.bar.org"))
-            //.AccessControlAllowMethods(black_box("POST,GET,OPTIONS,DELETE"))
-            //.AccessControlMaxAge(black_box("86400"))
+            .AccessControlAllowCredentials(black_box("true"))
+            .AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+            .AccessControlAllowOrigin(black_box("https://foo.bar.org"))
+            .AccessControlAllowMethods(black_box("POST,GET,OPTIONS,DELETE"))
+            .AccessControlMaxAge(black_box("86400"))
             .Vary(black_box("Origin"))
             .Server(black_box("ohkami"))
             .Connection(black_box("Keep-Alive"))
@@ -112,11 +112,11 @@ use ohkami_benches::response_headers::{
 #[bench] fn insert_http_crate(b: &mut test::Bencher) {
     let mut h = HeaderMap::new();
     b.iter(|| {
-        //h.insert(header::ACCESS_CONTROL_ALLOW_CREDENTIALS, HeaderValue::from_static(black_box("true")));
-        //h.insert(header::ACCESS_CONTROL_ALLOW_HEADERS, HeaderValue::from_static(black_box("X-Custom-Header,Upgrade-Insecure-Requests")));
-        //h.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, HeaderValue::from_static(black_box("https://foo.bar.org")));
-        //h.insert(header::ACCESS_CONTROL_ALLOW_METHODS, HeaderValue::from_static(black_box("POST,GET,OPTIONS,DELETE")));
-        //h.insert(header::ACCESS_CONTROL_MAX_AGE, HeaderValue::from_static(black_box("86400")));
+        h.insert(header::ACCESS_CONTROL_ALLOW_CREDENTIALS, HeaderValue::from_static(black_box("true")));
+        h.insert(header::ACCESS_CONTROL_ALLOW_HEADERS, HeaderValue::from_static(black_box("X-Custom-Header,Upgrade-Insecure-Requests")));
+        h.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, HeaderValue::from_static(black_box("https://foo.bar.org")));
+        h.insert(header::ACCESS_CONTROL_ALLOW_METHODS, HeaderValue::from_static(black_box("POST,GET,OPTIONS,DELETE")));
+        h.insert(header::ACCESS_CONTROL_MAX_AGE, HeaderValue::from_static(black_box("86400")));
         h.insert(header::VARY, HeaderValue::from_static(black_box("Origin")));
         h.insert(header::SERVER, HeaderValue::from_static(black_box("ohkami")));
         h.insert(header::CONNECTION, HeaderValue::from_static(black_box("Keep-Alive")));
@@ -135,10 +135,11 @@ use ohkami_benches::response_headers::{
     let mut h = FxMap::new();
     b.iter(|| {
         h
-            //.insert("Access-Control-Allow-Credentials", black_box("true"))
-            //.insert("Access-Control-Allow-Headers", black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-            //.insert("Access-Control-Allow-Origin", black_box("https://foo.bar.org"))
-            //.insert("Access-Control-Max-Age", black_box("86400"))
+            .insert("Access-Control-Allow-Credentials", black_box("true"))
+            .insert("Access-Control-Allow-Headers", black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+            .insert("Access-Control-Allow-Origin", black_box("https://foo.bar.org"))
+            .insert("Access-Control-Allow-Methods", black_box("POST,GET,OPTIONS,DELETE"))
+            .insert("Access-Control-Max-Age", black_box("86400"))
             .insert("Vary", black_box("Origin"))
             .insert("Server", black_box("ohkami"))
             .insert("Connection", black_box("Keep-Alive"))
@@ -157,10 +158,11 @@ use ohkami_benches::response_headers::{
     let mut h = MyHeaderMap::new();
     b.iter(|| {
         h.set()
-            //.AccessControlAllowCredentials(black_box("true"))
-            //.AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-            //.AccessControlAllowOrigin(black_box("https://foo.bar.org"))
-            //.AccessControlMaxAge(black_box("86400"))
+            .AccessControlAllowCredentials(black_box("true"))
+            .AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+            .AccessControlAllowOrigin(black_box("https://foo.bar.org"))
+            .AccessControlAllowMethods(black_box("POST,GET,OPTIONS,DELETE"))
+            .AccessControlMaxAge(black_box("86400"))
             .Vary(black_box("Origin"))
             .Server(black_box("ohkami"))
             .Connection(black_box("Keep-Alive"))
@@ -179,10 +181,11 @@ use ohkami_benches::response_headers::{
     let mut h = HeaderHashBrown::<true>::new();
     b.iter(|| {
         h
-            //.insert_standard_from_reqbytes(StandardHeader::AccessControlAllowCredentials, black_box(b"true"))
-            //.insert_standard_from_reqbytes(StandardHeader::AccessControlAllowHeaders, black_box(b"X-Custom-Header,Upgrade-Insecure-Requests"))
-            //.insert_standard_from_reqbytes(StandardHeader::AccessControlAllowOrigin, black_box(b"https://foo.bar.org"))
-            //.insert_standard_from_reqbytes(StandardHeader::AccessControlMaxAge, black_box(b"86400"))
+            .insert_standard_from_reqbytes(StandardHeader::AccessControlAllowCredentials, black_box(b"true"))
+            .insert_standard_from_reqbytes(StandardHeader::AccessControlAllowHeaders, black_box(b"X-Custom-Header,Upgrade-Insecure-Requests"))
+            .insert_standard_from_reqbytes(StandardHeader::AccessControlAllowOrigin, black_box(b"https://foo.bar.org"))
+            .insert_standard_from_reqbytes(StandardHeader::AccessControlAllowMethods, black_box(b"POST,GET,OPTIONS,DELETE"))
+            .insert_standard_from_reqbytes(StandardHeader::AccessControlMaxAge, black_box(b"86400"))
             .insert_standard_from_reqbytes(StandardHeader::Vary, black_box(b"Origin"))
             .insert_standard_from_reqbytes(StandardHeader::Server, black_box(b"ohkami"))
             .insert_standard_from_reqbytes(StandardHeader::Connection, black_box(b"Keep-Alive"))
@@ -203,11 +206,11 @@ use ohkami_benches::response_headers::{
 #[bench] fn remove_ohkami(b: &mut test::Bencher) {
     let mut h = ResponseHeaders::_new();
     h.set()
-        //.AccessControlAllowCredentials(black_box("true"))
-        //.AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-        //.AccessControlAllowOrigin(black_box("https://foo.bar.org"))
-        //.AccessControlAllowMethods(black_box("POST,GET,OPTIONS,DELETE"))
-        //.AccessControlMaxAge(black_box("86400"))
+        .AccessControlAllowCredentials(black_box("true"))
+        .AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+        .AccessControlAllowOrigin(black_box("https://foo.bar.org"))
+        .AccessControlAllowMethods(black_box("POST,GET,OPTIONS,DELETE"))
+        .AccessControlMaxAge(black_box("86400"))
         .Vary(black_box("Origin"))
         .Server(black_box("ohkami"))
         .Connection(black_box("Keep-Alive"))
@@ -223,22 +226,22 @@ use ohkami_benches::response_headers::{
 
     b.iter(|| {
         h.set()
-            //.AccessControlAllowCredentials(black_box(None))
-            //.AccessControlAllowHeaders(black_box(None))
-            //.AccessControlAllowOrigin(black_box(None))
-            //.AccessControlAllowMethods(black_box(None))
-            //.AccessControlMaxAge(black_box(None))
-            .Vary(black_box(None))
-            .Server(black_box(None))
-            .Connection(black_box(None))
-            .Date(black_box(None))
-            .Via(black_box(None))
-            .AltSvc(black_box(None))
-            .ProxyAuthenticate(black_box(None))
-            .ReferrerPolicy(black_box(None))
-            .XFrameOptions(black_box(None))
-            .custom("x-myapp-data", black_box(None))
-            .custom("something", black_box(None))
+            .AccessControlAllowCredentials(None)
+            .AccessControlAllowHeaders(None)
+            .AccessControlAllowOrigin(None)
+            .AccessControlAllowMethods(None)
+            .AccessControlMaxAge(None)
+            .Vary(None)
+            .Server(None)
+            .Connection(None)
+            .Date(None)
+            .Via(None)
+            .AltSvc(None)
+            .ProxyAuthenticate(None)
+            .ReferrerPolicy(None)
+            .XFrameOptions(None)
+            .custom("x-myapp-data", None)
+            .custom("something", None)
         ;
     });
 }
@@ -289,11 +292,11 @@ use ohkami_benches::response_headers::{
 
 #[bench] fn remove_http_crate(b: &mut test::Bencher) {
     let mut h = HeaderMap::new();
-    //h.insert(header::ACCESS_CONTROL_ALLOW_CREDENTIALS, HeaderValue::from_static(black_box("true")));
-    //h.insert(header::ACCESS_CONTROL_ALLOW_HEADERS, HeaderValue::from_static(black_box("X-Custom-Header,Upgrade-Insecure-Requests")));
-    //h.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, HeaderValue::from_static(black_box("https://foo.bar.org")));
-    //h.insert(header::ACCESS_CONTROL_ALLOW_METHODS, HeaderValue::from_static(black_box("POST,GET,OPTIONS,DELETE")));
-    //h.insert(header::ACCESS_CONTROL_MAX_AGE, HeaderValue::from_static(black_box("86400")));
+    h.insert(header::ACCESS_CONTROL_ALLOW_CREDENTIALS, HeaderValue::from_static(black_box("true")));
+    h.insert(header::ACCESS_CONTROL_ALLOW_HEADERS, HeaderValue::from_static(black_box("X-Custom-Header,Upgrade-Insecure-Requests")));
+    h.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, HeaderValue::from_static(black_box("https://foo.bar.org")));
+    h.insert(header::ACCESS_CONTROL_ALLOW_METHODS, HeaderValue::from_static(black_box("POST,GET,OPTIONS,DELETE")));
+    h.insert(header::ACCESS_CONTROL_MAX_AGE, HeaderValue::from_static(black_box("86400")));
     h.insert(header::VARY, HeaderValue::from_static(black_box("Origin")));
     h.insert(header::SERVER, HeaderValue::from_static(black_box("ohkami")));
     h.insert(header::CONNECTION, HeaderValue::from_static(black_box("Keep-Alive")));
@@ -307,11 +310,11 @@ use ohkami_benches::response_headers::{
     h.insert(HeaderName::from_static("something"), HeaderValue::from_static(black_box("anything")));
 
     b.iter(|| {
-        //h.remove(header::ACCESS_CONTROL_ALLOW_CREDENTIALS);
-        //h.remove(header::ACCESS_CONTROL_ALLOW_HEADERS);
-        //h.remove(header::ACCESS_CONTROL_ALLOW_ORIGIN);
-        //h.remove(header::ACCESS_CONTROL_ALLOW_METHODS);
-        //h.remove(header::ACCESS_CONTROL_MAX_AGE);
+        h.remove(header::ACCESS_CONTROL_ALLOW_CREDENTIALS);
+        h.remove(header::ACCESS_CONTROL_ALLOW_HEADERS);
+        h.remove(header::ACCESS_CONTROL_ALLOW_ORIGIN);
+        h.remove(header::ACCESS_CONTROL_ALLOW_METHODS);
+        h.remove(header::ACCESS_CONTROL_MAX_AGE);
         h.remove(header::VARY);
         h.remove(header::SERVER);
         h.remove(header::CONNECTION);
@@ -329,11 +332,11 @@ use ohkami_benches::response_headers::{
 #[bench] fn remove_fxmap(b: &mut test::Bencher) {
     let mut h = FxMap::new();
     h
-        //.insert("Access-Control-Allow-Credentials", black_box("true"))
-        //.insert("Access-Control-Allow-Headers", black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-        //.insert("Access-Control-Allow-Origin", black_box("https://foo.bar.org"))
-        //.insert("Access-Control-Allow-Methods", black_box("POST,GET,OPTIONS,DELETE"))
-        //.insert("Access-Control-Max-Age", black_box("86400"))
+        .insert("Access-Control-Allow-Credentials", black_box("true"))
+        .insert("Access-Control-Allow-Headers", black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+        .insert("Access-Control-Allow-Origin", black_box("https://foo.bar.org"))
+        .insert("Access-Control-Allow-Methods", black_box("POST,GET,OPTIONS,DELETE"))
+        .insert("Access-Control-Max-Age", black_box("86400"))
         .insert("Vary", black_box("Origin"))
         .insert("Server", black_box("ohkami"))
         .insert("Connection", black_box("Keep-Alive"))
@@ -348,11 +351,11 @@ use ohkami_benches::response_headers::{
 
     b.iter(|| {
         h
-            //.remove("Access-Control-Allow-Credentials")
-            //.remove("Access-Control-Allow-Headers")
-            //.remove("Access-Control-Allow-Origin")
-            //.remove("Access-Control-Allow-Methods")
-            //.remove("Access-Control-Max-Age")
+            .remove("Access-Control-Allow-Credentials")
+            .remove("Access-Control-Allow-Headers")
+            .remove("Access-Control-Allow-Origin")
+            .remove("Access-Control-Allow-Methods")
+            .remove("Access-Control-Max-Age")
             .remove("Vary")
             .remove("Server")
             .remove("Connection")
@@ -371,11 +374,11 @@ use ohkami_benches::response_headers::{
     let mut h = MyHeaderMap::new();
     
     h.set()
-        //.AccessControlAllowCredentials(black_box("true"))
-        //.AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-        //.AccessControlAllowOrigin(black_box("https://foo.bar.org"))
-        //.AccessControlAllowMethods(black_box("POST,GET,OPTIONS,DELETE"))
-        //.AccessControlMaxAge(black_box("86400"))
+        .AccessControlAllowCredentials(black_box("true"))
+        .AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+        .AccessControlAllowOrigin(black_box("https://foo.bar.org"))
+        .AccessControlAllowMethods(black_box("POST,GET,OPTIONS,DELETE"))
+        .AccessControlMaxAge(black_box("86400"))
         .Vary(black_box("Origin"))
         .Server(black_box("ohkami"))
         .Connection(black_box("Keep-Alive"))
@@ -390,22 +393,22 @@ use ohkami_benches::response_headers::{
 
     b.iter(|| {
         h.set()
-            //.AccessControlAllowCredentials(black_box(None))
-            //.AccessControlAllowHeaders(black_box(None))
-            //.AccessControlAllowOrigin(black_box(None))
-            //.AccessControlAllowMethods(black_box(None))
-            //.AccessControlMaxAge(black_box(None))
-            .Vary(black_box(None))
-            .Server(black_box(None))
-            .Connection(black_box(None))
-            .Date(black_box(None))
-            .Via(black_box(None))
-            .AltSvc(black_box(None))
-            .ProxyAuthenticate(black_box(None))
-            .ReferrerPolicy(black_box(None))
-            .XFrameOptions(black_box(None))
-            .custom("x-myapp-data", black_box(None))
-            .custom("something", black_box(None))
+            .AccessControlAllowCredentials(None)
+            .AccessControlAllowHeaders(None)
+            .AccessControlAllowOrigin(None)
+            .AccessControlAllowMethods(None)
+            .AccessControlMaxAge(None)
+            .Vary(None)
+            .Server(None)
+            .Connection(None)
+            .Date(None)
+            .Via(None)
+            .AltSvc(None)
+            .ProxyAuthenticate(None)
+            .ReferrerPolicy(None)
+            .XFrameOptions(None)
+            .custom("x-myapp-data", None)
+            .custom("something", None)
         ;
     });
 }
@@ -413,11 +416,11 @@ use ohkami_benches::response_headers::{
 #[bench] fn remove_header_hashbrown(b: &mut test::Bencher) {
     let mut h = HeaderHashBrown::<true>::new();
     h
-        //.insert_standard_from_reqbytes(StandardHeader::AccessControlAllowCredentials, black_box(b"true"))
-        //.insert_standard_from_reqbytes(StandardHeader::AccessControlAllowHeaders, black_box(b"X-Custom-Header,Upgrade-Insecure-Requests"))
-        //.insert_standard_from_reqbytes(StandardHeader::AccessControlAllowOrigin, black_box(b"https://foo.bar.org"))
-        //.insert_standard_from_reqbytes(StandardHeader::AccessControlAllowMethods, black_box(b"POST,GET,OPTIONS,DELETE"))
-        //.insert_standard_from_reqbytes(StandardHeader::AccessControlMaxAge, black_box(b"86400"))
+        .insert_standard_from_reqbytes(StandardHeader::AccessControlAllowCredentials, black_box(b"true"))
+        .insert_standard_from_reqbytes(StandardHeader::AccessControlAllowHeaders, black_box(b"X-Custom-Header,Upgrade-Insecure-Requests"))
+        .insert_standard_from_reqbytes(StandardHeader::AccessControlAllowOrigin, black_box(b"https://foo.bar.org"))
+        .insert_standard_from_reqbytes(StandardHeader::AccessControlAllowMethods, black_box(b"POST,GET,OPTIONS,DELETE"))
+        .insert_standard_from_reqbytes(StandardHeader::AccessControlMaxAge, black_box(b"86400"))
         .insert_standard_from_reqbytes(StandardHeader::Vary, black_box(b"Origin"))
         .insert_standard_from_reqbytes(StandardHeader::Server, black_box(b"ohkami"))
         .insert_standard_from_reqbytes(StandardHeader::Connection, black_box(b"Keep-Alive"))
@@ -432,11 +435,11 @@ use ohkami_benches::response_headers::{
 
     b.iter(|| {
         h
-            //.remove_standard(StandardHeader::AccessControlAllowCredentials)
-            //.remove_standard(StandardHeader::AccessControlAllowHeaders)
-            //.remove_standard(StandardHeader::AccessControlAllowOrigin)
-            //.remove_standard(StandardHeader::AccessControlAllowMethods)
-            //.remove_standard(StandardHeader::AccessControlMaxAge)
+            .remove_standard(StandardHeader::AccessControlAllowCredentials)
+            .remove_standard(StandardHeader::AccessControlAllowHeaders)
+            .remove_standard(StandardHeader::AccessControlAllowOrigin)
+            .remove_standard(StandardHeader::AccessControlAllowMethods)
+            .remove_standard(StandardHeader::AccessControlMaxAge)
             .remove_standard(StandardHeader::Vary)
             .remove_standard(StandardHeader::Server)
             .remove_standard(StandardHeader::Connection)
@@ -457,11 +460,11 @@ use ohkami_benches::response_headers::{
 #[bench] fn write_03_ohkami(b: &mut test::Bencher) {
     let mut h = ResponseHeaders::_new();
     h.set()
-        // .AccessControlAllowCredentials(black_box("true"))
-        // .AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-        // .AccessControlAllowOrigin(black_box("https://foo.bar.org"))
-        // .AccessControlAllowMethods(black_box("POST,GET,OPTIONS,DELETE"))
-        // .AccessControlMaxAge(black_box("86400"))
+        .AccessControlAllowCredentials(black_box("true"))
+        .AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+        .AccessControlAllowOrigin(black_box("https://foo.bar.org"))
+        .AccessControlAllowMethods(black_box("POST,GET,OPTIONS,DELETE"))
+        .AccessControlMaxAge(black_box("86400"))
         .Vary(black_box("Origin"))
         .Server(black_box("ohkami"))
         .Connection(black_box("Keep-Alive"))
@@ -563,11 +566,11 @@ use ohkami_benches::response_headers::{
 
 #[bench] fn write_02_http_crate(b: &mut test::Bencher) {
     let mut h = HeaderMap::new();
-    // h.insert(header::ACCESS_CONTROL_ALLOW_CREDENTIALS, HeaderValue::from_static(black_box("true")));
-    // h.insert(header::ACCESS_CONTROL_ALLOW_HEADERS, HeaderValue::from_static(black_box("X-Custom-Header,Upgrade-Insecure-Requests")));
-    // h.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, HeaderValue::from_static(black_box("https://foo.bar.org")));
-    // h.insert(header::ACCESS_CONTROL_ALLOW_METHODS, HeaderValue::from_static(black_box("POST,GET,OPTIONS,DELETE")));
-    // h.insert(header::ACCESS_CONTROL_MAX_AGE, HeaderValue::from_static(black_box("86400")));
+    h.insert(header::ACCESS_CONTROL_ALLOW_CREDENTIALS, HeaderValue::from_static(black_box("true")));
+    h.insert(header::ACCESS_CONTROL_ALLOW_HEADERS, HeaderValue::from_static(black_box("X-Custom-Header,Upgrade-Insecure-Requests")));
+    h.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, HeaderValue::from_static(black_box("https://foo.bar.org")));
+    h.insert(header::ACCESS_CONTROL_ALLOW_METHODS, HeaderValue::from_static(black_box("POST,GET,OPTIONS,DELETE")));
+    h.insert(header::ACCESS_CONTROL_MAX_AGE, HeaderValue::from_static(black_box("86400")));
     h.insert(header::VARY, HeaderValue::from_static(black_box("Origin")));
     h.insert(header::SERVER, HeaderValue::from_static(black_box("ohkami")));
     h.insert(header::CONNECTION, HeaderValue::from_static(black_box("Keep-Alive")));
@@ -595,11 +598,11 @@ use ohkami_benches::response_headers::{
 #[bench] fn write_03_fxmap(b: &mut test::Bencher) {
     let mut h = FxMap::new();
     h
-        // .insert("Access-Control-Allow-Credentials", black_box("true"))
-        // .insert("Access-Control-Allow-Headers", black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-        // .insert("Access-Control-Allow-Origin", black_box("https://foo.bar.org"))
-        // .insert("Access-Conctrol-Allow-Methods", black_box("POST,GET,OPTIONS,DELETE"))
-        // .insert("Access-Control-Max-Age", black_box("86400"))
+        .insert("Access-Control-Allow-Credentials", black_box("true"))
+        .insert("Access-Control-Allow-Headers", black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+        .insert("Access-Control-Allow-Origin", black_box("https://foo.bar.org"))
+        .insert("Access-Conctrol-Allow-Methods", black_box("POST,GET,OPTIONS,DELETE"))
+        .insert("Access-Control-Max-Age", black_box("86400"))
         .insert("Vary", black_box("Origin"))
         .insert("Server", black_box("ohkami"))
         .insert("Connection", black_box("Keep-Alive"))
@@ -621,11 +624,11 @@ use ohkami_benches::response_headers::{
 #[bench] fn write_04_headermap(b: &mut test::Bencher) {
     let mut h = MyHeaderMap::new();
     h.set()
-        // .AccessControlAllowCredentials(black_box("true"))
-        // .AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
-        // .AccessControlAllowOrigin(black_box("https://foo.bar.org"))
-        // .AccessControlAllowMethods(black_box("POST,GET,OPTIONS,DELETE"))
-        // .AccessControlMaxAge(black_box("86400"))
+        .AccessControlAllowCredentials(black_box("true"))
+        .AccessControlAllowHeaders(black_box("X-Custom-Header,Upgrade-Insecure-Requests"))
+        .AccessControlAllowOrigin(black_box("https://foo.bar.org"))
+        .AccessControlAllowMethods(black_box("POST,GET,OPTIONS,DELETE"))
+        .AccessControlMaxAge(black_box("86400"))
         .Vary(black_box("Origin"))
         .Server(black_box("ohkami"))
         .Connection(black_box("Keep-Alive"))
@@ -647,11 +650,11 @@ use ohkami_benches::response_headers::{
 #[bench] fn write_03_header_hashbrown(b: &mut test::Bencher) {
     let mut h = HeaderHashBrown::<true>::new();
     h
-        // .insert_standard_from_reqbytes(StandardHeader::AccessControlAllowCredentials, black_box(b"true"))
-        // .insert_standard_from_reqbytes(StandardHeader::AccessControlAllowHeaders, black_box(b"X-Custom-Header,Upgrade-Insecure-Requests"))
-        // .insert_standard_from_reqbytes(StandardHeader::AccessControlAllowOrigin, black_box(b"https://foo.bar.org"))
-        // .insert_standard_from_reqbytes(StandardHeader::AccessControlAllowMethods, black_box(b"POST,GET,OPTIONS,DELETE"))
-        // .insert_standard_from_reqbytes(StandardHeader::AccessControlMaxAge, black_box(b"86400"))
+        .insert_standard_from_reqbytes(StandardHeader::AccessControlAllowCredentials, black_box(b"true"))
+        .insert_standard_from_reqbytes(StandardHeader::AccessControlAllowHeaders, black_box(b"X-Custom-Header,Upgrade-Insecure-Requests"))
+        .insert_standard_from_reqbytes(StandardHeader::AccessControlAllowOrigin, black_box(b"https://foo.bar.org"))
+        .insert_standard_from_reqbytes(StandardHeader::AccessControlAllowMethods, black_box(b"POST,GET,OPTIONS,DELETE"))
+        .insert_standard_from_reqbytes(StandardHeader::AccessControlMaxAge, black_box(b"86400"))
         .insert_standard_from_reqbytes(StandardHeader::Vary, black_box(b"Origin"))
         .insert_standard_from_reqbytes(StandardHeader::Server, black_box(b"ohkami"))
         .insert_standard_from_reqbytes(StandardHeader::Connection, black_box(b"Keep-Alive"))

--- a/benches/src/header_hashbrown.rs
+++ b/benches/src/header_hashbrown.rs
@@ -12,13 +12,45 @@ pub fn hash(key: &[u8]) -> u64 {
 }
 
 
-pub struct HeaderHashBrown(
-    table::HeaderHashBrownTable
-);
+pub struct HeaderHashBrown<const TRACK_SIZE: bool = true> {
+    table: table::HeaderHashBrownTable,
+    size:  usize,
+}
 
-impl HeaderHashBrown {
+enum HeaderValue {
+    Bytes(Vec<u8>),
+    Slice(Slice),
+    #[allow(unused)]
+    Usize(usize),
+} const _: () = {
+    impl HeaderValue {
+        #[inline]
+        fn as_bytes(&self) -> &[u8] {
+            match self {
+                Self::Bytes(v) => v.as_slice(),
+                Self::Slice(s) => unsafe {s.as_bytes()},
+                Self::Usize(_) => unimplemented!()
+            }
+        }
+    }
+
+    impl From<CowSlice> for HeaderValue {
+        #[inline]
+        fn from(value: CowSlice) -> Self {
+            match value {
+                CowSlice::Own(o) => Self::Bytes(o.into()),
+                CowSlice::Ref(r) => Self::Slice(r),
+            }
+        }
+    }
+};
+
+impl<const TRACK_SIZE: bool> HeaderHashBrown<TRACK_SIZE> {
     pub fn new() -> Self {
-        Self(table::HeaderHashBrownTable::new())
+        Self {
+            table: table::HeaderHashBrownTable::new(),
+            size:  "\r\n".len(),
+        }
     }
 
     #[inline]
@@ -26,11 +58,11 @@ impl HeaderHashBrown {
         standard: StandardHeader,
         value:    CowSlice,
     ) -> &mut Self {
-        let key   = Slice::from_bytes(standard.as_str().as_bytes());
-        unsafe {self.0.insert_known(
-            standard.hash(),
-            key, value
-        )}
+        if TRACK_SIZE {
+            self.size += standard.as_str().len() + ": ".len() + value.len() + "\r\n".len()
+        }
+        let key = Slice::from_bytes(standard.as_str().as_bytes());
+        unsafe {self.table.insert_known(standard.hash(), key, value.into())}
         self
     }
     #[inline]
@@ -38,8 +70,11 @@ impl HeaderHashBrown {
         key:   &'static str,
         value: CowSlice,
     ) -> &mut Self {
+        if TRACK_SIZE {
+            self.size += key.len() + ": ".len() + value.len() + "\r\n".len()
+        }
         let key   = Slice::from_bytes(key.as_bytes());
-        self.0.insert(key, value);
+        self.table.insert(key, value.into());
         self
     }
 
@@ -48,12 +83,12 @@ impl HeaderHashBrown {
         standard: StandardHeader,
         value:    &[u8],
     ) -> &mut Self {
+        if TRACK_SIZE {
+            self.size += standard.as_str().len() + ": ".len() + value.len() + "\r\n".len()
+        }
         let key   = Slice::from_bytes(standard.as_str().as_bytes());
         let value = CowSlice::Ref(Slice::from_bytes(value));
-        unsafe {self.0.insert_known(
-            standard.hash(),
-            key, value
-        )}
+        unsafe {self.table.insert_known(standard.hash(), key, value.into())}
         self
     }
     #[inline]
@@ -61,9 +96,12 @@ impl HeaderHashBrown {
         key:   &[u8],
         value: &[u8],
     ) -> &mut Self {
+        if TRACK_SIZE {
+            self.size += key.len() + ": ".len() + value.len() + "\r\n".len()
+        }
         let key   = Slice::from_bytes(key);
         let value = CowSlice::Ref(Slice::from_bytes(value));
-        self.0.insert(key, value);
+        self.table.insert(key, value.into());
         self
     }
 
@@ -71,11 +109,13 @@ impl HeaderHashBrown {
     pub fn remove_standard(&mut self,
         standard: StandardHeader,
     ) -> &mut Self {
-        let key = Slice::from_bytes(standard.as_str().as_bytes());
-        unsafe {self.0.remove_known(
-            standard.hash(),
-            &key
-        )}
+        let key   = Slice::from_bytes(standard.as_str().as_bytes());
+        let value = unsafe {self.table.remove_known(standard.hash(), &key)};
+        if TRACK_SIZE {
+            if let Some(v) = value {
+                self.size -= standard.as_str().len() + ": ".len() + v.as_bytes().len() + "\r\n".len()
+            }
+        }
         self
     }
     #[inline]
@@ -83,13 +123,27 @@ impl HeaderHashBrown {
         key: &'static str
     ) -> &mut Self {
         let key = Slice::from_bytes(key.as_bytes());
-        self.0.remove(&key);
+        let value = self.table.remove(&key);
+        if TRACK_SIZE {
+            if let Some(v) = value {
+                self.size -= unsafe {key.as_bytes()}.len() + ": ".len() + v.as_bytes().len() + "\r\n".len()
+            }
+        }
         self
     }
+}
 
+impl HeaderHashBrown<false> {
     #[inline]
     pub fn write_to(&self, buf: &mut Vec<u8>) {
-        self.0.write_to(buf)
+        self.table.write_to(buf)
+    }
+}
+impl HeaderHashBrown<true> {
+    #[inline]
+    pub fn write_to(&self, buf: &mut Vec<u8>) {
+        buf.reserve(self.size);
+        unsafe {self.table.write_unchecked_to(buf)}
     }
 }
 
@@ -135,105 +189,106 @@ macro_rules! StandardHeader {
         }
     };
 } StandardHeader! {
-    Accept = "Accept" as 16433268118574137039
-    AcceptEncoding = "Accept-Encoding" as 2625511035195335676
-    AcceptLanguage = "Accept-Language" as 4857106753043711123
-    AcceptRanges = "Accept-Ranges" as 12598308797832930634
-    AccessControlAllowCredentials = "Access-Control-Allow-Credentials" as 9116155820374356126
-    AccessControlAllowHeaders = "Access-Control-Allow-Headers" as 8814696385715034476
-    AccessControlAllowMethods = "Access-Control-Allow-Methods" as 5462557967219305584
-    AccessControlAllowOrigin = "Access-Control-Allow-Origin" as 5378217592900298305
-    AccessControlExposeHeaders = "Access-Control-Expose-Headers" as 13325522807785516598
-    AccessControlMaxAge = "Access-Control-Max-Age" as 4432901313932580618
-    AccessControlRequestHeaders = "Access-Control-Request-Headers" as 16301979022674213810
-    AccessControlRequestMethod = "Access-Control-Request-Method" as 11634788784195468787
-    Age = "Age" as 10870321372244433485
-    Allow = "Allow" as 3848169699148495437
-    AltSvc = "Alt-Svc" as 5918467845764560387
-    Authorization = "Authorization" as 12196702939659785452
-    CacheControl = "Cache-Control" as 11800019523689531337
-    CacheStatus = "Cache-Status" as 18085679534749337128
-    CDNCacheControl = "CDN-Cache-Control" as 4331749271142744016
-    Connection = "Connection" as 16783757005565428516
-    ContentDisposition = "Content-Disposition" as 15172909992608599841
-    ContentEcoding = "Content-Ecoding" as 16593443043870130009
-    ContentLanguage = "Content-Language" as 16735614920345560642
-    ContentLength = "Content-Length" as 14334207866575450264
-    ContentLocation = "Content-Location" as 3944620592910008386
-    ContentRange = "Content-Range" as 11588459248563791643
-    ContentSecurityPolicy = "Content-Security-Policy" as 5108162438765258431
-    ContentSecurityPolicyReportOnly = "Content-Security-Policy-Report-Only" as 1939240664108222842
-    ContentType = "Content-Type" as 3996025485011955786
-    Cookie = "Cookie" as 17962636191368536035
-    Date = "Date" as 17579805628842460308
-    ETag = "ETag" as 18254449783657381417
-    Expect = "Expect" as 9494374193384502225
-    Expires = "Expires" as 4291902732285004317
-    Forwarded = "Forwarded" as 7787083747984806917
-    From = "From" as 15020628208580050622
-    Host = "Host" as 438791524312454376
-    IfMatch = "If-Match" as 17728942688211657341
-    IfModifiedSince = "If-Modified-Since" as 6352457413450827350
-    IfNoneMatch = "If-None-Match" as 3333932262875561685
-    IfRange = "If-Range" as 2945925517127017085
-    IfUnmodifiedSince = "If-Unmodified-Since" as 7522477305903254470
-    Link = "Link" as 2777503232630997308
-    Location = "Location" as 16649487898551303996
-    MaxForwards = "Max-Forwards" as 10752408927369271123
-    Origin = "Origin" as 14882833577272632186
-    ProxyAuthenticate = "Proxy-Authenticate" as 1820963910701534218
-    ProxyAuthorization = "Proxy-Authorization" as 12714354196972183062
-    Range = "Range" as 10582771998975603868
-    Referer = "Referer" as 5839330224843872351
-    ReferrerPolicy = "Referrer-Policy" as 18395389122136826733
-    Refresh = "Refresh" as 15850643017965868815
-    RetryAfter = "Retry-After" as 13276509559803940695
-    SecWebSocketAccept = "Sec-WebSocket-Accept" as 10946272471545366737
-    SecWebSocketExtensions = "Sec-WebSocket-Extensions" as 17103059385744334201
-    SecWebSocketKey = "Sec-WebSocket-Key" as 13420602090516222027
-    SecWebSocketProtocol = "Sec-WebSocket-Protocol" as 11040576895242091634
-    SecWebSocketVersion = "Sec-WebSocket-Version" as 5330225619909672710
-    Server = "Server" as 11765940313756672059
-    SetCookie = "SetCookie" as 3623682265152868430
-    StrictTransportSecurity = "Strict-Transport-Security" as 13089560602798786294
-    TE = "TE" as 6712032112658457060
-    Trailer = "Trailer" as 15190164523930466561
-    TransferEncoding = "Transfer-Encoding" as 8612619927895477042
-    Upgrade = "Upgrade" as 3830257985504030272
-    UpgradeInsecureRequests = "Upgrade-Insecure-Requests" as 12060850129311366976
-    UserAgent = "User-Agent" as 3519543940131721058
-    Vary = "Vary" as 8817482389623931662
-    Via = "Via" as 7229469575117716336
-    XContentTypeOptions = "X-Content-Type-Options" as 17298563304118097688
-    XFrameOptions = "X-Frame-Options" as 4381497337076230406
+    Accept = "Accept" as 8956897560123365965//16433268118574137039
+    AcceptEncoding = "Accept-Encoding" as 9008826061000250594//2625511035195335676
+    AcceptLanguage = "Accept-Language" as 263798198000172577//4857106753043711123
+    AcceptRanges = "Accept-Ranges" as 18342038782328862764//12598308797832930634
+    AccessControlAllowCredentials = "Access-Control-Allow-Credentials" as 9569548883698504606//9116155820374356126
+    AccessControlAllowHeaders = "Access-Control-Allow-Headers" as 14084078790202211956//8814696385715034476
+    AccessControlAllowMethods = "Access-Control-Allow-Methods" as 5070491789143864837//5462557967219305584
+    AccessControlAllowOrigin = "Access-Control-Allow-Origin" as 10178641993106032301//5378217592900298305
+    AccessControlExposeHeaders = "Access-Control-Expose-Headers" as 16649258875025620622//13325522807785516598
+    AccessControlMaxAge = "Access-Control-Max-Age" as 6947267048838179798//4432901313932580618
+    AccessControlRequestHeaders = "Access-Control-Request-Headers" as 14077911138246316357//16301979022674213810
+    AccessControlRequestMethod = "Access-Control-Request-Method" as 1511226599830663409//11634788784195468787
+    Age = "Age" as 12164395943281393619//10870321372244433485
+    Allow = "Allow" as 101864317638997375//3848169699148495437
+    AltSvc = "Alt-Svc" as 163385565780702487//5918467845764560387
+    Authorization = "Authorization" as 17342828658748765377//12196702939659785452
+    CacheControl = "Cache-Control" as 12700798416643114791//11800019523689531337
+    CacheStatus = "Cache-Status" as 4830815728491215736//18085679534749337128
+    CDNCacheControl = "CDN-Cache-Control" as 15067968555331201001//4331749271142744016
+    Connection = "Connection" as 12632990663184834470//16783757005565428516
+    ContentDisposition = "Content-Disposition" as 1390085196203246353//15172909992608599841
+    ContentEcoding = "Content-Ecoding" as 1761535790260946701//16593443043870130009
+    ContentLanguage = "Content-Language" as 1401788212079168976//16735614920345560642
+    ContentLength = "Content-Length" as 14843332951706164276//14334207866575450264
+    ContentLocation = "Content-Location" as 6809348355172982736//3944620592910008386
+    ContentRange = "Content-Range" as 6591774876766068439//11588459248563791643
+    ContentSecurityPolicy = "Content-Security-Policy" as 7848988030993024328//5108162438765258431
+    ContentSecurityPolicyReportOnly = "Content-Security-Policy-Report-Only" as 8225512036531862485//1939240664108222842
+    ContentType = "Content-Type" as 1539870117023715624//3996025485011955786
+    Cookie = "Cookie" as 12510759127542743569//17962636191368536035
+    Date = "Date" as 2562613028085471028//17579805628842460308
+    ETag = "ETag" as 14205462794407424201//18254449783657381417
+    Expect = "Expect" as 3319114356378929571//9494374193384502225
+    Expires = "Expires" as 14717995381802874822//4291902732285004317
+    Forwarded = "Forwarded" as 12510709791974329387//7787083747984806917
+    From = "From" as 3435607823061342//15020628208580050622
+    Host = "Host" as 3868342997265016712//438791524312454376
+    IfMatch = "If-Match" as 758385572210193693//17728942688211657341
+    IfModifiedSince = "If-Modified-Since" as 15420386658409231737//6352457413450827350
+    IfNoneMatch = "If-None-Match" as 8766751325359657529//3333932262875561685
+    IfRange = "If-Range" as 4422112474835105053//2945925517127017085
+    IfUnmodifiedSince = "If-Unmodified-Since" as 14842325997600933810//7522477305903254470
+    Link = "Link" as 6207054705583559644//2777503232630997308
+    Location = "Location" as 1632295297794314716//16649487898551303996
+    MaxForwards = "Max-Forwards" as 7426081339672782312//10752408927369271123
+    Origin = "Origin" as 5691687282345579944//14882833577272632186
+    ProxyAuthenticate = "Proxy-Authenticate" as 14130340937869200619//1820963910701534218
+    ProxyAuthorization = "Proxy-Authorization" as 4007097940433767016//12714354196972183062
+    Range = "Range" as 13591622306488845170//10582771998975603868
+    Referer = "Referer" as 61951474100055896//5839330224843872351
+    ReferrerPolicy = "Referrer-Policy" as 1327666139445013389//18395389122136826733
+    Refresh = "Refresh" as 7953246256297787639//15850643017965868815
+    RetryAfter = "Retry-After" as 11304873063226856260//13276509559803940695
+    SecWebSocketAccept = "Sec-WebSocket-Accept" as 5952345478380611784//10946272471545366737
+    SecWebSocketExtensions = "Sec-WebSocket-Extensions" as 12765399274657545454//17103059385744334201
+    SecWebSocketKey = "Sec-WebSocket-Key" as 11097846330773677699//13420602090516222027
+    SecWebSocketProtocol = "Sec-WebSocket-Protocol" as 16408706031545691252//11040576895242091634
+    SecWebSocketVersion = "Sec-WebSocket-Version" as 11714057070643420239//5330225619909672710
+    Server = "Server" as 2419935139755271097//11765940313756672059
+    SetCookie = "Set-Cookie" as 5506158778252165240//3623682265152868430
+    StrictTransportSecurity = "Strict-Transport-Security" as 828070379554355266//13089560602798786294
+    TE = "TE" as 2663045123408499844//6712032112658457060
+    Trailer = "Trailer" as 7062438620934618372//15190164523930466561
+    TransferEncoding = "Transfer-Encoding" as 7495137910697819204//8612619927895477042
+    Upgrade = "Upgrade" as 11782373995271654455//3830257985504030272
+    UpgradeInsecureRequests = "Upgrade-Insecure-Requests" as 11536776535922301664//12060850129311366976
+    UserAgent = "User-Agent" as 9952940223324636988//3519543940131721058
+    Vary = "Vary" as 12247033862576493998//8817482389623931662
+    Via = "Via" as 1872335714014322414//7229469575117716336
+    WWWAuthenticate = "WWW-Authenticate" as 8830284111271749131
+    XContentTypeOptions = "X-Content-Type-Options" as 10317259392692853873//17298563304118097688
+    XFrameOptions = "X-Frame-Options" as 15858069221280842781//4381497337076230406
 }
 
 
 mod table {
     use std::{hash::Hasher, marker::PhantomData};
-    use ohkami_lib::{Slice, CowSlice};
+    use ohkami_lib::Slice;
     use hashbrown::raw::RawTable;
-    use super::{DefaultHasher, hash};
+    use super::{DefaultHasher, hash, HeaderValue};
 
     pub struct HeaderHashBrownTable<H: Hasher + Default = DefaultHasher> {
-        table:  RawTable<(Slice, CowSlice)>,
+        table:  RawTable<(Slice, HeaderValue)>,
         hasher: PhantomData<H>,
     }
 
     impl<H: Hasher + Default> HeaderHashBrownTable<H> {
         pub fn new() -> Self {
             Self {
-                table:  RawTable::with_capacity(32),
+                table:  RawTable::with_capacity(16),
                 hasher: PhantomData
             }
         }
 
         #[inline(always)]
-        fn hasher() -> impl Fn(&(Slice, CowSlice))->u64 {
+        const fn hasher() -> impl Fn(&(Slice, HeaderValue))->u64 {
             |(k, _)| hash(unsafe {k.as_bytes()})
         }
         #[inline(always)]
-        fn equivalent(key: &Slice) -> impl Fn(&(Slice, CowSlice))->bool + '_ {
+        const fn equivalent(key: &Slice) -> impl Fn(&(Slice, HeaderValue))->bool + '_ {
             move |(k, _)| k == key
         }
     }
@@ -252,12 +307,12 @@ mod table {
         // }
 
         #[inline]
-        pub fn insert(&mut self, key: Slice, value: CowSlice) {
+        pub fn insert(&mut self, key: Slice, value: HeaderValue) {
             unsafe { self.insert_known(hash(key.as_bytes()), key, value) }
         }
         /// SAFETY: `hash` BE the hash value of `key`
         #[inline]
-        pub unsafe fn insert_known(&mut self, hash: u64, key: Slice, value: CowSlice) {
+        pub unsafe fn insert_known(&mut self, hash: u64, key: Slice, value: HeaderValue) {
             match self.table.find_or_find_insert_slot(hash, Self::equivalent(&key), Self::hasher()) {
                 Ok(bucket) => unsafe { bucket.as_mut().1 = value }
                 Err(slot)  => unsafe { self.table.insert_in_slot(hash, slot, (key, value)); }
@@ -265,13 +320,16 @@ mod table {
         }
 
         #[inline]
-        pub fn remove(&mut self, key: &Slice) {
+        pub fn remove(&mut self, key: &Slice) -> Option<HeaderValue> {
             unsafe { self.remove_known(hash(key.as_bytes()), key) }
         }
         /// SAFETY: `hash` BE the hash value of `key`
         #[inline]
-        pub unsafe fn remove_known(&mut self, hash: u64, key: &Slice) {
-            self.table.remove_entry(hash, Self::equivalent(key));
+        pub unsafe fn remove_known(&mut self, hash: u64, key: &Slice) -> Option<HeaderValue> {
+            match self.table.remove_entry(hash, Self::equivalent(key)) {
+                Some((_, v)) => Some(v),
+                None => None
+            }
         }
 
         #[inline]
@@ -286,6 +344,42 @@ mod table {
                 }
             }
             buf.extend_from_slice(b"\r\n");
+        }
+
+        /// SAFETY: `buf` has enough remaining capacity
+        #[inline]
+        pub unsafe fn write_unchecked_to(&self, buf: &mut Vec<u8>) {
+            //let mut push_unchecked = |bytes: &[u8]| unsafe {
+            //    std::ptr::copy_nonoverlapping(
+            //        bytes.as_ptr(),
+            //        buf.as_mut_ptr().add(buf.len()),
+            //        bytes.len()
+            //    );
+            //    buf.set_len(
+            //        buf.len() + bytes.len()
+            //    );
+            //};
+            macro_rules! push_unchecked {
+                ($bytes:expr) => {
+                    let (buf_len, bytes_len) = (buf.len(), $bytes.len());
+                    std::ptr::copy_nonoverlapping(
+                        $bytes.as_ptr(),
+                        buf.as_mut_ptr().add(buf_len),
+                        bytes_len
+                    );
+                    buf.set_len(
+                        buf_len + bytes_len
+                    );
+                };
+            }
+            for bucket in self.table.iter() {
+                let (k, v) = bucket.as_ref();
+                push_unchecked!(k.as_bytes());
+                push_unchecked!(b": ");
+                push_unchecked!(v.as_bytes());
+                push_unchecked!(b"\r\n");
+            }
+            push_unchecked!(b"\r\n");
         }
     }
 }

--- a/benches/src/response_headers/fxmap.rs
+++ b/benches/src/response_headers/fxmap.rs
@@ -55,7 +55,7 @@ impl FxMap {
 
         buf.reserve(self.size);
 
-        for (k, v) in &self.map {
+        for (k, v) in self.map.iter() {
             push!(buf <- k.as_bytes());
             push!(buf <- b": ");
             push!(buf <- v.as_bytes());

--- a/ohkami/src/response/headers.rs
+++ b/ohkami/src/response/headers.rs
@@ -467,7 +467,7 @@ impl Headers {
 
     #[cfg(feature="DEBUG")]
     pub fn _write_to(&self, buf: &mut Vec<u8>) {
-        buf.reserve_exact(self.size);
+        buf.reserve(self.size);
         unsafe {self.write_unchecked_to(buf)}
     }
 }


### PR DESCRIPTION
Fix `response::Headers::_write_to`, for-benchmark wrapper of `write_unchecked_to`, to reserve `buf` capacity by `Vec::reserve` instead of `Vec::reserve_exact`. Benchmark examples:

before
```txt
test write_02_http_crate       ... bench:         118.08 ns/iter (+/- 21.05)
test write_03_fxmap            ... bench:          94.93 ns/iter (+/- 5.96)
test write_03_header_hashbrown ... bench:          94.41 ns/iter (+/- 7.58)
test write_03_ohkami           ... bench:         153.62 ns/iter (+/- 12.09)
test write_04_headermap        ... bench:         105.58 ns/iter (+/- 18.24)
```

after
```txt
test write_02_http_crate       ... bench:         116.04 ns/iter (+/- 2.89)
test write_03_fxmap            ... bench:         100.20 ns/iter (+/- 4.12)
test write_03_header_hashbrown ... bench:          99.91 ns/iter (+/- 2.76)
test write_03_ohkami           ... bench:         117.10 ns/iter (+/- 3.13)
test write_04_headermap        ... bench:         124.93 ns/iter (+/- 3.37)
```

---

and

- Activate `"inline-more"` feature of `hashbrown`
- Introduce size tracking in `header_hashbrown`
- Fix input to the same & larger

for more fairness