### PR TITLE
feat: OHKAMI_WEBSOCKET_TIMEOUT

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ async fn main() {
 
 ### WebSocket with `"ws"` feature
 
-Currently, WebSocket on `rt_worker` is not supported.
+Currently, WebSocket on `rt_worker` is *NOT* supported.
 
 ```rust,no_run
 use ohkami::prelude::*;

--- a/ohkami/src/lib.rs
+++ b/ohkami/src/lib.rs
@@ -78,6 +78,16 @@ mod env {
                 .unwrap_or(42)
         })
     }
+
+    #[cfg(all(feature="ws", any(feature="rt_tokio",feature="rt_async-std")))]
+    pub(crate) fn OHKAMI_WEBSOCKET_TIMEOUT() -> u64 {
+        static OHKAMI_WEBSOCKET_TIMEOUT: OnceLock<u64> = OnceLock::new();
+        *OHKAMI_WEBSOCKET_TIMEOUT.get_or_init(|| {
+            std::env::var("OHKAMI_WEBSOCKET_TIMEOUT").ok()
+                .map(|v| v.parse().ok()).flatten()
+                .unwrap_or(1 * 60 * 60)
+        })
+    }
 }
 
 

--- a/ohkami/src/lib.rs
+++ b/ohkami/src/lib.rs
@@ -64,33 +64,6 @@ mod __rt__ {
 }
 
 
-#[allow(non_snake_case)]
-mod env {
-    #[allow(unused)]
-    use std::sync::OnceLock;
-
-    #[cfg(any(feature="rt_tokio",feature="rt_async-std"))]
-    pub(crate) fn OHKAMI_KEEPALIVE_TIMEOUT() -> u64 {
-        static OHKAMI_KEEPALIVE_TIMEOUT: OnceLock<u64> = OnceLock::new();
-        *OHKAMI_KEEPALIVE_TIMEOUT.get_or_init(|| {
-            std::env::var("OHKAMI_KEEPALIVE_TIMEOUT").ok()
-                .map(|v| v.parse().ok()).flatten()
-                .unwrap_or(42)
-        })
-    }
-
-    #[cfg(all(feature="ws", any(feature="rt_tokio",feature="rt_async-std")))]
-    pub(crate) fn OHKAMI_WEBSOCKET_TIMEOUT() -> u64 {
-        static OHKAMI_WEBSOCKET_TIMEOUT: OnceLock<u64> = OnceLock::new();
-        *OHKAMI_WEBSOCKET_TIMEOUT.get_or_init(|| {
-            std::env::var("OHKAMI_WEBSOCKET_TIMEOUT").ok()
-                .map(|v| v.parse().ok()).flatten()
-                .unwrap_or(1 * 60 * 60)
-        })
-    }
-}
-
-
 mod request;
 pub use request::{Request, Method, FromRequest, FromParam, Memory};
 pub use ::ohkami_macros::FromRequest;

--- a/ohkami/src/session/mod.rs
+++ b/ohkami/src/session/mod.rs
@@ -9,6 +9,32 @@ use crate::ohkami::router::RadixRouter;
 use crate::{Request, Response};
 
 
+mod env {
+    #![allow(unused, non_snake_case)]
+
+    use std::sync::OnceLock;
+
+    #[cfg(any(feature="rt_tokio",feature="rt_async-std"))]
+    pub(crate) fn OHKAMI_KEEPALIVE_TIMEOUT() -> u64 {
+        static OHKAMI_KEEPALIVE_TIMEOUT: OnceLock<u64> = OnceLock::new();
+        *OHKAMI_KEEPALIVE_TIMEOUT.get_or_init(|| {
+            std::env::var("OHKAMI_KEEPALIVE_TIMEOUT").ok()
+                .map(|v| v.parse().ok()).flatten()
+                .unwrap_or(42)
+        })
+    }
+
+    #[cfg(all(feature="ws", any(feature="rt_tokio",feature="rt_async-std")))]
+    pub(crate) fn OHKAMI_WEBSOCKET_TIMEOUT() -> u64 {
+        static OHKAMI_WEBSOCKET_TIMEOUT: OnceLock<u64> = OnceLock::new();
+        *OHKAMI_WEBSOCKET_TIMEOUT.get_or_init(|| {
+            std::env::var("OHKAMI_WEBSOCKET_TIMEOUT").ok()
+                .map(|v| v.parse().ok()).flatten()
+                .unwrap_or(1 * 60 * 60)
+        })
+    }
+}
+
 pub(crate) struct Session {
     router:     Arc<RadixRouter>,
     connection: TcpStream,
@@ -37,7 +63,7 @@ impl Session {
             crate::Response::InternalServerError()
         }
 
-        match timeout_in(Duration::from_secs(crate::env::OHKAMI_KEEPALIVE_TIMEOUT()), async {
+        match timeout_in(Duration::from_secs(env::OHKAMI_KEEPALIVE_TIMEOUT()), async {
             loop {
                 let mut req = Request::init();
                 let mut req = unsafe {Pin::new_unchecked(&mut req)};
@@ -65,16 +91,30 @@ impl Session {
 
             #[cfg(all(feature="ws", any(feature="rt_tokio",feature="rt_async-std")))]
             Some(Upgrade::WebSocket((config, handler))) => {
+                // SAFETY: `&mut self.connection` is valid while `handle`
+                let ws = unsafe {crate::ws::Session::new(&mut self.connection, config)};
+
                 #[cfg(feature="DEBUG")] {
                     println!("WebSocket session started");
                 }
 
-                // SAFETY: `&mut self.connection` is valid while `handle`
-                let ws = unsafe {crate::ws::Session::new(&mut self.connection, config)};
-
-                timeout_in(Duration::from_secs(crate::env::OHKAMI_WEBSOCKET_TIMEOUT()),
+                if timeout_in(Duration::from_secs(env::OHKAMI_WEBSOCKET_TIMEOUT()),
                     handler(ws)
-                ).await;
+                ).await.is_none() {
+                    let closer = &mut self.connection;
+                    (|| async move {
+                        use crate::ws::{Session, Config, Message, CloseFrame, CloseCode};
+
+                        (unsafe {Session::new(closer, Config::default())}).send(
+                            Message::Close(Some(CloseFrame {
+                                code:   CloseCode::Library(4000),
+                                reason: Some("OHKAMI_WEBSOCKET_TIMEOUT".into())
+                            }))
+                        ).await.expect("Failed to send close message");
+
+                        println!("WebSocket session aborted by `OHKAMI_WEBSOCKET_TIMEOUT` (default to 1 hour, and can be set via environment variable)")
+                    })().await
+                }
 
                 #[cfg(feature="DEBUG")] {
                     println!("WebSocket session finished");

--- a/ohkami/src/ws/frame.rs
+++ b/ohkami/src/ws/frame.rs
@@ -53,8 +53,8 @@ pub enum CloseCode {
     pub(super) fn into_bytes(self) -> [u8; 2] {
         u16::to_be_bytes(match self {
             Self::Normal => 1000, Self::Away      => 1001, Self::Protocol => 1002, Self::Unsupported => 1003,
-            Self::Status => 1005, Self::Abnormal  => 1006, Self::Invalid  => 1007,  Self::Policy => 1008,
-            Self::Size   => 1009, Self::Extension => 1010, Self::Error    => 1011,    Self::Restart => 1012,
+            Self::Status => 1005, Self::Abnormal  => 1006, Self::Invalid  => 1007, Self::Policy      => 1008,
+            Self::Size   => 1009, Self::Extension => 1010, Self::Error    => 1011, Self::Restart     => 1012,
             Self::Again  => 1013, Self::Tls       => 1015,
             Self::Reserved => 1016, Self::Iana(code) | Self::Library(code) | Self::Bad(code) => code,
         })

--- a/ohkami/src/ws/mod.rs
+++ b/ohkami/src/ws/mod.rs
@@ -4,7 +4,8 @@ mod session;
 mod message;
 mod frame;
 
-pub use message::Message;
+pub use message::{Message, CloseFrame};
+pub use frame::{CloseCode};
 pub(crate) use session::WebSocket as Session;
 
 use std::{future::Future, pin::Pin};

--- a/ohkami/src/ws/session.rs
+++ b/ohkami/src/ws/session.rs
@@ -3,7 +3,7 @@ use super::{Message, Config};
 use crate::__rt__::{AsyncWriter, AsyncReader};
 
 
-/* Used only in `ohkami::websocket::WebSocket::{new, with}` and NOT `use`able by user */
+/* Used only in `ohkami::ws::WebSocketContext::{connect, connect_with}` and NOT `use`able by user */
 
 /// WebSocket connection
 pub struct WebSocket<Conn: AsyncWriter + AsyncReader + Unpin + Send> {


### PR DESCRIPTION
Add `crate::env::OHKAMI_WEBSOCKET_TIMEOUT` with default 1 hour for resource protection