### PR TITLE
fix: always send close frame when closing websocket connection

### DIFF
--- a/examples/websocket/src/main.rs
+++ b/examples/websocket/src/main.rs
@@ -27,6 +27,12 @@ async fn echo_text(c: WebSocketContext<'_>) -> WebSocket {
                     break
                 };
                 println!("recv: `{text}`");
+
+                if text == "close" {
+                    println!("got close text, closing...");
+                    break
+                }
+
                 ws.send(Message::Text(text)).await.expect("Failed to send text");
             }
         }

--- a/examples/websocket/template/index.html
+++ b/examples/websocket/template/index.html
@@ -22,6 +22,9 @@
             console.log(e);
             ws.send("test");
         });
+        ws.addEventListener("close", (e) => {
+            console.log("close: ", e);
+        });
 
         const text_input  = document.getElementById("text-input");
         const send_button = document.getElementById("send-button");

--- a/ohkami/src/lib.rs
+++ b/ohkami/src/lib.rs
@@ -123,6 +123,16 @@ pub mod utils {
         };
     }
 
+    #[doc(hidden)]
+    #[macro_export]
+    macro_rules! DEBUG {
+        ( $( $t:tt )* ) => {
+            #[cfg(feature="DEBUG")] {
+                println!( $( $t )* );
+            }
+        };
+    }
+
     pub use crate::fangs::util::FangAction;
 
     #[cfg(feature="sse")]

--- a/ohkami/src/ws/session.rs
+++ b/ohkami/src/ws/session.rs
@@ -19,10 +19,6 @@ const _: () = {
     impl<Conn: AsyncWriter + AsyncReader + Unpin + Send> WebSocket<Conn> {
         /// SAFETY: `conn` is valid while entire the conversation
         pub(crate) unsafe fn new(conn: &mut Conn, config: Config) -> Self {
-            #[cfg(feature="DEBUG")] {
-                println!("`websocket::session::WebSocket::new` called")
-            }
-
             Self { conn, config, n_buffered:0 }
         }
     }


### PR DESCRIPTION
Before sended one only when aborting by `OHKAMI_WEBSOCKET_TIMEOUT`, otherwise just shutdowned, which is not a desired behavior. 
This fixes to send close frame in any case.