### PR TITLE
feat: `q.add` in `stream::queue`

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ async fn sse() -> DataStream<String> {
     DataStream::from_stream(stream::queue(|mut q| async move {
         for i in 1..=5 {
             sleep(Duration::from_secs(1)).await;
-            q.push(Ok(format!("Hi, I'm message #{i} !")))
+            q.add(format!("Hi, I'm message #{i} !"))
         }
     }))
 }

--- a/ohkami_lib/src/stream.rs
+++ b/ohkami_lib/src/stream.rs
@@ -341,5 +341,13 @@ mod stream {
                 unsafe {self.0.as_mut()}.push_back(value)
             }
         }
+
+        impl<T, E> Queue<Result<T, E>> {
+            /// `.push(Ok(value))`
+            #[inline(always)]
+            pub fn add(&mut self, value: T) {
+                unsafe {self.0.as_mut()}.push_back(Ok(value))
+            }
+        }
     };
 }


### PR DESCRIPTION
`q.add(value)`: shorthand for `q.push(Ok(value))`, which was almost a boilerplate in use of `stream::queue`