### PR TITLE
feat: always specialize `index.html` in `.Dir`

### DIFF
--- a/examples/static_files/src/main.rs
+++ b/examples/static_files/src/main.rs
@@ -3,6 +3,6 @@ use ohkami::prelude::*;
 #[tokio::main]
 async fn main() {
     Ohkami::new((
-        "/static-files".Dir("./public").omit_extensions(["html"]),
+        "/".Dir("./public"),//.omit_extensions(["html"]),
     )).howl("localhost:3000").await
 }


### PR DESCRIPTION
specialize access to `Dir/path/index.html` to

normal :

- [x] `GET /path/`
- [x] `GET /path/index.html`

omit `.html` :

- [x] `GET /path/`
- [ ] `GET /path/index.html`
- [ ] `GET /path/index`