### PR TITLE
fix ws Handler: `Fn` -> `FnOnce` & routing bug

### DIFF
--- a/examples/websocket/src/main.rs
+++ b/examples/websocket/src/main.rs
@@ -14,6 +14,7 @@ impl FangAction for Logger {
     }
 }
 
+
 async fn echo_text(c: WebSocketContext<'_>) -> WebSocket {
     c.connect(|mut ws| async move {
         #[cfg(feature="DEBUG")] {
@@ -44,10 +45,35 @@ async fn echo_text(c: WebSocketContext<'_>) -> WebSocket {
     })
 }
 
+
+async fn echo_text_2(
+    name: String,
+    ctx:  WebSocketContext<'_>
+) -> EchoTextSession<'_> {
+    EchoTextSession { name, ctx }
+}
+
+struct EchoTextSession<'ws> {
+    name: String,
+    ctx:  WebSocketContext<'ws>,
+}
+impl IntoResponse for EchoTextSession<'_> {
+    fn into_response(self) -> Response {
+        self.ctx.connect(|mut ws| async move {
+                ws.send(Message::Text(format!("Hello, {}!", self.name))).await.expect("failed to send");
+        
+                while let Ok(Some(Message::Text(text))) = ws.recv().await {
+                    ws.send(Message::Text(text)).await.expect("failed to send text");
+                }
+        }).into_response()
+    }
+}
+
 #[tokio::main]
 async fn main() {
     Ohkami::with(Logger, (
         "/".Dir("./template").omit_extensions([".html"]),
         "/echo".GET(echo_text),
+        "/echo2/:name".GET(echo_text_2)
     )).howl("localhost:3030").await
 }

--- a/examples/websocket/template/index.html
+++ b/examples/websocket/template/index.html
@@ -14,7 +14,7 @@
     </div>
 
     <script>
-        const ws = new WebSocket("ws://localhost:3030/echo");
+        const ws = new WebSocket("ws://localhost:3030/echo2/ohkami");
         ws.addEventListener("message", (e) => {
             console.log("ws got message: ", e.data);
         });

--- a/ohkami/src/ohkami/router/radix.rs
+++ b/ohkami/src/ohkami/router/radix.rs
@@ -26,19 +26,7 @@ pub(super) struct Node {
             struct PatternsMarker(&'static [Pattern]);
             impl std::fmt::Debug for PatternsMarker {
                 fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                    f.write_char('[')?;
-                    'items: {
-                        let mut n = self.0.len();
-                        loop {
-                            if n == 0 {break 'items}
-                            f.write_str(&format!("{:?}", self.0[n-1]))?;
-                            n -= 1;
-                            if n > 1 {f.write_char(' ')?;}
-                        }
-                    }
-                    f.write_char(']')?;
-
-                    Ok(())
+                    f.debug_list().entries(self.0).finish()
                 }
             }
 

--- a/ohkami/src/ohkami/router/trie.rs
+++ b/ohkami/src/ohkami/router/trie.rs
@@ -373,8 +373,9 @@ impl Node {
         }
 
         children.sort_unstable_by(|a, b| match (a.pattern.as_ref().unwrap(), b.pattern.as_ref().unwrap()) {
-            (Pattern::Static(_), Pattern::Param) => std::cmp::Ordering::Less,
-            (Pattern::Param, Pattern::Static(_)) => std::cmp::Ordering::Greater,
+            (Pattern::Static(_), Pattern::Param)     => std::cmp::Ordering::Less,
+            (Pattern::Param, Pattern::Static(_))     => std::cmp::Ordering::Greater,
+            (Pattern::Static(a), Pattern::Static(b)) => <[u8]>::cmp(&a, &b).reverse(),
             _ => std::cmp::Ordering::Equal
         });
 

--- a/ohkami/src/ws/mod.rs
+++ b/ohkami/src/ws/mod.rs
@@ -53,14 +53,14 @@ pub struct WebSocketContext<'req> {
 
     impl<'ctx> WebSocketContext<'ctx> {
         pub fn connect<Fut: Future<Output = ()> + Send + 'static>(self,
-            handler: impl Fn(Session<__rt__::TcpStream>) -> Fut + Send + Sync + 'static
+            handler: impl FnOnce(Session<__rt__::TcpStream>) -> Fut + Send + Sync + 'static
         ) -> WebSocket {
             self.connect_with(Config::default(), handler)
         }
 
         pub fn connect_with<Fut: Future<Output = ()> + Send + 'static>(self,
             config:  Config,
-            handler: impl Fn(Session<__rt__::TcpStream>) -> Fut + Send + Sync + 'static
+            handler: impl FnOnce(Session<__rt__::TcpStream>) -> Fut + Send + Sync + 'static
         ) -> WebSocket {
             WebSocket {
                 config,
@@ -75,7 +75,7 @@ pub struct WebSocketContext<'req> {
 };
 
 pub(crate) type Handler = Box<dyn
-    Fn(Session<__rt__::TcpStream>) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>
+    FnOnce(Session<__rt__::TcpStream>) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>
     + Send + Sync
 >;
 


### PR DESCRIPTION
- fix routing bug and add test:

Before `GET /abcd` to

```rust
Ohkami::new((
    "/abc".GET(|| async {"This is abc"}),
    "/abcd".GET(|| async {"This is abcd"}),
))
```

results to NotFound because this matches to `/abc`. So This PR fixes to sort this pattern of routing to

```rust
Ohkami::new((
    "/abcd".GET(|| async {"This is abcd"}),
    "/abc".GET(|| async {"This is abc"}),
))
```

in ahead.

---

- fix ws handler `Fn` to `FnOnce`

Before the handler was `Fn`. So, user-defined WebSocket response **holding some data** like

```rust
struct MyWebSocket<'ws> {
    ctx: WebSocketContext<'ws>,
    user_name: String, // <-- data
}

async fn handler(
    ctx: WebSocketContext<'_>,
    user_name: String
) -> MyWebSocket<'_> {
    MyWebSocket { ctx, user_name }
}
```

**must** implement `IntoResponse` as

```rust
impl IntoResponse for MyWebSocket<'_> {
    fn into_response(self) -> Response {
        self.ctx.connect(move |mut ws| { // <-- first move into closure
            let name = self.name.clone(); // <-- clone data
            async move {  // <-- second, move into async block
                /* 〜 */
            }
        })
    }
}
```

every time... :(

But, actually a WebSocket handler is *NOT* required to repeatedly-callable or implemeting `Fn`. It's enough to implement `FnOnce` and this PR does so. This enables simple `IntoResponse` :

```rust
impl IntoResponse for EchoTextSession<'_> {
    fn into_response(self) -> Response {
        self.ctx.connect(|mut ws| async move {
            /* 〜 */
        }).into_response()
    }
}
```