### PR TITLE
Explicitly not-support using `ws::Connection` in detouched tasks

### DIFF
--- a/examples/websocket/template/index.html
+++ b/examples/websocket/template/index.html
@@ -43,6 +43,11 @@
             <input id="echo3-text-input"/>
             <button id="echo3-send-button"></button>
         </div>
+        
+        <div class="echo-text">
+            <input id="echo4-text-input"/>
+            <button id="echo4-send-button"></button>
+        </div>
     </main>
 
     <script>
@@ -90,6 +95,7 @@
         connect_input_and_button_to("ws://localhost:3030/echo1",        "echo1-text-input", "echo1-send-button");
         connect_input_and_button_to("ws://localhost:3030/echo2/ohkami", "echo2-text-input", "echo2-send-button");
         connect_input_and_button_to("ws://localhost:3030/echo3/ohkami", "echo3-text-input", "echo3-send-button");
+        connect_input_and_button_to("ws://localhost:3030/echo4/ohkami", "echo4-text-input", "echo4-send-button");
     </script>
 </body>
 </html>

--- a/ohkami/src/ws/connection.rs
+++ b/ohkami/src/ws/connection.rs
@@ -59,7 +59,8 @@ const _: () = {
                 | Maybe you spawned tasks using ws::Connection or split halves of it |\n\
                 | and NOT join/await the tasks?                                      |\n\
                 | This is NOT supported because it may cause resource leak           |\n\
-                | due to an infinite loop in the websocket handler.                  |\n\
+                | due to something like an infinite loop or a dead lock in the       |\n\
+                | websocket handler.                                                 |\n\
                 | If you're doing it, please join/await the tasks in the handler!    |\n\
                 ---------------------------------------------------------------------|\n\
             ")

--- a/ohkami/src/ws/connection.rs
+++ b/ohkami/src/ws/connection.rs
@@ -1,25 +1,68 @@
 use std::io::Error;
+use std::{sync::Arc, cell::UnsafeCell};
 use super::{Message, Config};
 use crate::__rt__::{AsyncWriter, AsyncReader};
 
 
-/* Used only in `ohkami::ws::WebSocketContext::{connect, connect_with}` and NOT `use`able by user */
-
 /// WebSocket connection
 pub struct Connection<Conn: AsyncWriter + AsyncReader + Unpin + Send> {
-    conn:       *mut Conn,
+    conn:       Arc<UnsafeCell<(State, Conn)>>,
     config:     Config,
     n_buffered: usize,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+enum State { Alive, Closed }
+
 const _: () = {
     unsafe impl<Conn: AsyncWriter + AsyncReader + Unpin + Send> Send for Connection<Conn> {}
     unsafe impl<Conn: AsyncWriter + AsyncReader + Unpin + Send> Sync for Connection<Conn> {}
+
+    impl<Conn: AsyncWriter + AsyncReader + Unpin + Send> std::fmt::Debug for Connection<Conn> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let (state, underlying) = unsafe {&*self.conn.get()};
+            f.debug_struct("Connection")
+                .field("underlying", &(underlying as *const _))
+                .field("state", state)
+                .field("config", &self.config)
+                .field("n_buffered", &self.n_buffered)
+                .finish()
+        }
+    }
+    impl<Conn: AsyncWriter + AsyncReader + Unpin + Send> Clone for Connection<Conn> {
+        fn clone(&self) -> Self {
+            Connection {
+                conn:       Arc::clone(&self.conn),
+                config:     self.config.clone(),
+                n_buffered: self.n_buffered
+            }
+        }
+    }
     
     impl<Conn: AsyncWriter + AsyncReader + Unpin + Send> Connection<Conn> {
-        /// SAFETY: `conn` is valid while entire the conversation
-        pub(crate) unsafe fn new(conn: &mut Conn, config: Config) -> Self {
+        pub(crate) fn new(conn: Conn, config: Config) -> Self {
+            let conn = Arc::new(UnsafeCell::new((State::Alive, conn)));
             Self { conn, config, n_buffered:0 }
+        }
+
+        pub(crate) fn is_closed(&self) -> bool {
+            unsafe {&*self.conn.get()}.0 == State::Closed
+        }
+    }
+
+    impl State {
+        fn assert_alive(&self) {
+            (*self == State::Alive).then_some(()).expect("\n\
+                |---------------------------------------------------------------------\n\
+                | ws::Connection is already closed                                   |\n\
+                |                                                                    |\n\
+                | Maybe you spawned tasks using ws::Connection or split halves of it |\n\
+                | and NOT join/await the tasks?                                      |\n\
+                | This is NOT supported because it may cause resource leak           |\n\
+                | due to an infinite loop in the websocket handler.                  |\n\
+                | If you're doing it, please join/await the tasks in the handler!    |\n\
+                ---------------------------------------------------------------------|\n\
+            ")
         }
     }
 };
@@ -27,38 +70,38 @@ const _: () = {
 // =============================================================================
 pub(super) async fn send(
     message:    Message,
-    stream:     &mut (impl AsyncWriter + Unpin),
+    conn:       &mut (impl AsyncWriter + Unpin),
     config:     &Config,
     n_buffered: &mut usize,
 ) -> Result<(), Error> {
-    message.write(stream, config).await?;
-    flush(stream, n_buffered).await?;
+    message.write(conn, config).await?;
+    flush(conn, n_buffered).await?;
     Ok(())
 }
 pub(super) async fn write(
     message:    Message,
-    stream:     &mut (impl AsyncWriter + Unpin),
+    conn:       &mut (impl AsyncWriter + Unpin),
     config:     &Config,
     n_buffered: &mut usize,
 ) -> Result<usize, Error> {
-    let n = message.write(stream, config).await?;
+    let n = message.write(conn, config).await?;
 
     *n_buffered += n;
     if *n_buffered > config.write_buffer_size {
         if *n_buffered > config.max_write_buffer_size {
             panic!("Buffered messages is larger than `max_write_buffer_size`");
         } else {
-            flush(stream, n_buffered).await?
+            flush(conn, n_buffered).await?
         }
     }
 
     Ok(n)
 }
 pub(super) async fn flush(
-    stream:     &mut (impl AsyncWriter + Unpin),
+    conn:       &mut (impl AsyncWriter + Unpin),
     n_buffered: &mut usize,
 ) -> Result<(), Error> {
-    stream.flush().await
+    conn.flush().await
         .map(|_| *n_buffered = 0)
 }
 // =============================================================================
@@ -68,7 +111,10 @@ impl<Conn: AsyncWriter + AsyncReader + Unpin + Send> Connection<Conn> {
     /// 
     /// *note* : this automatically responds to a ping message
     pub async fn recv(&mut self) -> Result<Option<Message>, Error> {
-        let message = Message::read_from(unsafe {&mut *self.conn}, &self.config).await?;
+        let (state, conn) = unsafe {&mut *self.conn.get()};
+        state.assert_alive();
+
+        let message = Message::read_from(conn, &self.config).await?;
         if let Some(Message::Ping(payload)) = &message {
             self.send(Message::Pong(payload.clone())).await?;
         }
@@ -76,15 +122,26 @@ impl<Conn: AsyncWriter + AsyncReader + Unpin + Send> Connection<Conn> {
     }
 
     pub async fn send(&mut self, message: Message) -> Result<(), Error> {
-        send(message, unsafe {&mut *self.conn}, &self.config, &mut self.n_buffered).await
+        let (state, conn) = unsafe {&mut *self.conn.get()};
+        state.assert_alive();
+
+        if matches!(message, Message::Close(_)) {*state = State::Closed}
+        send(message, conn, &self.config, &mut self.n_buffered).await
     }
 
     pub async fn write(&mut self, message: Message) -> Result<usize, Error> {
-        write(message, unsafe {&mut *self.conn}, &self.config, &mut self.n_buffered).await
+        let (state, conn) = unsafe {&mut *self.conn.get()};
+        state.assert_alive();
+
+        if matches!(message, Message::Close(_)) {*state = State::Closed}
+        write(message, conn, &self.config, &mut self.n_buffered).await
     }
 
     pub async fn flush(&mut self) -> Result<(), Error> {
-        flush(unsafe {&mut *self.conn}, &mut self.n_buffered).await
+        let (state, conn) = unsafe {&mut *self.conn.get()};
+        state.assert_alive();
+
+        flush(conn, &mut self.n_buffered).await
     }
 }
 
@@ -97,7 +154,10 @@ pub mod split {
 
     impl Connection<TcpStream> {
         pub fn split(self) -> (ReadHalf, WriteHalf) {
-            let (read, write) = unsafe {self.conn.as_mut().unwrap()}.split();
+            let (state, conn) = unsafe {&mut *self.conn.get()};
+            state.assert_alive();
+    
+            let (read, write) = conn.split();
             (
                 ReadHalf  { conn: read,  config: self.config.clone() },
                 WriteHalf { conn: write, config: self.config, n_buffered: self.n_buffered }

--- a/ohkami/src/ws/message.rs
+++ b/ohkami/src/ws/message.rs
@@ -76,9 +76,7 @@ impl Message {
     ) -> Result<usize, Error> {
         self.into_frame().write_unmasked(stream, config).await
     }
-}
-
-impl Message {
+    
     /// Read a `Message` from a WebSocket connection.
     pub(crate) async fn read_from(
         stream: &mut (impl AsyncReader + Unpin),

--- a/ohkami/src/ws/mod.rs
+++ b/ohkami/src/ws/mod.rs
@@ -117,7 +117,7 @@ pub struct WebSocket {
 /// ## Note
 /// 
 /// - Currently, subprotocols via `Sec-WebSocket-Protocol` is not supported
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Config {
     pub write_buffer_size:      usize,
     pub max_write_buffer_size:  usize,


### PR DESCRIPTION
Before `ws::Connection` used just `*mut Conn` in its internal, but this easily cause **_undefined behavior_** if user spawns detouched tasks ( tasks that was spawned but not joined/awaited ) in WebSocket handler.
In addition, easy supporting such use, just avoiding UB, is not enough to avoid a **_resource leak_** due to something like infinite loop or dead lock in a WebSocket handler ( WebSocket handler without detouched tasks is protected by automatically timeout by `OHKAMI_WEBSOCKET_TIMEOUT` ).

This PR:

- introduce `State { Alive, Closed }` in `ws::Connection` and make it `Closed` when sending `Message::Close`
- use `Arc` instead of a raw pointer

which enables to **_validate the state_** to be `Alive` before `{recv, send, write, flush, split}` and make accessing to `ws::Connection` in a detouched tasks itself be never UB because the underlying connection is in `Arc` of count 1 at that time.
If the state is `Closed` when user is about to `{recv, send, write, flush, split}`, it's clear that it was called in a detouched task and Ohkami can cause a safe panic, instead of UB, with an instruction message.