### PR TITLE
refactor: graceful shutdown impl

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["kanarus <kanarus786@gmail.com>"]
 
 [features]
-DEBUG = ["ohkami/DEBUG"]
+DEBUG = ["ohkami/DEBUG", "ohkami/graceful"]
 # `--no-default-features` when running `bin/`
 default = ["DEBUG"]
 


### PR DESCRIPTION
- drop listener just when `ctrl_c_tx.closed()` in order to deny, not only not-handle, further connections
- more readable code