### PR TITLE
chore: not combine `cfg`s between outer and inner an anon-const to avoid error message on editor

### DIFF
--- a/ohkami/src/lib.rs
+++ b/ohkami/src/lib.rs
@@ -35,13 +35,12 @@
     Please wait for future development for other runtimes...
 "}
 
-#[cfg(not(feature="DEBUG"))] const _: () = {
-    #[cfg(all(feature="rt_worker", not(target_arch="wasm32")))]
-    compile_error! {"
-        `rt_worker` must be activated on `wasm32` target!
-        (We recommend to touch `.cargo/config.toml`: `[build] target = \"wasm32-unknown-unknown\"`)
-    "}
-};
+#[cfg(not(feature="DEBUG"))]
+#[cfg(all(feature="rt_worker", not(target_arch="wasm32")))]
+compile_error! {"
+    `rt_worker` must be activated on `wasm32` target!
+    (We recommend to touch `.cargo/config.toml`: `[build] target = \"wasm32-unknown-unknown\"`)
+"}
 
 
 #[allow(unused)]


### PR DESCRIPTION
`compile_error!` under a `cfg` in an anon-const under another `cfg` :

```rust
#[cfg(not(feature="DEBUG"))] const _: () = {
    #[cfg(all(feature="rt_worker", not(target_arch="wasm32")))]
    compile_error! {"
        `rt_worker` must be activated on `wasm32` target!
        (We recommend to touch `.cargo/config.toml`: `[build] target = \"wasm32-unknown-unknown\"`)
    "}
};
```

is unexpectedly displayed as an error on ( at least ) VSCode, which is not an actual problem but somehow annoying.
This PR fixes it not to use the anon-const and flatten `cfg`s.

## Screenshots

- before
![Screenshot from 2024-08-08 00-59-53](https://github.com/user-attachments/assets/fc988653-89bb-4639-94e9-8fb79ea01a1b)

- after
![Screenshot from 2024-08-08 01-00-30](https://github.com/user-attachments/assets/123c2781-2af3-47c3-ba8e-b3a3ac05b174)
