### PR TITLE
perf: reuse `Request` in a session

### DIFF
--- a/ohkami/src/header/map.rs
+++ b/ohkami/src/header/map.rs
@@ -14,6 +14,13 @@ impl<const N: usize, Value> IndexMap<N, Value> {
         }
     }
 
+    #[cfg(any(feature="rt_tokio",feature="rt_async-std"))]
+    #[inline]
+    pub(crate) fn clear(&mut self) {
+        for idx in &mut self.index {*idx = Self::NULL}
+        self.values.clear();
+    }
+
     #[inline(always)]
     pub(crate) unsafe fn get(&self, index: usize) -> Option<&Value> {
         match *self.index.get_unchecked(index) {

--- a/ohkami/src/request/headers.rs
+++ b/ohkami/src/request/headers.rs
@@ -359,6 +359,15 @@ impl Headers {
         Self::init()
     }
 
+    #[cfg(any(feature="rt_tokio",feature="rt_async-std"))]
+    #[inline]
+    pub(crate) fn clear(&mut self) {
+        self.standard.clear();
+        if let Some(map) = &mut self.custom {
+            map.clear()
+        }
+    }
+
     #[inline] pub(crate) fn get_raw(&self, name: Header) -> Option<&CowSlice> {
         unsafe {self.standard.get(name as usize)}
     }

--- a/ohkami/src/request/memory.rs
+++ b/ohkami/src/request/memory.rs
@@ -33,6 +33,12 @@ impl Store {
     pub(super) const fn init() -> Self {
         Self(None)
     }
+    #[cfg(any(feature="rt_tokio",feature="rt_async-std"))]
+    pub(super) fn clear(&mut self) {
+        if let Some(map) = &mut self.0 {
+            map.clear()
+        }
+    }
 
     #[inline] pub fn insert<Data: Send + Sync + 'static>(&mut self, value: Data) {
         self.0.get_or_insert_with(|| Box::new(HashMap::default()))

--- a/ohkami/src/request/mod.rs
+++ b/ohkami/src/request/mod.rs
@@ -186,6 +186,18 @@ impl Request {
             store:   Store::init(),
         }
     }
+    #[cfg(any(feature="rt_tokio",feature="rt_async-std"))]
+    #[inline]
+    pub(crate) fn clear(&mut self) {
+        for b in &mut *self.__buf__ {
+            match b {0 => break, _ => *b = 0}
+        }
+        self.path  = Path::uninit();
+        self.query = None;
+        self.headers.clear();
+        self.payload = None;
+        self.store.clear();
+    }
 
     #[cfg(any(feature="rt_tokio",feature="rt_async-std"))]
     #[inline]

--- a/ohkami/src/request/mod.rs
+++ b/ohkami/src/request/mod.rs
@@ -189,14 +189,16 @@ impl Request {
     #[cfg(any(feature="rt_tokio",feature="rt_async-std"))]
     #[inline]
     pub(crate) fn clear(&mut self) {
-        for b in &mut *self.__buf__ {
-            match b {0 => break, _ => *b = 0}
-        }
-        self.path  = Path::uninit();
-        self.query = None;
-        self.headers.clear();
-        self.payload = None;
-        self.store.clear();
+        if self.__buf__[0] != 0 {
+            for b in &mut *self.__buf__ {
+                match b {0 => break, _ => *b = 0}
+            }
+            self.path  = Path::uninit();
+            self.query = None;
+            self.headers.clear();
+            self.payload = None;
+            self.store.clear();
+        } /* else: just after `init`ed or `clear`ed */
     }
 
     #[cfg(any(feature="rt_tokio",feature="rt_async-std"))]

--- a/ohkami/src/response/mod.rs
+++ b/ohkami/src/response/mod.rs
@@ -172,7 +172,7 @@ impl Upgrade {
 impl Response {
     #[cfg_attr(not(feature="sse"), inline)]
     pub(crate) async fn send(mut self,
-        conn: &mut (impl AsyncWriter + Unpin + 'static)
+        conn: &mut (impl AsyncWriter + Unpin)
     ) -> Upgrade {
         self.complete();
 

--- a/ohkami/src/session/mod.rs
+++ b/ohkami/src/session/mod.rs
@@ -92,20 +92,6 @@ impl Session {
         }).await {
             Some(Upgrade::None) | None => {
                 crate::DEBUG!("about to shutdown connection");
-        
-                if let Some(err) = {
-                    #[cfg(feature="rt_tokio")] {use crate::__rt__::AsyncWriter;
-                        self.connection.shutdown().await
-                    }
-                    #[cfg(feature="rt_async-std")] {
-                        self.connection.shutdown(std::net::Shutdown::Both)
-                    }
-                }.err() {
-                    match err.kind() {
-                        std::io::ErrorKind::NotConnected => (),
-                        _ => panic!("Failed to shutdown stream: {err}")
-                    }
-                }
             }
 
             #[cfg(all(feature="ws", any(feature="rt_tokio",feature="rt_async-std")))]

--- a/ohkami/src/session/mod.rs
+++ b/ohkami/src/session/mod.rs
@@ -67,6 +67,7 @@ impl Session {
             let mut req = Request::init();
             let mut req = unsafe {Pin::new_unchecked(&mut req)};
             loop {
+                req.clear();
                 match req.as_mut().read(&mut self.connection).await {
                     Ok(Some(())) => {
                         let close = matches!(req.headers.Connection(), Some("close" | "Close"));
@@ -86,7 +87,6 @@ impl Session {
                     Ok(None) => break Upgrade::None,
                     Err(res) => {res.send(&mut self.connection).await;},
                 }
-                req.clear()
             }
         }).await {
             Some(Upgrade::None) | None => {

--- a/ohkami/src/session/mod.rs
+++ b/ohkami/src/session/mod.rs
@@ -82,12 +82,11 @@ impl Session {
 
                         if !upgrade.is_none() {break upgrade}
                         if close {break Upgrade::None}
-
-                        req.clear();
                     }
                     Ok(None) => break Upgrade::None,
                     Err(res) => {res.send(&mut self.connection).await;},
-                };
+                }
+                req.clear()
             }
         }).await {
             Some(Upgrade::None) | None => {


### PR DESCRIPTION
Before `Session` created one pair of `Request`/`Response` for each incoming request, this means it performs `Drop` and initialization 2N times.

This PR changes this into initialize `Request` only once per one `Session` and clear & reuse it through one session.

## Benchmark example
```sh
cargo run --bin param --no-default-features --release
```
```sh
wrk -H 'Connection: keep-alive' --connections 32 --threads 16 --duration 3s --timeout 1s 'http://localhost:3000/user/1234567890987654321'
```
Requests/sec

|   |  before   |   after   |
|---|-----------|-----------|
| 1 | 705338.20 | 717771.62 |
| 2 | 709623.03 | 715556.64 |
| 3 | 705485.43 | 724493.01 |
