### PR TITLE
feat: Add `"ip"` feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Select a native async runtime
 npm create cloudflare ./path/to/project -- --template https://github.com/ohkami-rs/ohkami-templates/worker
 ```
 
-Then your project directory has `wrangler.toml`, `package.json` and a Rust library crate. Local dev by `npm run dev` and deploy by `npm run deploy` !
+then your project directory has `wrangler.toml`, `package.json` and a Rust library crate. Local dev by `npm run dev` and deploy by `npm run deploy` !
 
 See README of the [template](https://github.com/ohkami-rs/ohkami-templates/tree/main/worker) for details.
 
@@ -139,6 +139,10 @@ async fn main() {
     )).howl("localhost:3030").await
 }
 ```
+
+### `"ip"`：remote IP address
+
+Get and hold remote peer's IP address
 
 ### `"nightly"`：enable nightly-only functionalities
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -103,9 +103,11 @@ tasks:
     dir: ohkami
     cmds:
       - cargo check --lib --features rt_tokio,{{.MAYBE_NIGHTLY}}
+      - cargo check --lib --features rt_tokio,ip,{{.MAYBE_NIGHTLY}}
       - cargo check --lib --features rt_tokio,sse,{{.MAYBE_NIGHTLY}}
       - cargo check --lib --features rt_tokio,sse,ws,{{.MAYBE_NIGHTLY}}
       - cargo check --lib --features rt_tokio,graceful,{{.MAYBE_NIGHTLY}}
+      - cargo check --lib --features rt_tokio,graceful,ip,{{.MAYBE_NIGHTLY}}
 
   check_rt_async-std:
     vars:
@@ -114,6 +116,7 @@ tasks:
     dir: ohkami
     cmds:
       - cargo check --lib --features rt_async-std,{{.MAYBE_NIGHTLY}}
+      - cargo check --lib --features rt_async-std,ip,{{.MAYBE_NIGHTLY}}
       - cargo check --lib --features rt_async-std,sse,{{.MAYBE_NIGHTLY}}
       - cargo check --lib --features rt_async-std,sse,ws,{{.MAYBE_NIGHTLY}}
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -16,7 +16,7 @@ members  = [
 
 [workspace.dependencies]
 # set `default-features = false` to assure "DEBUG" feature be off even when DEBUGing `../ohkami`
-ohkami             = { path = "../ohkami", default-features = false, features = ["rt_tokio", "testing", "sse", "ws"] }
+ohkami             = { path = "../ohkami", default-features = false, features = ["rt_tokio", "testing", "sse", "ws", "ip"] }
 tokio              = { version = "1", features = ["full"] }
 sqlx               = { version = "0.7.3", features = ["runtime-tokio-native-tls", "postgres", "macros", "chrono", "uuid"] }
 tracing            = "0.1"

--- a/examples/hello/src/main.rs
+++ b/examples/hello/src/main.rs
@@ -84,17 +84,9 @@ mod fangs {
     #[derive(Clone)]
     pub struct LogRequest;
     impl FangAction for LogRequest {
-        fn fore<'a>(&'a self, req: &'a mut Request) -> impl std::future::Future<Output = Result<(), Response>> + Send {
-            let __method__ = req.method;
-            let __path__   = req.path.str();
-
-            tracing::info!("\n\
-                Got request:\n\
-                [ method ] {__method__}\n\
-                [  path  ] {__path__}\n\
-            ");
-
-            async {Ok(())}
+        async fn fore<'a>(&'a self, req: &'a mut Request) -> Result<(), Response> {
+            tracing::info!("\nGot request: {req:#?}");
+            Ok(())
         }
     }
 }

--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -48,6 +48,7 @@ testing       = []
 sse           = ["ohkami_lib/stream"]
 ws            = ["dep:sha1"]
 graceful      = ["rt_tokio", "tokio/signal", "tokio/macros"]
+ip            = []
 
 ##### DEBUG #####
 DEBUG = [
@@ -60,6 +61,7 @@ DEBUG = [
 #    "testing",
 #    "sse",
 #    "ws",
+#    "ip",
 #    "rt_tokio",
 #    #"rt_async-std",
 #    #"rt_worker",

--- a/ohkami/src/fang/builtin/jwt.rs
+++ b/ohkami/src/fang/builtin/jwt.rs
@@ -414,7 +414,7 @@ impl<Payload: for<'de> Deserialize<'de>> JWT<Payload> {
         let req_bytes = TestRequest::GET("/")
             .header("Authorization", "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3MDY4MTEwNzUsInVzZXJfaWQiOiI5ZmMwMDViMi1mODU4LTQzMzYtODkwYS1mMWEyYWVmNjBhMjQifQ.AKp-0zvKK4Hwa6qCgxskckD04Snf0gpSG7U1LOpcC_I")
             .encode();
-        let mut req = Request::init();
+        let mut req = Request::init(#[cfg(feature="ip")] crate::utils::IP_0000);
         let mut req = unsafe {Pin::new_unchecked(&mut req)};
         req.as_mut().read(&mut &req_bytes[..]).await.ok();
 
@@ -427,7 +427,7 @@ impl<Payload: for<'de> Deserialize<'de>> JWT<Payload> {
             // Modifed last `I` of the value above to `X`
             .header("Authorization", "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3MDY4MTEwNzUsInVzZXJfaWQiOiI5ZmMwMDViMi1mODU4LTQzMzYtODkwYS1mMWEyYWVmNjBhMjQifQ.AKp-0zvKK4Hwa6qCgxskckD04Snf0gpSG7U1LOpcC_X")
             .encode();
-        let mut req = Request::init();
+        let mut req = Request::init(#[cfg(feature="ip")] crate::utils::IP_0000);
         let mut req = unsafe {Pin::new_unchecked(&mut req)};
         req.as_mut().read(&mut &req_bytes[..]).await.ok();
 

--- a/ohkami/src/lib.rs
+++ b/ohkami/src/lib.rs
@@ -35,18 +35,23 @@
     Can't activate multiple `rt_*` features at once!
 "}
 
-#[cfg(any(
-    all(feature="graceful", not(feature="rt_tokio")),
-))] compile_error! {"
-    In current versoin, `graceful` feature is only supported on `rt_tokio`.
-    Please wait for future development for other runtimes...
-"}
-
 #[cfg(not(feature="DEBUG"))]
 #[cfg(all(feature="rt_worker", not(target_arch="wasm32")))]
 compile_error! {"
     `rt_worker` must be activated on `wasm32` target!
     (We recommend to touch `.cargo/config.toml`: `[build] target = \"wasm32-unknown-unknown\"`)
+"}
+
+#[cfg(all(feature="rt_worker", feature="ip"))]
+compile_error! {"
+    Can't activate `ip` feature on `rt_worker`!
+"}
+
+#[cfg(any(
+    all(feature="graceful", not(feature="rt_tokio")),
+))] compile_error! {"
+    In current versoin, `graceful` feature is only supported on `rt_tokio`.
+    Please wait for future development for other runtimes...
 "}
 
 
@@ -231,6 +236,9 @@ pub mod utils {
 
         Timeout { proc, sleep: crate::__rt__::sleep(duration) }
     }
+
+    #[cfg(feature="ip")]
+    pub(crate) const IP_0000: std::net::IpAddr = std::net::IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0));
 }
 
 #[cfg(feature="rt_worker")]

--- a/ohkami/src/ohkami/mod.rs
+++ b/ohkami/src/ohkami/mod.rs
@@ -283,9 +283,9 @@ impl Ohkami {
                         crate::DEBUG!("Accepted {accept:#?}");
 
                         #[cfg(not(feature="ip"))]
-                        let Ok((connection, _)) = accept.await else {continue};
+                        let Ok((connection, _)) = accept else {continue};
                         #[cfg(feature="ip")]
-                        let Ok((connection, addr)) = accept.await else {continue};
+                        let Ok((connection, addr)) = accept else {continue};
 
                         let session = Session::new(
                             router.clone(),

--- a/ohkami/src/ohkami/mod.rs
+++ b/ohkami/src/ohkami/mod.rs
@@ -282,8 +282,16 @@ impl Ohkami {
                     accept = listener.accept() => {
                         crate::DEBUG!("Accepted {accept:#?}");
 
-                        let Ok((connection, _)) = accept else {continue};
-                        let session = Session::new(router.clone(), connection);
+                        #[cfg(not(feature="ip"))]
+                        let Ok((connection, _)) = accept.await else {continue};
+                        #[cfg(feature="ip")]
+                        let Ok((connection, addr)) = accept.await else {continue};
+
+                        let session = Session::new(
+                            router.clone(),
+                            connection,
+                            #[cfg(feature="ip")] addr.ip()
+                        );
 
                         let close_rx = close_rx.clone();
                         __rt__::task::spawn(async {
@@ -305,12 +313,16 @@ impl Ohkami {
         }
         #[cfg(all(feature="rt_tokio", not(feature="graceful")))] {
             loop {
+                #[cfg(not(feature="ip"))]
                 let Ok((connection, _)) = listener.accept().await else {continue};
+                #[cfg(feature="ip")]
+                let Ok((connection, addr)) = listener.accept().await else {continue};
 
                 __rt__::task::spawn({
                     Session::new(
                         router.clone(),
                         connection,
+                        #[cfg(feature="ip")] addr.ip()
                     ).manage()
                 });
             }
@@ -321,10 +333,14 @@ impl Ohkami {
             while let Some(connection) = listener.incoming().next().await {
                 let Ok(connection) = connection else {continue};
 
+                #[cfg(feature="ip")]
+                let Ok(addr) = connection.peer_addr() else {continue};
+
                 __rt__::task::spawn({
                     Session::new(
                         router.clone(),
                         connection,
+                        #[cfg(feature="ip")] addr.ip()
                     ).manage()
                 });
             }

--- a/ohkami/src/request/_test_parse.rs
+++ b/ohkami/src/request/_test_parse.rs
@@ -7,7 +7,7 @@ use super::{Request, Method, BUF_SIZE, Path, QueryParams, Store};
 
 macro_rules! assert_parse {
     ($case:expr, $expected:expr) => {
-        let mut actual = Request::init();
+        let mut actual = Request::init(#[cfg(feature="ip")] crate::utils::IP_0000);
         let mut actual = unsafe {Pin::new_unchecked(&mut actual)};
         actual.as_mut().read(&mut $case.as_bytes()).await.ok();
 
@@ -79,6 +79,9 @@ fn parse_path() {
         ], None),
         payload: None,
         store:   Store::init(),
+
+        #[cfg(feature="ip")]
+        addr: crate::utils::IP_0000
     });
 
 
@@ -109,6 +112,9 @@ fn parse_path() {
             br#"{"name":"kanarus","age":20}"#
         ))),
         store: Store::init(),
+
+        #[cfg(feature="ip")]
+        addr: crate::utils::IP_0000
     });
 
     {
@@ -154,7 +160,9 @@ fn parse_path() {
             ),
             payload: Some(CowSlice::Own(Vec::from("first_name=John&last_name=Doe&action=Submit").into())),
             store:   Store::init(),
-            // #[cfg(feature="websocket")] upgrade_id: None,
+
+            #[cfg(feature="ip")]
+            addr: crate::utils::IP_0000
         });
     }
 }

--- a/ohkami/src/session/mod.rs
+++ b/ohkami/src/session/mod.rs
@@ -38,15 +38,24 @@ mod env {
 pub(crate) struct Session {
     router:     Arc<RadixRouter>,
     connection: TcpStream,
+
+    #[cfg(feature="ip")]
+    addr: std::net::IpAddr
 }
 impl Session {
     pub(crate) fn new(
-        router:      Arc<RadixRouter>,
-        connection:  TcpStream,
+        router:     Arc<RadixRouter>,
+        connection: TcpStream,
+
+        #[cfg(feature="ip")]
+        addr: std::net::IpAddr
     ) -> Self {
         Self {
             router,
             connection,
+
+            #[cfg(feature="ip")]
+            addr
         }
     }
 
@@ -64,7 +73,7 @@ impl Session {
         }
 
         match timeout_in(Duration::from_secs(env::OHKAMI_KEEPALIVE_TIMEOUT()), async {
-            let mut req = Request::init();
+            let mut req = Request::init(#[cfg(feature="ip")] self.addr);
             let mut req = unsafe {Pin::new_unchecked(&mut req)};
             loop {
                 req.clear();

--- a/ohkami/src/testing/mod.rs
+++ b/ohkami/src/testing/mod.rs
@@ -55,7 +55,7 @@ impl TestingOhkami {
         let router = self.0.clone();
         
         let res = async move {
-            let mut request = Request::init();
+            let mut request = Request::init(#[cfg(feature="ip")] crate::utils::IP_0000);
             let mut request = unsafe {Pin::new_unchecked(&mut request)};
             
             let res = match request.as_mut().read(&mut &req.encode()[..]).await {


### PR DESCRIPTION
## functionality
Get remote peer's IP address in `Ohkami::howl`, pass it to `Session::manage`, and set `Request`'s `addr` public field to it when `init`.

## note
This PR doesn't support `"ip"` on `"rt_worker"`.
references:
- https://developers.cloudflare.com/fundamentals/reference/http-request-headers/#cf-connecting-ip
- https://developers.cloudflare.com/support/troubleshooting/restoring-visitor-ips/restoring-original-visitor-ips