### PR TITLE
chore: remove format::V

### DIFF
--- a/ohkami/src/format/builtin.rs
+++ b/ohkami/src/format/builtin.rs
@@ -15,3 +15,9 @@ pub use html::HTML;
 
 mod query;
 pub use query::Query;
+
+
+#[cold] #[inline(never)]
+fn reject(msg: impl std::fmt::Display) -> crate::Response {
+    crate::Response::BadRequest().with_text(msg.to_string())
+}

--- a/ohkami/src/format/builtin/html.rs
+++ b/ohkami/src/format/builtin/html.rs
@@ -5,9 +5,6 @@ pub struct HTML<T = String>(pub T);
 
 impl<T: Into<std::borrow::Cow<'static, str>>> IntoResponse for HTML<T> {
     fn into_response(self) -> Response {
-        match super::super::validated(self.0) {
-            Ok(v)  => Response::OK().with_html(v),
-            Err(e) => e,
-        }
+        Response::OK().with_html(self.0)
     }
 }

--- a/ohkami/src/format/builtin/json.rs
+++ b/ohkami/src/format/builtin/json.rs
@@ -13,8 +13,7 @@ impl<'req, S: Deserialize<'req>> FromRequest<'req> for JSON<S> {
             return None
         }
         serde_json::from_slice(req.payload()?)
-            .map_err(super::super::reject)
-            .and_then(super::super::validated)
+            .map_err(super::reject)
             .map(Self).into()
     }
 }
@@ -22,9 +21,6 @@ impl<'req, S: Deserialize<'req>> FromRequest<'req> for JSON<S> {
 impl<S: Serialize> IntoResponse for JSON<S> {
     #[inline(always)]
     fn into_response(self) -> Response {
-        match super::super::validated(self.0) {
-            Ok(v)  => Response::OK().with_json(v),
-            Err(e) => e,
-        }
+        Response::OK().with_json(self.0)
     }
 }

--- a/ohkami/src/format/builtin/multipart.rs
+++ b/ohkami/src/format/builtin/multipart.rs
@@ -15,8 +15,7 @@ impl<'req, S: Deserialize<'req>> FromRequest<'req> for Multipart<S> {
             return None
         }
         ohkami_lib::serde_multipart::from_bytes(req.payload()?)
-            .map_err(super::super::reject)
-            .and_then(super::super::validated)
+            .map_err(super::reject)
             .map(Self).into()
     }
 }

--- a/ohkami/src/format/builtin/query.rs
+++ b/ohkami/src/format/builtin/query.rs
@@ -9,8 +9,7 @@ impl<'req, S: Deserialize<'req>> FromRequest<'req> for Query<S> {
 
     fn from_request(req: &'req crate::Request) -> Option<Result<Self, Self::Error>> {
         req.query.as_ref()?.parse()
-            .map_err(super::super::reject)
-            .and_then(super::super::validated)
+            .map_err(super::reject)
             .map(Query).into()
     }
 }

--- a/ohkami/src/format/builtin/text.rs
+++ b/ohkami/src/format/builtin/text.rs
@@ -10,17 +10,13 @@ impl<'req, T: From<&'req str>> FromRequest<'req> for Text<T> {
             return None
         }
         std::str::from_utf8(req.payload()?)
-            .map_err(super::super::reject)
-            .and_then(super::super::validated)
+            .map_err(super::reject)
             .map(|s| Self(T::from(s))).into()
     }
 }
 
 impl<T: Into<std::borrow::Cow<'static, str>>> IntoResponse for Text<T> {
     fn into_response(self) -> Response {
-        match super::super::validated(self.0) {
-            Ok(v)  => Response::OK().with_text(v),
-            Err(e) => e,
-        }
+        Response::OK().with_text(self.0)
     }
 }

--- a/ohkami/src/format/builtin/urlencoded.rs
+++ b/ohkami/src/format/builtin/urlencoded.rs
@@ -13,19 +13,15 @@ impl<'req, S: Deserialize<'req>> FromRequest<'req> for URLEncoded<S> {
             return None
         }
         ohkami_lib::serde_urlencoded::from_bytes(req.payload()?)
-            .map_err(super::super::reject)
-            .and_then(super::super::validated)
+            .map_err(super::reject)
             .map(Self).into()
     }
 }
 
 impl<S: Serialize> IntoResponse for URLEncoded<S> {
     fn into_response(self) -> Response {
-        match super::super::validated(self.0) {
-            Ok(v) => Response::OK().with_payload("application/x-www-form-urlencoded",
-                ohkami_lib::serde_urlencoded::to_string(&v).unwrap().into_bytes()
-            ),
-            Err(e) => e
-        }
+        Response::OK().with_payload("application/x-www-form-urlencoded",
+            ohkami_lib::serde_urlencoded::to_string(&self.0).unwrap().into_bytes()
+        )
     }
 }

--- a/ohkami/src/format/mod.rs
+++ b/ohkami/src/format/mod.rs
@@ -8,67 +8,6 @@
 //! - `URLEncoded` - payload of application/x-www-form-urlencoded
 //! - `Text` - payload of text/plain
 //! - `HTML` - payload of text/html
-//! 
-//! ## Note
-//! 
-//! Every format should:
-//! 
-//! 1. have the structure of `struct {Name}<Schema>(pub Schema);`
-//! 2. properly handle result of `ohkami::format::validated`
 
 mod builtin;
 pub use builtin::*;
-
-
-#[cfg(feature="nightly")]
-/// ## In-place validation for schema struct in a format
-/// 
-/// Format holding a type implementing this
-/// will perform in-place validation when
-/// 
-/// - parsing request body to the type
-/// - building response body of the type
-/// 
-/// <br>
-/// 
-/// ### required
-/// 
-/// - `type ErrorMessage: Display` (directly used for an error response text)
-/// - `fn validate`
-pub trait V {
-    type ErrorMessage: std::fmt::Display;
-    fn validate(&self) -> Result<(), Self::ErrorMessage>;
-}
-
-#[doc(hidden)]
-#[inline]
-pub fn validated<S>(schema: S) -> Result<S, crate::Response> {
-    #[allow(non_camel_case_types)]
-    trait schema: Sized {
-        fn validated(self) -> Result<Self, crate::Response>;
-    }
-    impl<T> schema for T {
-        #[cfg(not(feature="nightly"))]
-        #[inline(always)]
-        fn validated(self) -> Result<Self, crate::Response> {Ok(self)}
-
-        #[cfg(feature="nightly")]
-        #[inline(always)]
-        default fn validated(self) -> Result<Self, crate::Response> {Ok(self)}
-    }
-    #[cfg(feature="nightly")]
-    impl<S: V> schema for S {
-        #[inline]
-        fn validated(self) -> Result<Self, crate::Response> {
-            self.validate().map_err(reject)?;
-            Ok(self)
-        }
-    }
-
-    schema.validated()
-}
-
-#[cold] #[inline(never)]
-fn reject(msg: impl std::fmt::Display) -> crate::Response {
-    crate::Response::BadRequest().with_text(msg.to_string())
-}


### PR DESCRIPTION
We published [SerdeV](https://github.com/ohkami-rs/serdev) and it's enough to perform validation on deserializing (if needed).