### PR TITLE
chore: benches_rt/tokio: set `event_interval` to 1

### DIFF
--- a/benches_rt/.gitignore
+++ b/benches_rt/.gitignore
@@ -1,0 +1,3 @@
+*flamegraph.svg
+perf.data
+perf.data.old

--- a/benches_rt/tokio/src/bin/param.rs
+++ b/benches_rt/tokio/src/bin/param.rs
@@ -1,15 +1,13 @@
 use ohkami::prelude::*;
 
-#[inline(always)]
-async fn echo_id(id: String) -> String {
-    id//.into()
-}
-
-#[tokio::main]
-async fn main() {
-    Ohkami::new((
-        "/user/:id"
-            .GET(echo_id),
-            //.GET(|id: String| async {id}),
-    )).howl("0.0.0.0:3000").await
+fn main() {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .event_interval(1)
+        .build()
+        .expect("Failed building the Runtime")
+        .block_on(Ohkami::new((
+            "/user/:id"
+                .GET(|id: String| async {id}),
+        )).howl("0.0.0.0:3000"))
 }


### PR DESCRIPTION
I found that in very simple senario, like getting a path param and echoing it as text, the higher setting `event_interval` of tokio runtime, the lower the performance be.
So this PR tries setting it to the minimum value, 1, in `benches_rt/tokio/src/bin/param` ( default: 61 ).

ref: https://docs.rs/tokio/1.39.3/tokio/runtime/struct.Builder.html#method.event_interval

## benchmark examples

```sh
wrk -H 'Connection: keep-alive' --connections 32 --threads 16 --duration 3s --timeout 1s 'http://localhost:3000/user/1234567890987654321'
```

- default ( `#[tokio::main] async fn main()` )
  1.  Requests/sec: 725217.89
  2. Requests/sec: 726961.24
  3. Requests/sec: 724529.73

- set `event_interval` to 1 ( `.event_interval(1)` )
  1. Requests/sec: 874318.85
  2. Requests/sec: 865562.96
  3. Requests/sec: 848599.67