### PR TITLE
chore: dependencies: remove tokio's "sync" feature ( unused )

### DIFF
--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -21,7 +21,7 @@ features      = ["rt_tokio", "nightly", "sse", "ws"]
 ohkami_lib    = { version = "=0.2.5", path = "../ohkami_lib" }
 ohkami_macros = { version = "=0.8.0", path = "../ohkami_macros" }
 
-tokio         = { version = "1",   optional = true, features = ["net", "rt", "io-util", "sync", "time"] }
+tokio         = { version = "1",   optional = true, features = ["net", "rt", "io-util", "time"] }
 async-std     = { version = "1",   optional = true }
 smol          = { version = "2",   optional = true }
 glommio       = { version = "0.9", optional = true }

--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -54,7 +54,7 @@ nightly       = []
 testing       = []
 sse           = ["ohkami_lib/stream"]
 ws            = ["dep:sha1"]
-graceful      = ["rt_tokio", "tokio/signal", "tokio/macros"]
+graceful      = ["tokio?/sync", "tokio?/signal", "tokio?/macros"]
 ip            = []
 
 ##### internal #####


### PR DESCRIPTION
only enable in `graceful`