### PR TITLE
feat: handle IP address by default on all native runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,10 +150,6 @@ async fn main() {
 }
 ```
 
-### `"ip"`：remote IP address
-
-Get and hold remote peer's IP address
-
 ### `"nightly"`：enable nightly-only functionalities
 
 - try response

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -137,7 +137,6 @@ tasks:
     dir: ohkami
     cmds:
       - cargo check --lib --features rt_tokio,{{.MAYBE_NIGHTLY}}
-      - cargo check --lib --features rt_tokio,ip,{{.MAYBE_NIGHTLY}}
       - cargo check --lib --features rt_tokio,sse,{{.MAYBE_NIGHTLY}}
       - cargo check --lib --features rt_tokio,sse,ws,{{.MAYBE_NIGHTLY}}
 
@@ -148,7 +147,6 @@ tasks:
     dir: ohkami
     cmds:
       - cargo check --lib --features rt_async-std,{{.MAYBE_NIGHTLY}}
-      - cargo check --lib --features rt_async-std,ip,{{.MAYBE_NIGHTLY}}
       - cargo check --lib --features rt_async-std,sse,{{.MAYBE_NIGHTLY}}
       - cargo check --lib --features rt_async-std,sse,ws,{{.MAYBE_NIGHTLY}}
 
@@ -159,7 +157,6 @@ tasks:
     dir: ohkami
     cmds:
       - cargo check --lib --features rt_smol,{{.MAYBE_NIGHTLY}}
-      - cargo check --lib --features rt_smol,ip,{{.MAYBE_NIGHTLY}}
       - cargo check --lib --features rt_smol,sse,{{.MAYBE_NIGHTLY}}
       - cargo check --lib --features rt_smol,sse,ws,{{.MAYBE_NIGHTLY}}
 
@@ -170,7 +167,6 @@ tasks:
     dir: ohkami
     cmds:
       - cargo check --lib --features rt_glommio,{{.MAYBE_NIGHTLY}}
-      - cargo check --lib --features rt_glommio,ip,{{.MAYBE_NIGHTLY}}
       - cargo check --lib --features rt_glommio,sse,{{.MAYBE_NIGHTLY}}
       - cargo check --lib --features rt_glommio,sse,ws,{{.MAYBE_NIGHTLY}}
 

--- a/benches_rt/tokio/Cargo.toml
+++ b/benches_rt/tokio/Cargo.toml
@@ -9,9 +9,6 @@ authors = ["kanarus <kanarus786@gmail.com>"]
 ohkami  = { path = "../../ohkami", default-features = false, features = ["rt_tokio"] }
 tokio   = { version = "1", features = ["full"] }
 
-[features]
-ip = ["ohkami/ip"]
-
 [profile.release]
 opt-level = 3
 debug = false

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -16,7 +16,7 @@ members  = [
 
 [workspace.dependencies]
 # set `default-features = false` to assure "DEBUG" feature be off even when DEBUGing `../ohkami`
-ohkami             = { path = "../ohkami", default-features = false, features = ["rt_tokio", "testing", "sse", "ws", "ip"] }
+ohkami             = { path = "../ohkami", default-features = false, features = ["rt_tokio", "testing", "sse", "ws"] }
 tokio              = { version = "1", features = ["full"] }
 sqlx               = { version = "0.7.3", features = ["runtime-tokio-native-tls", "postgres", "macros", "chrono", "uuid"] }
 tracing            = "0.1"

--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -54,7 +54,6 @@ nightly       = []
 testing       = []
 sse           = ["ohkami_lib/stream"]
 ws            = ["dep:sha1"]
-ip            = []
 
 ##### internal #####
 __rt__        = []

--- a/ohkami/src/fang/builtin/jwt.rs
+++ b/ohkami/src/fang/builtin/jwt.rs
@@ -414,7 +414,7 @@ impl<Payload: for<'de> Deserialize<'de>> JWT<Payload> {
         let req_bytes = TestRequest::GET("/")
             .header("Authorization", "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3MDY4MTEwNzUsInVzZXJfaWQiOiI5ZmMwMDViMi1mODU4LTQzMzYtODkwYS1mMWEyYWVmNjBhMjQifQ.AKp-0zvKK4Hwa6qCgxskckD04Snf0gpSG7U1LOpcC_I")
             .encode();
-        let mut req = Request::init(#[cfg(feature="ip")] crate::utils::IP_0000);
+        let mut req = Request::init(crate::utils::IP_0000);
         let mut req = unsafe {Pin::new_unchecked(&mut req)};
         req.as_mut().read(&mut &req_bytes[..]).await.ok();
 
@@ -427,7 +427,7 @@ impl<Payload: for<'de> Deserialize<'de>> JWT<Payload> {
             // Modifed last `I` of the value above to `X`
             .header("Authorization", "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3MDY4MTEwNzUsInVzZXJfaWQiOiI5ZmMwMDViMi1mODU4LTQzMzYtODkwYS1mMWEyYWVmNjBhMjQifQ.AKp-0zvKK4Hwa6qCgxskckD04Snf0gpSG7U1LOpcC_X")
             .encode();
-        let mut req = Request::init(#[cfg(feature="ip")] crate::utils::IP_0000);
+        let mut req = Request::init(crate::utils::IP_0000);
         let mut req = unsafe {Pin::new_unchecked(&mut req)};
         req.as_mut().read(&mut &req_bytes[..]).await.ok();
 

--- a/ohkami/src/lib.rs
+++ b/ohkami/src/lib.rs
@@ -49,11 +49,6 @@ compile_error! {"
     (We recommend to touch `.cargo/config.toml`: `[build] target = \"wasm32-unknown-unknown\"`)
 "}
 
-#[cfg(all(feature="rt_worker", feature="ip"))]
-compile_error! {"
-    Can't activate `ip` feature on `rt_worker`!
-"}
-
 
 #[allow(unused)]
 mod __rt__ {
@@ -276,7 +271,7 @@ pub mod utils {
         Timeout { proc, sleep: crate::__rt__::sleep(duration) }
     }
 
-    #[cfg(feature="ip")]
+    #[cfg(feature="__rt_native__")]
     pub const IP_0000: std::net::IpAddr = std::net::IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0));
 
     #[cfg(feature="rt_glommio")]

--- a/ohkami/src/ohkami/mod.rs
+++ b/ohkami/src/ohkami/mod.rs
@@ -318,15 +318,12 @@ impl Ohkami {
             loop {
                 __rt__::select! {
                     accept = listener.accept() => {
-                        #[cfg(not(feature="ip"))]
-                        let Ok((connection, _)) = accept else {continue};
-                        #[cfg(feature="ip")]
                         let Ok((connection, addr)) = accept else {continue};
 
                         let session = Session::new(
                             router.clone(),
                             connection,
-                            #[cfg(feature="ip")] addr.ip()
+                            addr.ip()
                         );
 
                         let close_rx = close_rx.clone();
@@ -348,15 +345,12 @@ impl Ohkami {
             loop {
                 __rt__::select! {
                     accept = __rt__::FutureExt::fuse(listener.accept()) => {
-                        #[cfg(not(feature="ip"))]
-                        let Ok((connection, _)) = accept else {continue};
-                        #[cfg(feature="ip")]
                         let Ok((connection, addr)) = accept else {continue};
 
                         let session = Session::new(
                             router.clone(),
                             connection,
-                            #[cfg(feature="ip")] addr.ip()
+                            addr.ip()
                         );
 
                         let close_rx = close_rx.clone();
@@ -378,15 +372,12 @@ impl Ohkami {
             loop {
                 __rt__::select! {
                     accept = __rt__::FutureExt::fuse(listener.accept()) => {
-                        #[cfg(not(feature="ip"))]
-                        let Ok((connection, _)) = accept else {continue};
-                        #[cfg(feature="ip")]
                         let Ok((connection, addr)) = accept else {continue};
 
                         let session = Session::new(
                             router.clone(),
                             connection,
-                            #[cfg(feature="ip")] addr.ip()
+                            addr.ip()
                         );
 
                         let close_rx = close_rx.clone();
@@ -409,14 +400,12 @@ impl Ohkami {
                 __rt__::select! {
                     accept = __rt__::FutureExt::fuse(listener.accept()) => {
                         let Ok(connection) = accept else {continue};
-        
-                        #[cfg(feature="ip")]
                         let Ok(addr) = connection.peer_addr() else {continue};
         
                         let session = Session::new(
                             router.clone(),
                             connection,
-                            #[cfg(feature="ip")] addr.ip()
+                            addr.ip()
                         );
 
                         let close_rx = close_rx.clone();

--- a/ohkami/src/request/_test_parse.rs
+++ b/ohkami/src/request/_test_parse.rs
@@ -33,7 +33,7 @@ fn parse_path() {
 
     macro_rules! assert_parse {
         ($case:expr, $expected:expr) => {
-            let mut actual = Request::init(#[cfg(feature="ip")] crate::utils::IP_0000);
+            let mut actual = Request::init(crate::utils::IP_0000);
             let mut actual = unsafe {Pin::new_unchecked(&mut actual)};
             actual.as_mut().read(&mut $case.as_bytes()).await.ok();
 
@@ -80,9 +80,7 @@ fn parse_path() {
         ], None),
         payload: None,
         store:   Store::init(),
-
-        #[cfg(feature="ip")]
-        addr: crate::utils::IP_0000
+        ip:      crate::utils::IP_0000
     });
 
 
@@ -113,9 +111,7 @@ fn parse_path() {
             br#"{"name":"kanarus","age":20}"#
         ))),
         store: Store::init(),
-
-        #[cfg(feature="ip")]
-        addr: crate::utils::IP_0000
+        ip:    crate::utils::IP_0000
     });
 
     {
@@ -161,9 +157,7 @@ fn parse_path() {
             ),
             payload: Some(CowSlice::Own(Vec::from("first_name=John&last_name=Doe&action=Submit").into())),
             store:   Store::init(),
-
-            #[cfg(feature="ip")]
-            addr: crate::utils::IP_0000
+            ip:      crate::utils::IP_0000
         });
     }
 }

--- a/ohkami/src/request/mod.rs
+++ b/ohkami/src/request/mod.rs
@@ -51,6 +51,7 @@ pub(crate) const PAYLOAD_LIMIT: usize = 1 << 32;
 /// - `path`
 /// - `queries`
 /// - `payload`
+/// - `ip`
 /// 
 /// and a `memory`.
 /// 
@@ -133,7 +134,7 @@ pub struct Request {
     /// Query params of this request
     /// 
     /// In handler, using a struct of expected schema
-    /// with `ohkami::typed::Query` attribute is recommended for *type-safe*
+    /// with `ohkami::format::Query` is recommended for *type-safe*
     /// query parsing.
     /// 
     /// ---
@@ -163,16 +164,21 @@ pub struct Request {
 
     store: Store,
 
-    #[cfg(feature="ip")]
-    pub addr: std::net::IpAddr
+    #[cfg(feature="__rt_native__")]
+    /// Remote ( directly connected ) peer's IP address
+    /// 
+    /// ---
+    /// 
+    /// **NOTE** : If a proxy is in front of Ohkami, this will be the proxy's address
+    pub ip: std::net::IpAddr,
 }
 
 impl Request {
     #[cfg(feature="__rt__")]
     #[inline]
     pub(crate) fn init(
-        #[cfg(feature="ip")]
-        addr: std::net::IpAddr
+        #[cfg(feature="__rt_native__")]
+        ip: std::net::IpAddr
     ) -> Self {
         Self {
             #[cfg(feature="__rt_native__")]
@@ -191,9 +197,9 @@ impl Request {
             headers: RequestHeaders::init(),
             payload: None,
             store:   Store::init(),
-
-            #[cfg(feature="ip")]
-            addr
+            
+            #[cfg(feature="__rt_native__")]
+            ip,
         }
     }
     #[cfg(feature="__rt_native__")]
@@ -452,8 +458,8 @@ const _: () = {
             if let Some(payload) = self.payload.as_ref().map(|cs| unsafe {cs.as_bytes()}) {
                 d.field("payload", &String::from_utf8_lossy(payload));
             }
-            #[cfg(feature="ip")] {
-                d.field("ip_address", &self.addr);
+            #[cfg(feature="__rt_native__")] {
+                d.field("ip", &self.ip);
             }
 
             d.finish()

--- a/ohkami/src/session/mod.rs
+++ b/ohkami/src/session/mod.rs
@@ -37,24 +37,18 @@ mod env {
 pub(crate) struct Session {
     router:     Arc<RadixRouter>,
     connection: TcpStream,
-
-    #[cfg(feature="ip")]
-    addr: std::net::IpAddr
+    ip:         std::net::IpAddr,
 }
 impl Session {
     pub(crate) fn new(
         router:     Arc<RadixRouter>,
         connection: TcpStream,
-
-        #[cfg(feature="ip")]
-        addr: std::net::IpAddr
+        ip:         std::net::IpAddr
     ) -> Self {
         Self {
             router,
             connection,
-
-            #[cfg(feature="ip")]
-            addr
+            ip
         }
     }
 
@@ -72,7 +66,7 @@ impl Session {
         }
 
         match timeout_in(Duration::from_secs(env::OHKAMI_KEEPALIVE_TIMEOUT()), async {
-            let mut req = Request::init(#[cfg(feature="ip")] self.addr);
+            let mut req = Request::init(self.ip);
             let mut req = unsafe {Pin::new_unchecked(&mut req)};
             loop {
                 req.clear();

--- a/ohkami/src/testing/mod.rs
+++ b/ohkami/src/testing/mod.rs
@@ -55,7 +55,7 @@ impl TestingOhkami {
         let router = self.0.clone();
         
         let res = async move {
-            let mut request = Request::init(#[cfg(feature="ip")] crate::utils::IP_0000);
+            let mut request = Request::init(#[cfg(feature="__rt_native__")] crate::utils::IP_0000);
             let mut request = unsafe {Pin::new_unchecked(&mut request)};
             
             let res = match request.as_mut().read(&mut &req.encode()[..]).await {


### PR DESCRIPTION
- Make `Reauest` have `ip` on all native runtime
- Remove feature flag `ip`