### PR TITLE
Fix version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 ```toml
 [dependencies]
-ohkami = { version = "0.21", features = ["rt_tokio"] }
+ohkami = { version = "0.20", features = ["rt_tokio"] }
 tokio  = { version = "1",    features = ["full"] }
 ```
 


### PR DESCRIPTION
I just saw that the version in the README.md is after the latest currently accessible version on GH / crates.io
Was this a typo or was there a v21 that got rolled back? Amazing project though :)