### PR TITLE
perf(ws on rt_worker): `SessionMap`: use `swap_remove` & omit redundant `None` check

### DIFF
--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -43,7 +43,7 @@ mews          = { version = "0.1", optional = true }
 
 
 [features]
-#default       = ["testing"]
+default       = ["testing"]
 
 rt_tokio      = ["__rt__", "__rt_native__", "dep:tokio",     "tokio/io-util", "tokio/macros",    "ohkami_lib/signal", "mews?/tokio"]
 rt_async-std  = ["__rt__", "__rt_native__", "dep:async-std", "dep:futures-util",                 "ohkami_lib/signal", "mews?/async-std"]
@@ -65,15 +65,15 @@ DEBUG = [
     "tokio?/rt-multi-thread",
     "async-std?/attributes",
 ]
-default = [
-    "nightly",
-    "testing",
-    "sse",
-    "ws",
-    #"rt_tokio",
-    #"rt_async-std",
-    #"rt_smol",
-    #"rt_glommio",
-    "rt_worker",
-    "DEBUG",
-]
+#default = [
+#    "nightly",
+#    "testing",
+#    "sse",
+#    "ws",
+#    #"rt_tokio",
+#    #"rt_async-std",
+#    #"rt_smol",
+#    #"rt_glommio",
+#    "rt_worker",
+#    "DEBUG",
+#]

--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -43,7 +43,7 @@ mews          = { version = "0.1", optional = true }
 
 
 [features]
-default       = ["testing"]
+#default       = ["testing"]
 
 rt_tokio      = ["__rt__", "__rt_native__", "dep:tokio",     "tokio/io-util", "tokio/macros",    "ohkami_lib/signal", "mews?/tokio"]
 rt_async-std  = ["__rt__", "__rt_native__", "dep:async-std", "dep:futures-util",                 "ohkami_lib/signal", "mews?/async-std"]
@@ -65,15 +65,15 @@ DEBUG = [
     "tokio?/rt-multi-thread",
     "async-std?/attributes",
 ]
-#default = [
-#    "nightly",
-#    "testing",
-#    "sse",
-#    "ws",
-#    #"rt_tokio",
-#    #"rt_async-std",
-#    #"rt_smol",
-#    #"rt_glommio",
-#    "rt_worker",
-#    "DEBUG",
-#]
+default = [
+    "nightly",
+    "testing",
+    "sse",
+    "ws",
+    #"rt_tokio",
+    #"rt_async-std",
+    #"rt_smol",
+    #"rt_glommio",
+    "rt_worker",
+    "DEBUG",
+]

--- a/ohkami/src/ws/worker.rs
+++ b/ohkami/src/ws/worker.rs
@@ -190,7 +190,7 @@ impl<S> SessionMap<S> {
     pub fn remove(&mut self, ws: &worker::WebSocket) -> Option<S> {
         ws.close::<&str>(None, None).ok();
         if let Some(index) = self.index_of(ws) {
-            Some(self.0.remove(index).1)
+            Some(self.0.swap_remove(index).1)
         } else {
             None
         }
@@ -201,13 +201,11 @@ impl<S> SessionMap<S> {
 
     pub fn get(&self, ws: &worker::WebSocket) -> Option<&S> {
         let index = self.index_of(&ws)?;
-        let (_, session) = self.0.get(index)?;
-        Some(session)
+        Some(&self.0[index].1)
     }
     pub fn get_mut(&mut self, ws: &worker::WebSocket) -> Option<&mut S> {
         let index = self.index_of(&ws)?;
-        let (_, session) = self.0.get_mut(index)?;
-        Some(session)
+        Some(&mut self.0[index].1)
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &(worker::WebSocket, S)> {


### PR DESCRIPTION
In `ws::SessionMap` on `rt_worker`,

- use `Vec::swap_remove` in `remove` instead of `Vec::remove` ( here not needed to preserve ordering of the remaining elements )
- omit redundant `None` check in `get`, `get_mut`