### PR TITLE
enhance: headers set optional value

### DIFF
--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -43,7 +43,7 @@ mews          = { version = "0.1", optional = true }
 
 
 [features]
-#default       = ["testing"]
+default       = ["testing"]
 
 rt_tokio      = ["__rt__", "__rt_native__", "dep:tokio",     "tokio/io-util", "tokio/macros",    "ohkami_lib/signal", "mews?/tokio"]
 rt_async-std  = ["__rt__", "__rt_native__", "dep:async-std", "dep:futures-util",                 "ohkami_lib/signal", "mews?/async-std"]
@@ -65,15 +65,15 @@ DEBUG = [
     "tokio?/rt-multi-thread",
     "async-std?/attributes",
 ]
-default = [
-    "nightly",
-    "testing",
-    "sse",
-    "ws",
-    #"rt_tokio",
-    #"rt_async-std",
-    #"rt_smol",
-    #"rt_glommio",
-    "rt_worker",
-    "DEBUG",
-]
+#default = [
+#    "nightly",
+#    "testing",
+#    "sse",
+#    "ws",
+#    #"rt_tokio",
+#    #"rt_async-std",
+#    #"rt_smol",
+#    #"rt_glommio",
+#    "rt_worker",
+#    "DEBUG",
+#]

--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -43,7 +43,7 @@ mews          = { version = "0.1", optional = true }
 
 
 [features]
-default       = ["testing"]
+#default       = ["testing"]
 
 rt_tokio      = ["__rt__", "__rt_native__", "dep:tokio",     "tokio/io-util", "tokio/macros",    "ohkami_lib/signal", "mews?/tokio"]
 rt_async-std  = ["__rt__", "__rt_native__", "dep:async-std", "dep:futures-util",                 "ohkami_lib/signal", "mews?/async-std"]
@@ -65,15 +65,15 @@ DEBUG = [
     "tokio?/rt-multi-thread",
     "async-std?/attributes",
 ]
-#default = [
-#    "nightly",
-#    "testing",
-#    "sse",
-#    "ws",
-#    #"rt_tokio",
-#    #"rt_async-std",
-#    #"rt_smol",
-#    #"rt_glommio",
-#    "rt_worker",
-#    "DEBUG",
-#]
+default = [
+    "nightly",
+    "testing",
+    "sse",
+    "ws",
+    #"rt_tokio",
+    #"rt_async-std",
+    #"rt_smol",
+    #"rt_glommio",
+    "rt_worker",
+    "DEBUG",
+]

--- a/ohkami/src/request/headers.rs
+++ b/ohkami/src/request/headers.rs
@@ -50,14 +50,7 @@ pub trait HeaderAction<'set> {
         }
     }
 
-    // remove
-    impl<'set> HeaderAction<'set> for () {
-        #[inline]
-        fn perform(self, set: SetHeaders<'set>, key: Header) -> SetHeaders<'set> {
-            set.0.remove(key);
-            set
-        }
-    }
+    // remove or insert
     impl<'set> HeaderAction<'set> for Option<Cow<'static, str>> {
         #[inline]
         fn perform(self, set: SetHeaders<'set>, key: Header) -> SetHeaders<'set> {
@@ -110,15 +103,7 @@ pub trait CustomHeadersAction<'set> {
         }
     }
 
-    // remove
-    impl<'set> CustomHeadersAction<'set> for () {
-        fn perform(self, set: SetHeaders<'set>, key: &'static str) -> SetHeaders<'set> {
-            if let Some(c) = &mut set.0.custom {
-                c.remove(&Slice::from_bytes(key.as_bytes()));
-            }
-            set
-        }
-    }
+    // remove or insert
     impl<'set> CustomHeadersAction<'set> for Option<Cow<'static, str>> {
         fn perform(self, set: SetHeaders<'set>, key: &'static str) -> SetHeaders<'set> {
             match self {

--- a/ohkami/src/request/mod.rs
+++ b/ohkami/src/request/mod.rs
@@ -152,10 +152,14 @@ pub struct Request {
     /// 
     /// `{action}`:
     /// - just `{value}` to insert
-    /// - `None` or `()` to remove
-    /// - `append({value})` to append
+    /// - `None` to remove
+    /// - `header::append({value})` to append
     /// 
-    /// `{value}`: `String`, `&'static str`, `Cow<&'static, str>`
+    /// `{value}`:
+    /// - `String`
+    /// - `&'static str`
+    /// - `Cow<'static, str>`
+    /// - `Some(Cow<'static, str>)`
     pub headers: RequestHeaders,
 
     pub payload: Option<CowSlice>,

--- a/ohkami/src/request/mod.rs
+++ b/ohkami/src/request/mod.rs
@@ -152,7 +152,7 @@ pub struct Request {
     /// 
     /// `{action}`:
     /// - just `{value}` to insert
-    /// - `None` to remove
+    /// - `None` or `()` to remove
     /// - `append({value})` to append
     /// 
     /// `{value}`: `String`, `&'static str`, `Cow<&'static, str>`

--- a/ohkami/src/response/headers.rs
+++ b/ohkami/src/response/headers.rs
@@ -50,13 +50,7 @@ pub trait HeaderAction<'action> {
         }
     }
 
-    // remove
-    impl<'a> HeaderAction<'a> for () {
-        #[inline] fn perform(self, set: SetHeaders<'a>, key: Header) -> SetHeaders<'a> {
-            set.0.remove(key);
-            set
-        }
-    }
+    // remove or insert
     impl<'a> HeaderAction<'a> for Option<Cow<'static, str>> {
         #[inline] fn perform(self, set: SetHeaders<'a>, key: Header) -> SetHeaders<'a> {
             match self {
@@ -99,14 +93,7 @@ pub trait CustomHeadersAction<'action> {
         }
     }
 
-    /* remove */
-    impl<'set> CustomHeadersAction<'set> for () {
-        #[inline]
-        fn perform(self, set: SetHeaders<'set>, key: &'static str) -> SetHeaders<'set> {
-            set.0.remove_custom(key);
-            set
-        }
-    }
+    /* remove or insert */
     impl<'set> CustomHeadersAction<'set> for Option<Cow<'static, str>> {
         #[inline]
         fn perform(self, set: SetHeaders<'set>, key: &'static str) -> SetHeaders<'set> {

--- a/ohkami/src/response/headers.rs
+++ b/ohkami/src/response/headers.rs
@@ -22,14 +22,6 @@ pub struct SetHeaders<'set>(
 pub trait HeaderAction<'action> {
     fn perform(self, set: SetHeaders<'action>, key: Header) -> SetHeaders<'action>;
 } const _: () = {
-    // remove
-    impl<'a> HeaderAction<'a> for Option<()> {
-        #[inline] fn perform(self, set: SetHeaders<'a>, key: Header) -> SetHeaders<'a> {
-            set.0.remove(key);
-            set
-        }
-    }
-
     // append
     impl<'a> HeaderAction<'a> for Append {
         #[inline] fn perform(self, set: SetHeaders<'a>, key: Header) -> SetHeaders<'a> {
@@ -57,20 +49,28 @@ pub trait HeaderAction<'action> {
             set
         }
     }
+
+    // remove
+    impl<'a> HeaderAction<'a> for () {
+        #[inline] fn perform(self, set: SetHeaders<'a>, key: Header) -> SetHeaders<'a> {
+            set.0.remove(key);
+            set
+        }
+    }
+    impl<'a> HeaderAction<'a> for Option<Cow<'static, str>> {
+        #[inline] fn perform(self, set: SetHeaders<'a>, key: Header) -> SetHeaders<'a> {
+            match self {
+                None => set.0.remove(key),
+                Some(v) => set.0.insert(key, v),
+            }
+            set
+        }
+    }
 };
 
 pub trait CustomHeadersAction<'action> {
     fn perform(self, set: SetHeaders<'action>, key: &'static str) -> SetHeaders<'action>;
 } const _: () = {
-    /* remove */
-    impl<'set> CustomHeadersAction<'set> for Option<()> {
-        #[inline]
-        fn perform(self, set: SetHeaders<'set>, key: &'static str) -> SetHeaders<'set> {
-            set.0.remove_custom(key);
-            set
-        }
-    }
-
     /* append */
     impl<'set> CustomHeadersAction<'set> for Append {
         fn perform(self, set: SetHeaders<'set>, key: &'static str) -> SetHeaders<'set> {
@@ -95,6 +95,25 @@ pub trait CustomHeadersAction<'action> {
     impl<'set> CustomHeadersAction<'set> for Cow<'static, str> {
         fn perform(self, set: SetHeaders<'set>, key: &'static str) -> SetHeaders<'set> {
             set.0.insert_custom(key, self);
+            set
+        }
+    }
+
+    /* remove */
+    impl<'set> CustomHeadersAction<'set> for () {
+        #[inline]
+        fn perform(self, set: SetHeaders<'set>, key: &'static str) -> SetHeaders<'set> {
+            set.0.remove_custom(key);
+            set
+        }
+    }
+    impl<'set> CustomHeadersAction<'set> for Option<Cow<'static, str>> {
+        #[inline]
+        fn perform(self, set: SetHeaders<'set>, key: &'static str) -> SetHeaders<'set> {
+            match self {
+                None => set.0.remove_custom(key),
+                Some(v) => set.0.insert_custom(key, v),
+            }
             set
         }
     }

--- a/ohkami/src/response/mod.rs
+++ b/ohkami/src/response/mod.rs
@@ -101,10 +101,14 @@ pub struct Response {
     /// 
     /// `{action}`:
     /// - just `{value}` to insert
-    /// - `None` or `()` to remove
-    /// - `append({value})` to append
+    /// - `None` to remove
+    /// - `header::append({value})` to append
     /// 
-    /// `{value}`: `String`, `&'static str`, `Cow<&'static, str>`
+    /// `{value}`:
+    /// - `String`
+    /// - `&'static str`
+    /// - `Cow<'static, str>`
+    /// - `Some(Cow<'static, str>)`
     pub headers: ResponseHeaders,
 
     pub(crate) content: Content,

--- a/ohkami/src/response/mod.rs
+++ b/ohkami/src/response/mod.rs
@@ -101,7 +101,7 @@ pub struct Response {
     /// 
     /// `{action}`:
     /// - just `{value}` to insert
-    /// - `None` to remove
+    /// - `None` or `()` to remove
     /// - `append({value})` to append
     /// 
     /// `{value}`: `String`, `&'static str`, `Cow<&'static, str>`


### PR DESCRIPTION
Support

```rust
{req/res}.headers.set()
    .Header(if cond {Some("value".into())} else {None})
```

`Some()` can only hold direct `Cow<'static, str>` for `None` convention ( if this is generic, `.set().Header(None)` to remove is to *need type annotation* )