### PR TITLE
perf: custom headers: use `Vec<(K, V)>` instead of `FxHashMap<K, V>`

### DIFF
--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -69,10 +69,10 @@ DEBUG = [
 #    "testing",
 #    "sse",
 #    "ws",
-#    #"rt_tokio",
+#    "rt_tokio",
 #    #"rt_async-std",
 #    #"rt_smol",
 #    #"rt_glommio",
-#    "rt_worker",
+#    #"rt_worker",
 #    "DEBUG",
 #]

--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -31,7 +31,6 @@ byte_reader   = { workspace = true }
 serde         = { workspace = true }
 
 serde_json    = { version = "1.0" }
-rustc-hash    = { version = "2.0" }
 
 base64        = { version = "0.22" }
 hmac          = { version = "0.12", default-features = false }

--- a/ohkami/src/header/map.rs
+++ b/ohkami/src/header/map.rs
@@ -7,7 +7,7 @@ pub(crate) struct IndexMap<const N: usize, Value> {
 /// 
 /// Usually, a web app handles 0 ~ 4 custom headers, and so
 /// simple `Vec<(K, V)>` is efficient than `HashMap<K, V>`
-/// to store/iterate/search.
+/// to store/iterate/mutate.
 pub(crate) struct TupleMap<K: PartialEq, V>(
     Vec<(K, V)>
 );

--- a/ohkami/src/header/map.rs
+++ b/ohkami/src/header/map.rs
@@ -100,6 +100,10 @@ impl<K: PartialEq, V> TupleMap<K, V> {
         }; None
     }
 
+    pub(crate) fn clear(&mut self) {
+        self.0.clear();
+    }
+
     pub(crate) fn iter(&self) -> impl Iterator<Item = &(K, V)> {
         self.0.iter()
     }

--- a/ohkami/src/header/map.rs
+++ b/ohkami/src/header/map.rs
@@ -3,6 +3,15 @@ pub(crate) struct IndexMap<const N: usize, Value> {
     values: Vec<(usize, Value)>,
 }
 
+/// Key-Value map mainly used to store custom headers.
+/// 
+/// Usually, a web app handles 0 ~ 4 custom headers, and so
+/// simple `Vec<(K, V)>` is efficient than `HashMap<K, V>`
+/// to store/iterate/search.
+pub(crate) struct TupleMap<K: PartialEq, V>(
+    Vec<(K, V)>
+);
+
 impl<const N: usize, Value> IndexMap<N, Value> {
     const NULL: u8 = u8::MAX;
 
@@ -54,6 +63,48 @@ impl<const N: usize, Value> IndexMap<N, Value> {
     }
 }
 
+impl<K: PartialEq, V> TupleMap<K, V> {
+    pub(crate) fn new() -> Self {
+        Self(Vec::new())
+    }
+    pub(crate) fn from_iter<const N: usize>(iter: [(K, V); N]) -> Self {
+        Self(Vec::from(iter))
+    }
+
+    #[inline]
+    pub(crate) fn get(&self, key: &K) -> Option<&V> {
+        for (k, v) in &self.0 {
+            if key == k {return Some(v)}
+        }; None
+    }
+    #[inline]
+    pub(crate) fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+        for (k, v) in &mut self.0 {
+            if key == k {return Some(v)}
+        }; None
+    }
+
+    #[inline]
+    pub(crate) fn insert(&mut self, key: K, value: V) -> Option<V> {
+        for (k, v) in &mut self.0 {
+            if &key == k {return Some(std::mem::replace(v, value))}
+        }; {self.0.push((key, value)); None}
+    }
+
+    #[inline]
+    pub(crate) fn remove(&mut self, key: K) -> Option<V> {
+        for i in 0..self.0.len() {
+            if &key == &unsafe {self.0.get_unchecked(i)}.0 {
+                return Some(self.0.swap_remove(i).1)
+            }
+        }; None
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &(K, V)> {
+        self.0.iter()
+    }
+}
+
 const _: () = {
     impl<const N: usize, Value: PartialEq> PartialEq for IndexMap<N, Value> {
         fn eq(&self, other: &Self) -> bool {
@@ -71,6 +122,18 @@ const _: () = {
                 index:  self.index.clone(),
                 values: self.values.clone(),
             }
+        }
+    }
+
+    impl<K: PartialEq, V: PartialEq> PartialEq for TupleMap<K, V> {
+        fn eq(&self, other: &Self) -> bool {
+            self.0 == other.0
+        }
+    }
+
+    impl<K: Clone + PartialEq, V: Clone> Clone for TupleMap<K, V> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
         }
     }
 };

--- a/ohkami/src/header/mod.rs
+++ b/ohkami/src/header/mod.rs
@@ -8,4 +8,4 @@ mod setcookie;
 pub(crate) use setcookie::*;
 
 mod map;
-pub(crate) use map::IndexMap;
+pub(crate) use map::{IndexMap, TupleMap};

--- a/ohkami/src/response/headers.rs
+++ b/ohkami/src/response/headers.rs
@@ -453,7 +453,7 @@ impl Headers {
             }
         }
         if let Some(custom) = self.custom.as_ref() {
-            for (k, v) in &**custom {
+            for (k, v) in custom.iter() {
                 crate::push_unchecked!(buf <- k.as_bytes());
                 crate::push_unchecked!(buf <- b": ");
                 crate::push_unchecked!(buf <- v.as_bytes());


### PR DESCRIPTION
replace custom headers store with

```rust
/// Key-Value map mainly used to store custom headers.
/// 
/// Usually, a web app handles 0 ~ 4 custom headers, and so
/// simple `Vec<(K, V)>` is efficient than `HashMap<K, V>`
/// to store/iterate/mutate.
pub(crate) struct TupleMap<K: PartialEq, V>(
    Vec<(K, V)>
);
```