### PR TITLE
rename(headers): set `.custom()` -> `.__()` / get `.custom()` -> `.get()`

### DIFF
--- a/ohkami/src/header/map.rs
+++ b/ohkami/src/header/map.rs
@@ -100,6 +100,7 @@ impl<K: PartialEq, V> TupleMap<K, V> {
         }; None
     }
 
+    #[allow(unused)]
     pub(crate) fn clear(&mut self) {
         self.0.clear();
     }

--- a/ohkami/src/request/_test_headers.rs
+++ b/ohkami/src/request/_test_headers.rs
@@ -24,8 +24,8 @@ use crate::header::append;
 #[test] fn append_custom_header() {
     let mut h = RequestHeaders::init();
 
-    h.set().custom("Custom-Header", append("A"));
-    assert_eq!(h.custom("Custom-Header"), Some("A"));
-    h.set().custom("Custom-Header", append("B"));
-    assert_eq!(h.custom("Custom-Header"), Some("A, B"));
+    h.set().__("Custom-Header", append("A"));
+    assert_eq!(h.get("Custom-Header"), Some("A"));
+    h.set().__("Custom-Header", append("B"));
+    assert_eq!(h.get("Custom-Header"), Some("A, B"));
 }

--- a/ohkami/src/response/_test.rs
+++ b/ohkami/src/response/_test.rs
@@ -56,7 +56,7 @@ async fn test_response_into_bytes() {
     let mut res = Response::NotFound();
     res.headers.set()
         .Server("ohkami")
-        .custom("Hoge-Header", "Something-Custom");
+        .__("Hoge-Header", "Something-Custom");
     assert_bytes_eq!(res, format!("\
         HTTP/1.1 404 Not Found\r\n\
         Server: ohkami\r\n\
@@ -69,7 +69,7 @@ async fn test_response_into_bytes() {
     let mut res = Response::NotFound();
     res.headers.set()
         .Server("ohkami")
-        .custom("Hoge-Header", "Something-Custom")
+        .__("Hoge-Header", "Something-Custom")
         .SetCookie("id", "42", |d|d.Path("/").SameSiteLax())
         .SetCookie("name", "John", |d|d.Path("/where").SameSiteStrict());
     assert_bytes_eq!(res, format!("\
@@ -86,7 +86,7 @@ async fn test_response_into_bytes() {
     let mut res = Response::NotFound().with_text("sample text");
     res.headers.set()
         .Server("ohkami")
-        .custom("Hoge-Header", "Something-Custom")
+        .__("Hoge-Header", "Something-Custom")
         .SetCookie("id", "42", |d|d.Path("/").SameSiteLax())
         .SetCookie("name", "John", |d|d.Path("/where").SameSiteStrict());
     assert_bytes_eq!(res, format!("\
@@ -144,7 +144,7 @@ async fn test_stream_response() {
         )
         .with_headers(|h| h
             .Server("ohkami")
-            .custom("is-stream", "true")
+            .__("is-stream", "true")
             .SetCookie("name", "John", |d|d.Path("/where").SameSiteStrict())
         );
     assert_bytes_eq!(res, format!("\
@@ -181,8 +181,8 @@ async fn test_stream_response() {
         )
         .with_headers(|h| h
             .Server("ohkami")
-            .custom("is-stream", "true")
             .SetCookie("name", "John", |d|d.Path("/where").SameSiteStrict())
+            .__("is-stream", "true")
         );
     assert_bytes_eq!(res, format!("\
         HTTP/1.1 200 OK\r\n\

--- a/ohkami/src/response/_test_headers.rs
+++ b/ohkami/src/response/_test_headers.rs
@@ -58,8 +58,8 @@ use super::ResponseHeaders;
 #[test] fn append_custom_header() {
     let mut h = ResponseHeaders::new();
 
-    h.set().custom("Custom-Header", append("A"));
-    assert_eq!(h.custom("Custom-Header"), Some("A"));
+    h.set().__("Custom-Header", append("A"));
+    assert_eq!(h.get("Custom-Header"), Some("A"));
     {
         let mut buf = Vec::new();
         h._write_to(&mut buf);
@@ -69,8 +69,8 @@ use super::ResponseHeaders;
         ");
     }
 
-    h.set().custom("Custom-Header", append("B"));
-    assert_eq!(h.custom("Custom-Header"), Some("A, B"));
+    h.set().__("Custom-Header", append("B"));
+    assert_eq!(h.get("Custom-Header"), Some("A, B"));
     {
         let mut buf = Vec::new();
         h._write_to(&mut buf);

--- a/ohkami/src/response/mod.rs
+++ b/ohkami/src/response/mod.rs
@@ -94,8 +94,8 @@ pub struct Response {
 
     /// Headers of this response
     /// 
-    /// - `.{Name}()`, `.custom({Name})` to get the value
-    /// - `.set().{Name}({action})`, `.set().custom({Name}, {action})` to mutate the values
+    /// - `.{Name}()`, `.get({Name})` to get the value
+    /// - `.set().{Name}({action})`, `.set().__({Name}, {action})` to mutate the value
     /// 
     /// ---
     /// 

--- a/ohkami/src/testing/mod.rs
+++ b/ohkami/src/testing/mod.rs
@@ -29,7 +29,6 @@
 
 use crate::{Response, Request, Ohkami, Status, Method};
 use crate::ohkami::router::RadixRouter;
-use crate::response::ResponseHeader;
 
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -188,9 +187,7 @@ impl TestResponse {
     }
 
     pub fn header(&self, name: &'static str) -> Option<&str> {
-        ResponseHeader::from_bytes(name.as_bytes())
-            .and_then(|h| self.0.headers.get(h))
-            .or_else(|| self.0.headers.get_custom(name))
+        self.0.headers.get(name)
     }
     pub fn headers(&self) -> impl Iterator<Item = (&str, &str)> {
         self.0.headers.iter()


### PR DESCRIPTION
for ease of viewing