### PR TITLE
refactor: runtime abstraction

### DIFF
--- a/benches_rt/glommio/Cargo.toml
+++ b/benches_rt/glommio/Cargo.toml
@@ -19,3 +19,6 @@ incremental = false
 codegen-units = 1
 rpath = false
 strip = false
+
+[features]
+DEBUG = ["ohkami/DEBUG"]

--- a/benches_rt/smol/Cargo.toml
+++ b/benches_rt/smol/Cargo.toml
@@ -19,3 +19,6 @@ incremental = false
 codegen-units = 1
 rpath = false
 strip = false
+
+[features]
+DEBUG = ["ohkami/DEBUG"]

--- a/benches_rt/tokio/Cargo.toml
+++ b/benches_rt/tokio/Cargo.toml
@@ -19,3 +19,6 @@ incremental = false
 codegen-units = 1
 rpath = false
 strip = false
+
+[features]
+DEBUG = ["ohkami/DEBUG"]

--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -43,7 +43,7 @@ mews          = { version = "0.1",  optional = true }
 
 
 [features]
-#default       = ["testing"]
+default       = ["testing"]
 
 rt_tokio      = ["__rt__", "__rt_native__", "dep:tokio",     "tokio/io-util", "tokio/macros",    "mews?/tokio"]
 rt_async-std  = ["__rt__", "__rt_native__", "dep:async-std", "dep:futures-util",                 "mews?/async-std"]
@@ -62,15 +62,15 @@ __rt_native__ = ["dep:ctrlc"]
 
 ##### DEBUG #####
 DEBUG = ["tokio?/rt-multi-thread"]
-default = [
-    "nightly",
-    "testing",
-    "sse",
-    "ws",
-    #"rt_tokio",
-    #"rt_async-std",
-    #"rt_smol",
-    "rt_glommio",
-    #"rt_worker",
-    #"DEBUG",
-]
+#default = [
+#    "nightly",
+#    "testing",
+#    "sse",
+#    "ws",
+#    "rt_tokio",
+#    #"rt_async-std",
+#    #"rt_smol",
+#    #"rt_glommio",
+#    #"rt_worker",
+#    #"DEBUG",
+#]

--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -54,7 +54,7 @@ rt_worker     = ["__rt__", "dep:worker", "ohkami_macros/worker"]
 nightly       = []
 testing       = []
 sse           = ["ohkami_lib/stream"]
-ws            = ["dep:mews"]
+ws            = ["ohkami_lib/stream", "dep:mews"]
 
 ##### internal #####
 __rt__        = []

--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -36,40 +36,41 @@ base64        = { version = "0.22" }
 hmac          = { version = "0.12", default-features = false }
 sha2          = { version = "0.10", default-features = false }
 
+ctrlc         = { version = "3.4",  optional = true }
 num_cpus      = { version = "1.16", optional = true }
 futures-util  = { version = "0.3",  optional = true, default-features = false, features = ["io", "async-await-macro"] }
-mews          = { version = "0.1", optional = true }
+mews          = { version = "0.1",  optional = true }
 
 
 [features]
-default       = ["testing"]
+#default       = ["testing"]
 
-rt_tokio      = ["__rt__", "__rt_native__", "dep:tokio",     "tokio/io-util", "tokio/macros",    "ohkami_lib/signal", "mews?/tokio"]
-rt_async-std  = ["__rt__", "__rt_native__", "dep:async-std", "dep:futures-util",                 "ohkami_lib/signal", "mews?/async-std"]
-rt_smol       = ["__rt__", "__rt_native__", "dep:smol",      "dep:futures-util",                 "ohkami_lib/signal", "mews?/smol"]
-rt_glommio    = ["__rt__", "__rt_native__", "dep:glommio",   "dep:futures-util", "dep:num_cpus", "ohkami_lib/signal", "mews?/glommio"]
+rt_tokio      = ["__rt__", "__rt_native__", "dep:tokio",     "tokio/io-util", "tokio/macros",    "mews?/tokio"]
+rt_async-std  = ["__rt__", "__rt_native__", "dep:async-std", "dep:futures-util",                 "mews?/async-std"]
+rt_smol       = ["__rt__", "__rt_native__", "dep:smol",      "dep:futures-util",                 "mews?/smol"]
+rt_glommio    = ["__rt__", "__rt_native__", "dep:glommio",   "dep:futures-util", "dep:num_cpus", "mews?/glommio"]
 rt_worker     = ["__rt__", "dep:worker", "ohkami_macros/worker"]
 
 nightly       = []
 testing       = []
 sse           = ["ohkami_lib/stream"]
-ws            = ["ohkami_lib/stream", "dep:mews"]
+ws            = ["dep:mews"]
 
 ##### internal #####
 __rt__        = []
-__rt_native__ = []
+__rt_native__ = ["dep:ctrlc"]
 
 ##### DEBUG #####
 DEBUG = ["tokio?/rt-multi-thread"]
-#default = [
-#    "nightly",
-#    "testing",
-#    "sse",
-#    "ws",
-#    "rt_tokio",
-#    #"rt_async-std",
-#    #"rt_smol",
-#    #"rt_glommio",
-#    #"rt_worker",
-#    #"DEBUG",
-#]
+default = [
+    "nightly",
+    "testing",
+    "sse",
+    "ws",
+    "rt_tokio",
+    #"rt_async-std",
+    #"rt_smol",
+    #"rt_glommio",
+    #"rt_worker",
+    #"DEBUG",
+]

--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -67,10 +67,10 @@ default = [
     "testing",
     "sse",
     "ws",
-    "rt_tokio",
+    #"rt_tokio",
     #"rt_async-std",
     #"rt_smol",
-    #"rt_glommio",
+    "rt_glommio",
     #"rt_worker",
     #"DEBUG",
 ]

--- a/ohkami/src/lib.rs
+++ b/ohkami/src/lib.rs
@@ -42,12 +42,6 @@
     Can't activate multiple `rt_*` features at once!
 "}
 
-#[cfg(all(feature="sse", not(feature="__rt__")))]
-compile_error! {"Can't activate `sse` feature without a `rt_*` feature"}
-
-#[cfg(all(feature="ws", not(feature="__rt__")))]
-compile_error! {"Can't activate `ws` feature without a `rt_*` feature"}
-
 #[cfg(not(feature="DEBUG"))]
 #[cfg(all(feature="rt_worker", not(target_arch="wasm32")))]
 compile_error! {"

--- a/ohkami/src/ohkami/mod.rs
+++ b/ohkami/src/ohkami/mod.rs
@@ -479,7 +479,7 @@ mod sync {
                         } else {
                             #[cfg(any(feature="rt_tokio", feature="rt_async-std", feature="rt_smol"))] {
                                 let prev_waker = WAKER.swap(
-                                    cx.waker() as *const Waker as *mut Waker,
+                                    Box::into_raw(Box::new(cx.waker().clone())),
                                     Ordering::SeqCst
                                 );
                                 if !prev_waker.is_null() {
@@ -507,7 +507,7 @@ mod sync {
                     CATCH.store(true, Ordering::SeqCst);
                     let waker = WAKER.swap(null_mut(), Ordering::SeqCst);
                     if !waker.is_null() {
-                        unsafe {waker.read()}.wake();
+                        unsafe {Box::from_raw(waker)}.wake();
                     }
                 }).expect("Something went wrong with Ctrl-C");
 

--- a/ohkami/src/request/mod.rs
+++ b/ohkami/src/request/mod.rs
@@ -25,7 +25,7 @@ pub use from_request::*;
 use ohkami_lib::{Slice, CowSlice};
 
 #[cfg(feature="__rt_native__")]
-use crate::__rt__::AsyncReader;
+use crate::__rt__::AsyncRead;
 
 #[allow(unused)]
 use {
@@ -223,7 +223,7 @@ impl Request {
     #[inline]
     pub(crate) async fn read(
         mut self: Pin<&mut Self>,
-        stream:   &mut (impl AsyncReader + Unpin),
+        stream:   &mut (impl AsyncRead + Unpin),
     ) -> Result<Option<()>, crate::Response> {
         use crate::Response;
 
@@ -296,7 +296,7 @@ impl Request {
     #[cfg(feature="__rt_native__")]
     #[inline]
     async fn read_payload(
-        stream:        &mut (impl AsyncReader + Unpin),
+        stream:        &mut (impl AsyncRead + Unpin),
         remaining_buf: &[u8],
         size:          usize,
     ) -> CowSlice {

--- a/ohkami/src/response/mod.rs
+++ b/ohkami/src/response/mod.rs
@@ -19,7 +19,7 @@ use std::borrow::Cow;
 use ohkami_lib::{CowSlice, Slice};
 
 #[cfg(feature="__rt_native__")]
-use crate::__rt__::AsyncWriter;
+use crate::__rt__::AsyncWrite;
 #[cfg(feature="sse")]
 use crate::util::StreamExt;
 
@@ -329,7 +329,7 @@ impl Upgrade {
 impl Response {
     #[cfg_attr(not(feature="sse"), inline)]
     pub(crate) async fn send(mut self,
-        conn: &mut (impl AsyncWriter + Unpin)
+        conn: &mut (impl AsyncWrite + Unpin)
     ) -> Upgrade {
         self.complete();
 

--- a/ohkami/src/router/final.rs
+++ b/ohkami/src/router/final.rs
@@ -135,15 +135,15 @@ impl Pattern {
         bytes: &'b [u8],
         path:  &mut Path
     ) -> Option<&'b [u8]/* remaining part of `bytes` */> {
-        crate::DEBUG!("[Pattern::take_through] self: `{self:?}`, bytes: '{}'", bytes.escape_ascii());
+        //crate::DEBUG!("[Pattern::take_through] self: `{self:?}`, bytes: '{}'", bytes.escape_ascii());
         match self {
             Pattern::Static(s) => {
                 let size = s.len();
                 if bytes.len() >= size && *s == unsafe {bytes.get_unchecked(..size)} {
-                    crate::DEBUG!("[Pattern::take_through] Static => remaining = Some('{}')", bytes[size..].escape_ascii());
+                    //crate::DEBUG!("[Pattern::take_through] Static => remaining = Some('{}')", bytes[size..].escape_ascii());
                     Some(unsafe {bytes.get_unchecked(size..)})
                 } else {
-                    crate::DEBUG!("[Pattern::take_through] Static => remaining = None");
+                    //crate::DEBUG!("[Pattern::take_through] Static => remaining = None");
                     None
                 }
             }
@@ -153,10 +153,10 @@ impl Pattern {
                 && *unsafe {bytes.get_unchecked(1)} != b'/' {
                     let (param, remaining) = util::split_next_section(unsafe {bytes.get_unchecked(1..)});
                     unsafe {path.push_param(Slice::from_bytes(param))};
-                    crate::DEBUG!("[Pattern::take_through] Param => remaining = Some('{}')", remaining.escape_ascii());
+                    //crate::DEBUG!("[Pattern::take_through] Param => remaining = Some('{}')", remaining.escape_ascii());
                     Some(remaining)
                 } else {
-                    crate::DEBUG!("[Pattern::take_through] Param => remaining = None");
+                    //crate::DEBUG!("[Pattern::take_through] Param => remaining = None");
                     None
                 }
             }

--- a/ohkami_lib/src/lib.rs
+++ b/ohkami_lib/src/lib.rs
@@ -20,5 +20,3 @@ pub mod stream;
 #[cfg(feature="stream")]
 pub use stream::{Stream, StreamExt};
 
-#[cfg(feature="signal")]
-pub mod signal;

--- a/ohkami_lib/src/signal.rs
+++ b/ohkami_lib/src/signal.rs
@@ -1,2 +1,0 @@
-pub use ::tokio::signal::ctrl_c;
-pub use ::tokio::sync::watch;


### PR DESCRIPTION
closes #285

---

refactor codes around runtime-abstraction, with fixing https://github.com/ohkami-rs/ohkami/issues/285 and add a regression test ( `ohkami::can_howl_on_any_native_runtime` test )