### PR TITLE
chore: remove feature flag `testing` && export `testing` module behind `#[cfg(debug_assertions)]`

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -78,7 +78,7 @@ tasks:
       MAYBE_FEATURES_NIGHTLY:
         sh: cargo version | grep -q 'nightly' && echo '--features nightly' || echo ''
       MAYBE_FEATURES_NIGHTLY_full:
-        sh: cargo version | grep -q 'nightly' && echo '--features nightly,sse,ws' || echo '--features testing'
+        sh: cargo version | grep -q 'nightly' && echo '--features nightly,sse,ws' || echo '--features sse,ws'
     dir: ./ohkami
     cmds:
       - cargo check --lib {{.MAYBE_FEATURES_NIGHTLY}}

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -16,7 +16,7 @@ members  = [
 
 [workspace.dependencies]
 # set `default-features = false` to assure "DEBUG" feature be off even when DEBUGing `../ohkami`
-ohkami             = { path = "../ohkami", default-features = false, features = ["rt_tokio", "testing", "sse", "ws"] }
+ohkami             = { path = "../ohkami", default-features = false, features = ["rt_tokio", "sse", "ws"] }
 tokio              = { version = "1", features = ["full"] }
 sqlx               = { version = "0.7.3", features = ["runtime-tokio-native-tls", "postgres", "macros", "chrono", "uuid"] }
 tracing            = "0.1"

--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -44,8 +44,6 @@ mews          = { version = "0.2",  optional = true }
 
 
 [features]
-default       = ["testing"]
-
 rt_tokio      = ["__rt__", "__rt_native__", "dep:tokio",     "tokio/io-util", "tokio/macros",    "mews?/rt_tokio"    ]
 rt_async-std  = ["__rt__", "__rt_native__", "dep:async-std", "dep:futures-util",                 "mews?/rt_async-std"]
 rt_smol       = ["__rt__", "__rt_native__", "dep:smol",      "dep:futures-util",                 "mews?/rt_smol"     ]
@@ -54,7 +52,6 @@ rt_glommio    = ["__rt__", "__rt_native__", "dep:glommio",   "dep:futures-util",
 rt_worker     = ["__rt__", "dep:worker", "ohkami_macros/worker"]
 
 nightly       = []
-testing       = []
 sse           = ["ohkami_lib/stream"]
 ws            = ["ohkami_lib/stream", "dep:mews"]
 
@@ -66,7 +63,6 @@ __rt_native__ = ["dep:ctrlc"]
 DEBUG = ["tokio?/rt-multi-thread"]
 #default = [
 #    "nightly",
-#    "testing",
 #    "sse",
 #    "ws",
 #    "rt_tokio",

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -173,8 +173,8 @@ impl<Inner: FangProc> FangProc for CORSProc<Inner> {
 
 
 
+#[cfg(debug_assertions)]
 #[cfg(feature="rt_tokio")]
-#[cfg(feature="testing")]
 #[cfg(test)]
 mod test {
     use crate::prelude::*;

--- a/ohkami/src/fang/builtin/jwt.rs
+++ b/ohkami/src/fang/builtin/jwt.rs
@@ -375,8 +375,8 @@ impl<Payload: for<'de> Deserialize<'de>> JWT<Payload> {
 
 
 
+#[cfg(debug_assertions)]
 #[cfg(feature="rt_tokio")]
-#[cfg(feature="testing")]
 #[cfg(test)] mod test {
     use super::{JWT, JWTToken};
     use crate::__rt__::test;

--- a/ohkami/src/fang/builtin/timeout.rs
+++ b/ohkami/src/fang/builtin/timeout.rs
@@ -75,7 +75,7 @@ const _: () = {
 };
 
 
-#[cfg(all(test, feature="testing", feature="rt_tokio"))]
+#[cfg(all(test, debug_assertions, feature="rt_tokio"))]
 #[crate::__rt__::test] async fn test_timeout() {
     use crate::prelude::*;
     use crate::testing::*;

--- a/ohkami/src/fang/middleware/util.rs
+++ b/ohkami/src/fang/middleware/util.rs
@@ -111,7 +111,7 @@ pub trait FangAction: Clone + Send + Sync + 'static {
 
 
 
-#[cfg(all(test, feature="testing", feature="rt_tokio"))]
+#[cfg(all(test, debug_assertions, feature="rt_tokio"))]
 mod test {
     use super::*;
     use crate::prelude::*;

--- a/ohkami/src/lib.rs
+++ b/ohkami/src/lib.rs
@@ -154,7 +154,7 @@ mod __rt__ {
         glommio::spawn_local(task).detach();
     }
 
-    #[cfg(all(test, feature="testing"))]
+    #[cfg(all(test, debug_assertions))]
     pub(crate) mod testing {
         pub(crate) fn block_on(future: impl std::future::Future) {
             #[cfg(feature="rt_tokio")]
@@ -222,7 +222,7 @@ pub mod typed;
 #[cfg(feature="ws")]
 pub mod ws;
 
-#[cfg(feature="testing")]
+#[cfg(debug_assertions)]
 #[cfg(feature="__rt__")]
 pub mod testing;
 

--- a/ohkami/src/ohkami/_test.rs
+++ b/ohkami/src/ohkami/_test.rs
@@ -1,5 +1,5 @@
 #![allow(non_snake_case)]
-#![cfg(feature="testing")]
+#![cfg(debug_assertions)]
 #![cfg(feature="rt_tokio")] // for `#[__rt__::test]`
 
 use crate::__rt__;

--- a/ohkami/src/ohkami/mod.rs
+++ b/ohkami/src/ohkami/mod.rs
@@ -528,7 +528,7 @@ mod sync {
     };
 }
 
-#[cfg(all(feature="testing", feature="__rt_native__"))]
+#[cfg(all(debug_assertions, feature="__rt_native__"))]
 #[cfg(test)]
 #[test] fn can_howl_on_any_native_async_runtime() {
     __rt__::testing::block_on(async {

--- a/ohkami/src/request/_test_extract.rs
+++ b/ohkami/src/request/_test_extract.rs
@@ -1,5 +1,5 @@
+#![cfg(debug_assertions)]
 #![cfg(feature="rt_tokio")]
-#![cfg(feature="testing")]
 
 use crate::prelude::*;
 use crate::testing::*;

--- a/ohkami/src/request/_test_headers.rs
+++ b/ohkami/src/request/_test_headers.rs
@@ -1,4 +1,4 @@
-#![cfg(any(feature="testing", feature="DEBUG"))]
+#![cfg(any(debug_assertions, feature="DEBUG"))]
 #![cfg(feature="__rt__")]
 
 use ohkami_lib::CowSlice;

--- a/ohkami/src/request/mod.rs
+++ b/ohkami/src/request/mod.rs
@@ -330,7 +330,7 @@ impl Request {
     }
 
     #[cfg(feature="rt_worker")]
-    #[cfg(feature="testing")]
+    #[cfg(debug_assertions)]
     pub(crate) async fn read(mut self: Pin<&mut Self>,
         raw_bytes: &mut &[u8]
     ) -> Result<Option<()>, crate::Response> {

--- a/ohkami/src/testing/mod.rs
+++ b/ohkami/src/testing/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(debug_assertions)]
+
 //! Ohkami testing tools
 //! 
 //! <br>


### PR DESCRIPTION
- This simplifies the design of feature flags.
- `testing` module is automatically excluded in release build ( no one will like to opt out this behavior ).