### PR TITLE
rename: `SetHeaders`: `.__()` -> `.x()`

### DIFF
--- a/benches/benches/response_headers.rs
+++ b/benches/benches/response_headers.rs
@@ -35,8 +35,8 @@ use ohkami_benches::response_headers::{
             .ProxyAuthenticate(black_box("Basic realm=\"Access to the internal site\""))
             .ReferrerPolicy(black_box("same-origin"))
             .XFrameOptions(black_box("DENY"))
-            .__("x-myapp-data", black_box("myappdata; excellent"))
-            .__("something", black_box("anything"))
+            .x("x-myapp-data", black_box("myappdata; excellent"))
+            .x("something", black_box("anything"))
         ;
     });
 }
@@ -81,8 +81,8 @@ use ohkami_benches::response_headers::{
             .ProxyAuthenticate(black_box("Basic realm=\"Access to the internal site\""))
             .ReferrerPolicy(black_box("same-origin"))
             .XFrameOptions(black_box("DENY"))
-            .__("x-myapp-data", black_box("myappdata; excellent"))
-            .__("something", black_box("anything"))
+            .x("x-myapp-data", black_box("myappdata; excellent"))
+            .x("something", black_box("anything"))
         ;
     });
 }
@@ -220,8 +220,8 @@ use ohkami_benches::response_headers::{
         .ProxyAuthenticate(black_box("Basic realm=\"Access to the internal site\""))
         .ReferrerPolicy(black_box("same-origin"))
         .XFrameOptions(black_box("DENY"))
-        .__("x-myapp-data", black_box("myappdata; excellent"))
-        .__("something", black_box("anything"))
+        .x("x-myapp-data", black_box("myappdata; excellent"))
+        .x("something", black_box("anything"))
     ;
 
     b.iter(|| {
@@ -240,8 +240,8 @@ use ohkami_benches::response_headers::{
             .ProxyAuthenticate(None)
             .ReferrerPolicy(None)
             .XFrameOptions(None)
-            .__("x-myapp-data", None)
-            .__("something", None)
+            .x("x-myapp-data", None)
+            .x("something", None)
         ;
     });
 }
@@ -474,8 +474,8 @@ use ohkami_benches::response_headers::{
         .ProxyAuthenticate(black_box("Basic realm=\"Access to the internal site\""))
         .ReferrerPolicy(black_box("same-origin"))
         .XFrameOptions(black_box("DENY"))
-        .__("x-myapp-data", black_box("myappdata; excellent"))
-        .__("something", black_box("anything"))
+        .x("x-myapp-data", black_box("myappdata; excellent"))
+        .x("something", black_box("anything"))
     ;
 
     let mut buf = Vec::new();

--- a/ohkami/src/request/_test_headers.rs
+++ b/ohkami/src/request/_test_headers.rs
@@ -24,8 +24,8 @@ use crate::header::append;
 #[test] fn append_custom_header() {
     let mut h = RequestHeaders::init();
 
-    h.set().__("Custom-Header", append("A"));
+    h.set().x("Custom-Header", append("A"));
     assert_eq!(h.get("Custom-Header"), Some("A"));
-    h.set().__("Custom-Header", append("B"));
+    h.set().x("Custom-Header", append("B"));
     assert_eq!(h.get("Custom-Header"), Some("A, B"));
 }

--- a/ohkami/src/request/headers.rs
+++ b/ohkami/src/request/headers.rs
@@ -164,11 +164,11 @@ macro_rules! Header {
                 }
             )*
 
-            #[deprecated = "use `.__` instead"]
+            #[deprecated = "use `.x` instead"]
             pub fn custom(self, name: &'static str, action: impl CustomHeadersAction<'set>) -> Self {
-                self.__(name, action)
+                self.x(name, action)
             }
-            pub fn __(self, name: &'static str, action: impl CustomHeadersAction<'set>) -> Self {
+            pub fn x(self, name: &'static str, action: impl CustomHeadersAction<'set>) -> Self {
                 if self.0.custom.is_none() {
                     self.0.custom = Some(Box::new(TupleMap::new()));
                 }

--- a/ohkami/src/request/mod.rs
+++ b/ohkami/src/request/mod.rs
@@ -145,8 +145,8 @@ pub struct Request {
 
     /// Headers of this request
     /// 
-    /// - `.{Name}()`, `.custom({Name})` to get the value
-    /// - `.set().{Name}({action})`, `.set().custom({Name}, {action})` to mutate the values
+    /// - `.{Name}()`, `.get({Name})` to get the value
+    /// - `.set().{Name}({action})`, `.set().x({Name}, {action})` to mutate the values
     /// 
     /// ---
     /// 

--- a/ohkami/src/response/_test.rs
+++ b/ohkami/src/response/_test.rs
@@ -53,7 +53,7 @@ async fn test_response_into_bytes() {
     let mut res = Response::NotFound();
     res.headers.set()
         .Server("ohkami")
-        .__("Hoge-Header", "Something-Custom");
+        .x("Hoge-Header", "Something-Custom");
     assert_bytes_eq!(res, format!("\
         HTTP/1.1 404 Not Found\r\n\
         Server: ohkami\r\n\
@@ -66,7 +66,7 @@ async fn test_response_into_bytes() {
     let mut res = Response::NotFound();
     res.headers.set()
         .Server("ohkami")
-        .__("Hoge-Header", "Something-Custom")
+        .x("Hoge-Header", "Something-Custom")
         .SetCookie("id", "42", |d|d.Path("/").SameSiteLax())
         .SetCookie("name", "John", |d|d.Path("/where").SameSiteStrict());
     assert_bytes_eq!(res, format!("\
@@ -83,7 +83,7 @@ async fn test_response_into_bytes() {
     let mut res = Response::NotFound().with_text("sample text");
     res.headers.set()
         .Server("ohkami")
-        .__("Hoge-Header", "Something-Custom")
+        .x("Hoge-Header", "Something-Custom")
         .SetCookie("id", "42", |d|d.Path("/").SameSiteLax())
         .SetCookie("name", "John", |d|d.Path("/where").SameSiteStrict());
     assert_bytes_eq!(res, format!("\
@@ -139,7 +139,7 @@ async fn test_stream_response() {
         )
         .with_headers(|h| h
             .Server("ohkami")
-            .__("is-stream", "true")
+            .x("is-stream", "true")
             .SetCookie("name", "John", |d|d.Path("/where").SameSiteStrict())
         );
     assert_bytes_eq!(res, format!("\
@@ -177,7 +177,7 @@ async fn test_stream_response() {
         .with_headers(|h| h
             .Server("ohkami")
             .SetCookie("name", "John", |d|d.Path("/where").SameSiteStrict())
-            .__("is-stream", "true")
+            .x("is-stream", "true")
         );
     assert_bytes_eq!(res, format!("\
         HTTP/1.1 200 OK\r\n\

--- a/ohkami/src/response/_test_headers.rs
+++ b/ohkami/src/response/_test_headers.rs
@@ -58,7 +58,7 @@ use super::ResponseHeaders;
 #[test] fn append_custom_header() {
     let mut h = ResponseHeaders::new();
 
-    h.set().__("Custom-Header", append("A"));
+    h.set().x("Custom-Header", append("A"));
     assert_eq!(h.get("Custom-Header"), Some("A"));
     {
         let mut buf = Vec::new();
@@ -69,7 +69,7 @@ use super::ResponseHeaders;
         ");
     }
 
-    h.set().__("Custom-Header", append("B"));
+    h.set().x("Custom-Header", append("B"));
     assert_eq!(h.get("Custom-Header"), Some("A, B"));
     {
         let mut buf = Vec::new();

--- a/ohkami/src/response/headers.rs
+++ b/ohkami/src/response/headers.rs
@@ -157,12 +157,12 @@ macro_rules! Header {
                 }
             )*
 
-            #[deprecated = "use `.__` instead"]
+            #[deprecated = "use `.x` instead"]
             pub fn custom(self, name: &'static str, action: impl CustomHeadersAction<'set>) -> Self {
-                self.__(name, action)
+                self.x(name, action)
             }
             #[inline]
-            pub fn __(self, name: &'static str, action: impl CustomHeadersAction<'set>) -> Self {
+            pub fn x(self, name: &'static str, action: impl CustomHeadersAction<'set>) -> Self {
                 action.perform(self, name)
             }
         }
@@ -520,7 +520,7 @@ const _: () = {
             for (k, v) in iter {
                 match Header::from_bytes(k.as_bytes()) {
                     Some(h) => this.insert(h, v.into()),
-                    None    => {this.set().__(k, v.into());}
+                    None    => {this.set().x(k, v.into());}
                 }
             }
             this

--- a/ohkami/src/response/mod.rs
+++ b/ohkami/src/response/mod.rs
@@ -94,7 +94,7 @@ pub struct Response {
     /// Headers of this response
     /// 
     /// - `.{Name}()`, `.get({Name})` to get the value
-    /// - `.set().{Name}({action})`, `.set().__({Name}, {action})` to mutate the value
+    /// - `.set().{Name}({action})`, `.set().x({Name}, {action})` to mutate the value
     /// 
     /// ---
     /// 


### PR DESCRIPTION
`.__` is too eccentric...