### PR TITLE
docs: update doc comment for current `OHKAMI_*` environment variables

### DIFF
--- a/ohkami/src/ohkami/mod.rs
+++ b/ohkami/src/ohkami/mod.rs
@@ -251,8 +251,9 @@ impl Ohkami {
     /// - `smol::net::AsyncToSocketAddrs` if using `smol`
     /// - `std::net::ToSocketAddrs` if using `nio` or `glommio`
     /// 
-    /// *note* : Keep-Alive timeout is 42 seconds and this is not
-    /// configureable by user (it'll be in future version...)
+    /// *note* : Keep-Alive timeout is 42 seconds by default.
+    /// This is configureable by `OHKAMI_KEEPALIVE_TIMEOUT`
+    /// environment variable.
     /// 
     /// <br>
     /// 

--- a/ohkami/src/ws/mod.rs
+++ b/ohkami/src/ws/mod.rs
@@ -10,6 +10,12 @@ pub use self::worker::*;
 
 /// # Context for WebSocket handshake
 /// 
+/// `.upgrade` performs handshake and creates a WebSocket session.
+/// 
+/// *note* : The session is timeout in 1 hour by default.
+/// This is configurable by `OHKAMI_WEBSOCKET_TIMEOUT`
+/// environment variable.
+/// 
 /// <br>
 /// 
 /// *example.rs*

--- a/ohkami/src/ws/mod.rs
+++ b/ohkami/src/ws/mod.rs
@@ -12,8 +12,8 @@ pub use self::worker::*;
 /// 
 /// `.upgrade` performs handshake and creates a WebSocket session.
 /// 
-/// *note* : The session is timeout in 1 hour by default.
-/// This is configurable by `OHKAMI_WEBSOCKET_TIMEOUT`
+/// *note* : The session is timeout in 3600 seconds ( = 1 hour )
+/// by default. This is configurable by `OHKAMI_WEBSOCKET_TIMEOUT`
 /// environment variable.
 /// 
 /// <br>


### PR DESCRIPTION
- `OHKAMI_KEEPALIVE_TIMEOUT` ( secs; default: 42 )
- `OHKAMI_WEBSOCKET_TIMEOUT` ( secs; default: 3600 )