### PR TITLE
feat: pass fangs via `Ohkami::new`

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,12 +269,14 @@ impl FangAction for GreetingFang {
 
 #[tokio::main]
 async fn main() {
-    // `with` registers to a Ohkami
-    Ohkami::with(GreetingFang(1), (
+    Ohkami::new((
+        // register fangs to a Ohkami
+        GreetingFang(1),
+        
         "/hello"
             .GET(|| async {"Hello, fangs!"})
             .POST((
-                // This registers *local fangs* to a handler
+                // register *local fangs* to a handler
                 GreetingFang(2),
                 || async {"I'm `POST /hello`!"}
             ))

--- a/examples/basic_auth/src/main.rs
+++ b/examples/basic_auth/src/main.rs
@@ -3,14 +3,16 @@ use ohkami::fang::BasicAuth;
 
 #[tokio::main]
 async fn main() {
+    let private_ohkami = Ohkami::new((
+        BasicAuth {
+            username: "master of hello",
+            password: "world"
+        },
+        "/hello".GET(|| async {"Hello, private :)"})
+    ));
+
     Ohkami::new((
         "/hello".GET(|| async {"Hello, public!"}),
-        "/private".By(Ohkami::with(
-            BasicAuth {
-                username: "master of hello",
-                password: "world"
-            },
-            "/hello".GET(|| async {"Hello, private :)"})
-        ))
+        "/private".By(private_ohkami)
     )).howl("localhost:8888").await
 }

--- a/examples/chatgpt/src/main.rs
+++ b/examples/chatgpt/src/main.rs
@@ -19,8 +19,10 @@ async fn main() {
         curl -v 'http://localhost:5050/chat-once' -H 'Content-Type: text/plain' -d '＜your question＞'\n\
     ");
 
-    Ohkami::with(api_key, (
-        "/chat-once".POST(relay_chat_completion),
+    Ohkami::new((
+        api_key,
+        "/chat-once"
+            .POST(relay_chat_completion),
     )).howl("localhost:5050").await
 }
 

--- a/examples/form/src/main.rs
+++ b/examples/form/src/main.rs
@@ -24,7 +24,8 @@ struct FormData<'req> {
 }
 
 async fn post_submit(
-    Multipart(form): Multipart<FormData<'_>>) -> NoContent {
+    Multipart(form): Multipart<FormData<'_>>
+) -> NoContent {
     println!("\n\
         ===== submit =====\n\
         [account name] {:?}\n\
@@ -52,7 +53,7 @@ impl FangAction for Logger {
 
 #[tokio::main]
 async fn main() {
-    Ohkami::with((Logger,), (
+    Ohkami::new((Logger,
         "/form"  .GET(get_form),
         "/submit".POST(post_submit),
     )).howl("localhost:5000").await

--- a/examples/hello/src/main.rs
+++ b/examples/hello/src/main.rs
@@ -102,17 +102,15 @@ async fn main() {
 
     tracing::info!("Started listening on http://localhost:3000");
 
-    Ohkami::with((
+    Ohkami::new((
         fangs::LogRequest,
-    ), (
         "/hc" .GET(health_handler::health_check),
-        "/api".By(Ohkami::with((
+        "/api".By(Ohkami::new((
             fangs::SetServer,
-        ), (
-            "/query".
-                GET(hello_handler::hello_by_query),
-            "/json".
-                POST(hello_handler::hello_by_json),
+            "/query"
+                .GET(hello_handler::hello_by_query),
+            "/json"
+                .POST(hello_handler::hello_by_json),
         ))),
     )).howl("localhost:3000").await
 }

--- a/examples/websocket/src/main.rs
+++ b/examples/websocket/src/main.rs
@@ -142,7 +142,7 @@ async fn main() {
         }
     }
     
-    Ohkami::with(Logger, (
+    Ohkami::new((Logger,
         "/".Dir("./template").omit_extensions([".html"]),
         "/echo1".GET(echo_text),
         "/echo2/:name".GET(echo_text_2),

--- a/ohkami/src/fang/builtin/basicauth.rs
+++ b/ohkami/src/fang/builtin/basicauth.rs
@@ -30,14 +30,16 @@ use crate::openapi;
 /// #[tokio::main]
 /// async fn main() {
 ///     Ohkami::new((
-///         "/hello".GET(|| async {"Hello, public!"}),
-///         "/private".By(Ohkami::with(
+///         "/hello"
+///             .GET(|| async {"Hello, public!"}),
+///         "/private".By(Ohkami::new((
 ///             BasicAuth {
 ///                 username: "master of hello",
 ///                 password: "world"
 ///             },
-///             "/hello".GET(|| async {"Hello, private :)"})
-///         ))
+///             "/hello"
+///                 .GET(|| async {"Hello, private :)"})
+///         )))
 ///     )).howl("localhost:8888").await
 /// }
 /// ```

--- a/ohkami/src/fang/builtin/basicauth.rs
+++ b/ohkami/src/fang/builtin/basicauth.rs
@@ -143,13 +143,13 @@ const _: () = {
 
     let t = Ohkami::new((
         "/hello".GET(|| async {"Hello!"}),
-        "/private".By(Ohkami::with(
+        "/private".By(Ohkami::new((
             BasicAuth {
                 username: "ohkami",
                 password: "password"
             },
             "/".GET(|| async {"Hello, private!"})
-        ))
+        )))
     )).test();
 
     crate::__rt__::testing::block_on(async {

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -183,7 +183,7 @@ mod test {
 
     #[test] fn options_request() {
         crate::__rt__::testing::block_on(async {
-            let t = Ohkami::with((),
+            let t = Ohkami::new(
                 "/hello".POST(|| async {"Hello!"})
             ).test(); {
                 let req = TestRequest::OPTIONS("/");
@@ -196,9 +196,9 @@ mod test {
                 assert_eq!(res.text(), None);
             }
 
-            let t = Ohkami::with(CORS::new("https://example.x.y.z"),
+            let t = Ohkami::new((CORS::new("https://example.x.y.z"),
                 "/hello".POST(|| async {"Hello!"})
-            ).test(); {
+            )).test(); {
                 let req = TestRequest::OPTIONS("/");
                 let res = t.oneshot(req).await;
                 assert_eq!(res.status(), Status::NotFound);
@@ -225,9 +225,9 @@ mod test {
 
     #[test] fn cors_headers() {
         crate::__rt__::testing::block_on(async {
-            let t = Ohkami::with(CORS::new("https://example.example"),
+            let t = Ohkami::new((CORS::new("https://example.example"),
                 "/".GET(|| async {"Hello!"})
-            ).test(); {
+            )).test(); {
                 let req = TestRequest::GET("/");
                 let res = t.oneshot(req).await;
 
@@ -243,14 +243,14 @@ mod test {
                 assert_eq!(res.header("Vary"), None);
             }
 
-            let t = Ohkami::with(
+            let t = Ohkami::new((
                 CORS::new("https://example.example")
                     .AllowCredentials()
                     .AllowHeaders(["Content-Type", "X-Custom"]),
                 "/abc"
                     .GET(|| async {"Hello!"})
                     .PUT(|| async {"Hello!"})
-            ).test(); {
+            )).test(); {
                 let req = TestRequest::OPTIONS("/abc");
                 let res = t.oneshot(req).await;
 
@@ -310,12 +310,12 @@ mod test {
                 assert_eq!(res.header("Vary"), None);
             }
 
-            let t = Ohkami::with(
+            let t = Ohkami::new((
                 CORS::new("*")
                     .AllowHeaders(["Content-Type", "X-Custom"])
                     .MaxAge(1024),
                 "/".POST(|| async {"Hello!"})
-            ).test(); {
+            )).test(); {
                 let req = TestRequest::OPTIONS("/");
                 let res = t.oneshot(req).await;
 

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -14,15 +14,13 @@ use crate::{header::append, Fang, FangProc, Request, Response, Status};
 /// 
 /// #[tokio::main]
 /// async fn main() {
-///     Ohkami::with((
+///     Ohkami::new((
 ///         CORS::new("https://foo.bar.org")
 ///             .AllowHeaders(["Content-Type", "X-Requested-With"])
 ///             .AllowCredentials()
 ///             .MaxAge(86400),
-///     ), (
-///         "/api".GET(|| async {
-///             "Hello, CORS!"
-///         }),
+///         "/api"
+///             .GET(|| async {"Hello, CORS!"}),
 ///     )).howl("localhost:8080").await
 /// }
 /// ```

--- a/ohkami/src/fang/builtin/jwt.rs
+++ b/ohkami/src/fang/builtin/jwt.rs
@@ -602,7 +602,7 @@ impl<Payload: for<'de> Deserialize<'de>> JWT<Payload> {
             "/signin".By(Ohkami::new(
                 "/".PUT(signin),
             )),
-            "/profile".By(Ohkami::with((my_jwt(),), (
+            "/profile".By(Ohkami::new((my_jwt(),
                 "/".GET(get_profile),
             ))),
         )).test();

--- a/ohkami/src/fang/builtin/jwt.rs
+++ b/ohkami/src/fang/builtin/jwt.rs
@@ -76,7 +76,7 @@ use base64::engine::{Engine as _, general_purpose::URL_SAFE_NO_PAD as BASE64URL}
 /// async fn main() {
 ///     Ohkami::new((
 ///         "/auth".GET(auth),
-///         "/private".By(Ohkami::with(our_jwt(), (
+///         "/private".By(Ohkami::new((our_jwt(),
 ///             "/hello/:name".GET(hello),
 ///         )))
 ///     )).howl("localhost:3000").await

--- a/ohkami/src/fang/builtin/memory.rs
+++ b/ohkami/src/fang/builtin/memory.rs
@@ -15,16 +15,15 @@ use crate::FromRequest;
 /// async fn main() {
 ///     let sample_data = Arc::new(String::from("ohkami"));
 /// 
-///     Ohkami::with(
+///     Ohkami::new((
 ///         Memory::new(sample_data), // <--
-///         (
-///             "/hello".GET(hello),
-///         )
-///     ).howl("0.0.0.0:8080").await
+///         "/hello"
+///             .GET(hello),
+///     )).howl("0.0.0.0:8080").await
 /// }
 /// 
 /// async fn hello(
-///     Memory(name): Memory<'_, String>,
+///     Memory(name): Memory<'_, String>, // <--
 /// ) -> String {
 ///     format!("Hello, {name}!")
 /// }

--- a/ohkami/src/fang/builtin/timeout.rs
+++ b/ohkami/src/fang/builtin/timeout.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 /// 
 /// #[tokio::main]
 /// async fn main() {
-///     Ohkami::with(Timeout::by_secs(10), (
+///     Ohkami::new((Timeout::by_secs(10),
 ///         "/hello/:sleep".GET(sleeping_hello),
 ///     )).howl("0.0.0.0:3000").await
 /// }

--- a/ohkami/src/fang/builtin/timeout.rs
+++ b/ohkami/src/fang/builtin/timeout.rs
@@ -88,9 +88,8 @@ const _: () = {
         format!("Hello, {name}!")
     }
 
-    let t = Ohkami::with((
+    let t = Ohkami::new((
         Timeout::by_secs(2),
-    ), (
         "/greet/:name/:sleep".GET(lazy_greeting),
     )).test();
 

--- a/ohkami/src/fang/middleware/util.rs
+++ b/ohkami/src/fang/middleware/util.rs
@@ -184,11 +184,11 @@ mod test {
             }
         }
 
-        let t = Ohkami::with((
+        let t = Ohkami::new((
             GreetingFang { name: "Clerk" },
             GreetingFangWithAction { name: "John" },
-        ), (
-            "/greet".POST(|| async {"Hi, I'm Handler!"}),
+            "/greet"
+                .POST(|| async {"Hi, I'm Handler!"}),
         )).test();
 
         crate::__rt__::testing::block_on(async {

--- a/ohkami/src/header/append.rs
+++ b/ohkami/src/header/append.rs
@@ -25,9 +25,12 @@ pub struct Append(pub(crate) Cow<'static, str>);
 /// 
 /// #[tokio::main]
 /// async fn main() {
-///     Ohkami::with(AppendServer("ohkami"),
+///     Ohkami::new((
+///         AppendServer("ohkami"),
+///         
 ///         "/".GET(|| async {"Hello, append!"})
-///     ).howl("localhost:3000").await
+/// 
+///     )).howl("localhost:3000").await
 /// }
 /// ```
 #[inline]

--- a/ohkami/src/ohkami/mod.rs
+++ b/ohkami/src/ohkami/mod.rs
@@ -136,12 +136,20 @@ pub struct Ohkami {
 }
 
 impl Ohkami {
-    pub fn new<Fangs>(routing: impl routing::Routing<Fangs>) -> Self {
+    pub fn new<Fangs>(routing: impl Routing<Fangs>) -> Self {
         let mut this = Self {
             router: Router::new(),
             fangs:  None,
         };
         routing.apply(&mut this);
+        this
+    }
+    pub fn with(fangs: impl Fangs + 'static, routes: impl Routing) -> Self {
+        let mut this = Self {
+            router: Router::new(),
+            fangs:  Some(Arc::new(fangs)),
+        };
+        routes.apply(&mut this);
         this
     }
 

--- a/ohkami/src/ohkami/routing.rs
+++ b/ohkami/src/ohkami/routing.rs
@@ -359,7 +359,7 @@ const _: () = {
     }
 };
 
-pub trait Routing<Fangs> {
+pub trait Routing<Fangs = ()> {
     fn apply(self, target: &mut Ohkami);
 }
 const _: () = {

--- a/ohkami/src/request/mod.rs
+++ b/ohkami/src/request/mod.rs
@@ -74,9 +74,9 @@ pub(crate) const PAYLOAD_LIMIT: usize = 1 << 32;
 /// 
 /// #[tokio::main]
 /// async fn main() {
-///     Ohkami::with(LogRequest,
+///     Ohkami::new((LogRequest,
 ///         "/".GET(|| async {"Hello, world!"})
-///     ).howl("localhost:8000").await
+///     )).howl("localhost:8000").await
 /// }
 /// ```
 /// 

--- a/ohkami/src/response/mod.rs
+++ b/ohkami/src/response/mod.rs
@@ -54,9 +54,9 @@ use crate::{sse, util::{Stream, StreamExt}};
 /// 
 /// #[tokio::main]
 /// async fn main() {
-///     Ohkami::with(SetHeaders,
+///     Ohkami::new((SetHeaders,
 ///         "/".GET(|| async {"Hello, ohkami!"})
-///     ).howl("localhost:5050").await
+///     )).howl("localhost:5050").await
 /// }
 /// ```
 /// 

--- a/ohkami/src/router/base.rs
+++ b/ohkami/src/router/base.rs
@@ -1,7 +1,7 @@
 use super::util::ID;
 use super::segments::{RouteSegments, RouteSegment};
 use crate::fang::{BoxedFPC, Fangs, handler::Handler};
-use crate::ohkami::routes::{ByAnother, HandlerSet};
+use crate::ohkami::routing::{ByAnother, HandlerSet};
 use std::{sync::Arc, collections::HashSet};
 
 #[cfg_attr(feature="openapi", derive(Clone))]

--- a/samples/petstore/src/main.rs
+++ b/samples/petstore/src/main.rs
@@ -44,9 +44,9 @@ impl FangAction for Logger {
 async fn main() {
     let db = Arc::new(mock::DB::new());
 
-    let o = Ohkami::with((
-        Logger, Memory::new(db)
-    ), (
+    let o = Ohkami::new((
+        Logger,
+        Memory::new(db),
         "/pets"
             .GET(list_pets)
             .POST(create_pet),

--- a/samples/realworld/src/handlers.rs
+++ b/samples/realworld/src/handlers.rs
@@ -12,10 +12,9 @@ pub fn realworld_ohkami(
     pool: PgPool,
 ) -> Ohkami {
     Ohkami::new(
-        "/api".By(Ohkami::with((
+        "/api".By(Ohkami::new((
             Logger,
             Memory::new(pool),
-        ), (
             "/users"   .By(users::users_ohkami()),
             "/user"    .By(user::user_ohkami()),
             "/profiles".By(profiles::profiles_ohkami()),

--- a/samples/realworld/src/handlers/profiles.rs
+++ b/samples/realworld/src/handlers/profiles.rs
@@ -9,7 +9,8 @@ use crate::db::UserEntity;
 
 
 pub fn profiles_ohkami() -> Ohkami {
-    Ohkami::with(Auth::required(), (
+    Ohkami::new((
+        Auth::required(),
         "/:username"
             .GET(get_profile),
         "/:username/follow"

--- a/samples/realworld/src/handlers/user.rs
+++ b/samples/realworld/src/handlers/user.rs
@@ -12,7 +12,8 @@ use crate::{
 
 
 pub fn user_ohkami() -> Ohkami {
-    Ohkami::with(Auth::required(), (
+    Ohkami::new((
+        Auth::required(),
         "/"
             .GET(get_user)
             .PUT(update),

--- a/samples/worker-with-openapi/src/lib.rs
+++ b/samples/worker-with-openapi/src/lib.rs
@@ -19,12 +19,13 @@ pub fn ohkami() -> Ohkami {
     #[cfg(debug_assertions)]
     console_error_panic_hook::set_once();
 
-    let openapi_doc_server_ohkami = Ohkami::with(BasicAuth {
-        username: "ohkami",
-        password: Bindings::OPENAPI_DOC_PASSWORD
-    },
+    let openapi_doc_server_ohkami = Ohkami::new((
+        BasicAuth {
+            username: "ohkami",
+            password: Bindings::OPENAPI_DOC_PASSWORD
+        },
         "/".GET(|| async {include_str!("../openapi.json")})
-    );
+    ));
 
     let api_ohkami = Ohkami::new((
         "/users"
@@ -38,7 +39,8 @@ pub fn ohkami() -> Ohkami {
             .POST((TokenAuth, post_tweet)),
     ));
 
-    Ohkami::with(Logger, (
+    Ohkami::new((
+        Logger,
         "/openapi.json".By(openapi_doc_server_ohkami),
         "/api".By(api_ohkami)
     ))


### PR DESCRIPTION
This PR enables to pass fangs via `Ohkami::new`:

  ```rust
  Ohkami::new((
      Logger,
      Memory::new(connection_pool),
      "/users"
          .GET(list_users)
          .POST(create_user),
  ))
  ```

This is the same as

  ```rust
  Ohkami::with((
      Logger,
      Memory::new(connection_pool)
  ), (
      "/users"
          .GET(list_users)
          .POST(create_user),
  ))
  ```

but the former may be somehow more unified and simple.