### PR TITLE
`Memory` to `Context`

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ async fn main() {
 
 Ohkami's request handling system is called "**fang**s", and middlewares are implemented on this.
 
-*builtin fang* : `CORS`, `JWT`, `BasicAuth`, `Timeout`, `Memory`
+*builtin fang* : `CORS`, `JWT`, `BasicAuth`, `Timeout`, `Context`
 
 ```rust,no_run
 use ohkami::prelude::*;

--- a/benches/benches/tuplemap_vs_hashmap.rs
+++ b/benches/benches/tuplemap_vs_hashmap.rs
@@ -16,6 +16,7 @@ impl std::hash::Hasher for AsIsHasher {
             
 macro_rules! tuplemap_vs_hashmap {
     ($name:ident : size = $size:literal, iter = $search_iteration:literal) => {
+        #[allow(non_snake_case)]
         mod $name {
             use super::*;
 
@@ -109,3 +110,7 @@ tuplemap_vs_hashmap!(size2_search100 : size = 2, iter = 100);
 tuplemap_vs_hashmap!(size4_search2__ : size = 4, iter = 2  );
 tuplemap_vs_hashmap!(size4_search10_ : size = 4, iter = 10 );
 tuplemap_vs_hashmap!(size4_search100 : size = 4, iter = 100);
+
+tuplemap_vs_hashmap!(size8_search2__ : size = 8, iter = 2  );
+tuplemap_vs_hashmap!(size8_search10_ : size = 8, iter = 10 );
+tuplemap_vs_hashmap!(size8_search100 : size = 8, iter = 100);

--- a/benches/benches/tuplemap_vs_hashmap.rs
+++ b/benches/benches/tuplemap_vs_hashmap.rs
@@ -1,0 +1,111 @@
+#![feature(test)] extern crate test;
+
+#[derive(Default)]
+struct AsIsHasher(u64);
+impl std::hash::Hasher for AsIsHasher {
+    #[cold] #[inline(never)] fn write(&mut self, _: &[u8]) {
+        unsafe {std::hint::unreachable_unchecked()}
+    }
+    #[inline(always)] fn write_u64(&mut self, type_id_value: u64) {
+        self.0 = type_id_value
+    }
+    #[inline(always)] fn finish(&self) -> u64 {
+        self.0
+    }
+}
+            
+macro_rules! tuplemap_vs_hashmap {
+    ($name:ident : size = $size:literal, iter = $search_iteration:literal) => {
+        mod $name {
+            use super::*;
+
+            #[bench]
+            fn create_tuplemap(b: &mut test::Bencher) {
+                use ohkami_lib::map::TupleMap;
+                use rand::prelude::*;
+            
+                let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(314159265358979);
+                let keys: [u64; $size] = std::array::from_fn(|_| rng.gen());
+            
+                b.iter(|| -> TupleMap<u64, Box<String>> {
+                    TupleMap::<u64, Box<String>>::from_iter(
+                        keys.map(|k| (k, Box::new(k.to_string())))
+                    )
+                })
+            }
+
+            #[bench]
+            fn search_tuplemap(b: &mut test::Bencher) {
+                use ohkami_lib::map::TupleMap;
+                use rand::prelude::*;
+            
+                let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(314159265358979);
+                let keys: [u64; $size] = std::array::from_fn(|_| rng.gen());
+
+                let map = TupleMap::<u64, Box<String>>::from_iter(
+                    keys.map(|k| (k, Box::new(k.to_string())))
+                );
+            
+                b.iter(|| -> String {
+                    (0..$search_iteration).fold(String::new(), |mut a, _| {
+                        let i = rng.gen_range(0..$size * 2) as u64;
+                        if let Some(v) = map.get(&i) {
+                            a.push_str(v)
+                        }
+                        a
+                    })
+                })
+            }
+            
+            #[bench]
+            fn create_hashmap(b: &mut test::Bencher) {
+                use std::{collections::HashMap, hash::BuildHasherDefault};
+                use rand::prelude::*;
+                
+                let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(314159265358979);
+                let keys: [u64; $size] = std::array::from_fn(|_| rng.gen());            
+            
+                b.iter(|| -> HashMap::<u64, Box<String>, BuildHasherDefault<AsIsHasher>> {
+                    HashMap::<u64, Box<String>, BuildHasherDefault<AsIsHasher>>::from_iter(
+                        keys.map(|k| (k, Box::new(k.to_string())))
+                    )
+                })
+            }
+            
+            #[bench]
+            fn search_hashmap(b: &mut test::Bencher) {
+                use std::{collections::HashMap, hash::BuildHasherDefault};
+                use rand::prelude::*;
+                
+                let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(314159265358979);
+                let keys: [u64; $size] = std::array::from_fn(|_| rng.gen());
+
+                let map = HashMap::<u64, Box<String>, BuildHasherDefault<AsIsHasher>>::from_iter(
+                    keys.map(|k| (k, Box::new(k.to_string())))
+                );            
+            
+                b.iter(|| -> String {
+                    (0..$search_iteration).fold(String::new(), |mut a, _| {
+                        let i = rng.gen_range(0..$size * 2) as u64;
+                        if let Some(v) = map.get(&i) {
+                            a.push_str(v)
+                        }
+                        a
+                    })
+                })
+            }
+        }
+    }
+}
+
+tuplemap_vs_hashmap!(size1_search2__ : size = 1, iter = 2  );
+tuplemap_vs_hashmap!(size1_search10_ : size = 1, iter = 10 );
+tuplemap_vs_hashmap!(size1_search100 : size = 1, iter = 100);
+
+tuplemap_vs_hashmap!(size2_search2__ : size = 2, iter = 2  );
+tuplemap_vs_hashmap!(size2_search10_ : size = 2, iter = 10 );
+tuplemap_vs_hashmap!(size2_search100 : size = 2, iter = 100);
+
+tuplemap_vs_hashmap!(size4_search2__ : size = 4, iter = 2  );
+tuplemap_vs_hashmap!(size4_search10_ : size = 4, iter = 10 );
+tuplemap_vs_hashmap!(size4_search100 : size = 4, iter = 100);

--- a/examples/chatgpt/src/main.rs
+++ b/examples/chatgpt/src/main.rs
@@ -27,7 +27,7 @@ async fn main() {
 }
 
 pub async fn relay_chat_completion(
-    Memory(APIKey(api_key)): Memory<'_, APIKey>,
+    Context(APIKey(api_key)): Context<'_, APIKey>,
     Text(content): Text<String>,
 ) -> Result<DataStream, Error> {
     let mut gpt_response = reqwest::Client::new()

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -7,8 +7,8 @@ pub use cors::CORS;
 mod jwt;
 pub use jwt::{JWT, JWTToken};
 
-mod memory;
-pub use memory::Memory;
+mod context;
+pub use context::Context;
 
 #[cfg(feature="__rt_native__")]
 mod timeout;

--- a/ohkami/src/fang/builtin/jwt.rs
+++ b/ohkami/src/fang/builtin/jwt.rs
@@ -47,7 +47,7 @@ use base64::engine::{Engine as _, general_purpose::URL_SAFE_NO_PAD as BASE64URL}
 /// }
 /// 
 /// async fn hello(name: &str,
-///     Memory(auth): Memory<'_, OurJWTPayload>
+///     Context(auth): Context<'_, OurJWTPayload>
 /// ) -> String {
 ///     format!("Hello {name}, you're authorized!")
 /// }
@@ -542,7 +542,7 @@ impl<Payload: for<'de> Deserialize<'de>> JWT<Payload> {
         }
 
         async fn get_profile(
-            Memory(jwt_payload): Memory<'_, MyJWTPayload>
+            Context(jwt_payload): Context<'_, MyJWTPayload>
         ) -> Result<JSON<Profile>, APIError> {
             let r = &mut *repository().await.lock().unwrap();
 

--- a/ohkami/src/header/map.rs
+++ b/ohkami/src/header/map.rs
@@ -3,15 +3,6 @@ pub(crate) struct IndexMap<const N: usize, Value> {
     values: Vec<(usize, Value)>,
 }
 
-/// Key-Value map mainly used to store custom headers.
-/// 
-/// Usually, a web app handles 0 ~ 4 custom headers, and so
-/// simple `Vec<(K, V)>` is efficient than `HashMap<K, V>`
-/// to store/iterate/mutate.
-pub(crate) struct TupleMap<K: PartialEq, V>(
-    Vec<(K, V)>
-);
-
 impl<const N: usize, Value> IndexMap<N, Value> {
     const NULL: u8 = u8::MAX;
 
@@ -63,53 +54,6 @@ impl<const N: usize, Value> IndexMap<N, Value> {
     }
 }
 
-impl<K: PartialEq, V> TupleMap<K, V> {
-    pub(crate) fn new() -> Self {
-        Self(Vec::new())
-    }
-    pub(crate) fn from_iter<const N: usize>(iter: [(K, V); N]) -> Self {
-        Self(Vec::from(iter))
-    }
-
-    #[inline]
-    pub(crate) fn get(&self, key: &K) -> Option<&V> {
-        for (k, v) in &self.0 {
-            if key == k {return Some(v)}
-        }; None
-    }
-    #[inline]
-    pub(crate) fn get_mut(&mut self, key: &K) -> Option<&mut V> {
-        for (k, v) in &mut self.0 {
-            if key == k {return Some(v)}
-        }; None
-    }
-
-    #[inline]
-    pub(crate) fn insert(&mut self, key: K, value: V) -> Option<V> {
-        for (k, v) in &mut self.0 {
-            if &key == k {return Some(std::mem::replace(v, value))}
-        }; {self.0.push((key, value)); None}
-    }
-
-    #[inline]
-    pub(crate) fn remove(&mut self, key: K) -> Option<V> {
-        for i in 0..self.0.len() {
-            if &key == &unsafe {self.0.get_unchecked(i)}.0 {
-                return Some(self.0.swap_remove(i).1)
-            }
-        }; None
-    }
-
-    #[allow(unused)]
-    pub(crate) fn clear(&mut self) {
-        self.0.clear();
-    }
-
-    pub(crate) fn iter(&self) -> impl Iterator<Item = &(K, V)> {
-        self.0.iter()
-    }
-}
-
 const _: () = {
     impl<const N: usize, Value: PartialEq> PartialEq for IndexMap<N, Value> {
         fn eq(&self, other: &Self) -> bool {
@@ -127,18 +71,6 @@ const _: () = {
                 index:  self.index.clone(),
                 values: self.values.clone(),
             }
-        }
-    }
-
-    impl<K: PartialEq, V: PartialEq> PartialEq for TupleMap<K, V> {
-        fn eq(&self, other: &Self) -> bool {
-            self.0 == other.0
-        }
-    }
-
-    impl<K: Clone + PartialEq, V: Clone> Clone for TupleMap<K, V> {
-        fn clone(&self) -> Self {
-            Self(self.0.clone())
         }
     }
 };

--- a/ohkami/src/header/mod.rs
+++ b/ohkami/src/header/mod.rs
@@ -8,4 +8,4 @@ mod setcookie;
 pub(crate) use setcookie::*;
 
 mod map;
-pub(crate) use map::{IndexMap, TupleMap};
+pub(crate) use map::IndexMap;

--- a/ohkami/src/lib.rs
+++ b/ohkami/src/lib.rs
@@ -245,7 +245,7 @@ pub mod prelude {
     pub use crate::util::FangAction;
     pub use crate::serde::{Serialize, Deserialize};
     pub use crate::format::{JSON, Query};
-    pub use crate::fang::Memory;
+    pub use crate::fang::Context;
 
     #[cfg(feature="__rt__")]
     pub use crate::{Route, Ohkami};

--- a/ohkami/src/request/headers.rs
+++ b/ohkami/src/request/headers.rs
@@ -1,6 +1,6 @@
-use crate::header::{IndexMap, TupleMap, Append};
+use crate::header::{IndexMap, Append};
 use std::borrow::Cow;
-use ohkami_lib::{CowSlice, Slice};
+use ohkami_lib::{CowSlice, Slice, map::TupleMap};
 
 
 pub struct Headers {

--- a/ohkami/src/request/store.rs
+++ b/ohkami/src/request/store.rs
@@ -1,34 +1,14 @@
-use std::{
-    any::{Any, TypeId},
-    collections::HashMap,
-    hash::{Hasher, BuildHasherDefault},
-};
-
+use ohkami_lib::map::TupleMap;
+use std::any::{Any, TypeId};
 
 pub struct Store(
     Option<Box<
-        HashMap<
+        TupleMap<
             TypeId,
-            Box<dyn Any + Send + Sync>,
-            BuildHasherDefault<TypeIDHasger>,
+            Box<dyn Any + Send + Sync>
         >
     >>
 );
-
-#[derive(Default)]
-struct TypeIDHasger(u64);
-impl Hasher for TypeIDHasger {
-    #[cold] fn write(&mut self, _: &[u8]) {
-        unsafe {std::hint::unreachable_unchecked()}
-    }
-
-    #[inline(always)] fn write_u64(&mut self, type_id_value: u64) {
-        self.0 = type_id_value
-    }
-    #[inline(always)] fn finish(&self) -> u64 {
-        self.0
-    }
-}
 
 impl Store {
     #[cfg(feature="__rt__")]
@@ -43,18 +23,23 @@ impl Store {
         }
     }
 
-    #[inline] pub fn insert<Data: Send + Sync + 'static>(&mut self, value: Data) {
-        self.0.get_or_insert_with(|| Box::new(HashMap::default()))
+    #[inline]
+    pub fn insert<Data: Send + Sync + 'static>(&mut self, value: Data) {
+        if self.0.is_none() {
+            self.0 = Some(Box::new(TupleMap::new()));
+        }
+        unsafe {self.0.as_mut().unwrap_unchecked()}
             .insert(TypeId::of::<Data>(), Box::new(value));
     }
 
-    #[inline] pub fn get<Data: Send + Sync + 'static>(&self) -> Option<&Data> {
+    #[inline]
+    pub fn get<Data: Send + Sync + 'static>(&self) -> Option<&Data> {
         self.0.as_ref().and_then(|map| map
             .get(&TypeId::of::<Data>())
             .map(|boxed| {
                 let data: &dyn Any = &**boxed;
                 #[cfg(debug_assertions)] {
-                    assert!(data.is::<Data>(), "Request's Memory is poisoned!!!");
+                    assert!(data.is::<Data>(), "Request store is poisoned!!!");
                 }
                 unsafe { &*(data as *const dyn Any as *const Data) }
             })

--- a/ohkami/src/request/store.rs
+++ b/ohkami/src/request/store.rs
@@ -28,7 +28,7 @@ impl Store {
         if self.0.is_none() {
             self.0 = Some(Box::new(TupleMap::new()));
         }
-        unsafe {self.0.as_mut().unwrap_unchecked()}
+        (unsafe {self.0.as_mut().unwrap_unchecked()})
             .insert(TypeId::of::<Data>(), Box::new(value));
     }
 

--- a/ohkami/src/response/headers.rs
+++ b/ohkami/src/response/headers.rs
@@ -1,4 +1,5 @@
-use crate::header::{IndexMap, TupleMap, Append, SetCookie, SetCookieBuilder};
+use crate::header::{IndexMap, Append, SetCookie, SetCookieBuilder};
+use ohkami_lib::map::TupleMap;
 use std::borrow::Cow;
 
 

--- a/ohkami_lib/src/lib.rs
+++ b/ohkami_lib/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod map;
+
 pub mod mime;
 
 pub mod num;

--- a/ohkami_lib/src/map.rs
+++ b/ohkami_lib/src/map.rs
@@ -1,0 +1,66 @@
+/// Key-Value map mainly used to store custom headers.
+/// 
+/// Usually, a web app handles 0 ~ 4 custom headers, and so
+/// simple `Vec<(K, V)>` is efficient than `HashMap<K, V>`
+/// to store/iterate/mutate.
+pub struct TupleMap<K: PartialEq, V>(
+    Vec<(K, V)>
+);
+
+impl<K: PartialEq, V> TupleMap<K, V> {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+    pub fn from_iter<const N: usize>(iter: [(K, V); N]) -> Self {
+        Self(Vec::from(iter))
+    }
+
+    #[inline]
+    pub fn get(&self, key: &K) -> Option<&V> {
+        for (k, v) in &self.0 {
+            if key == k {return Some(v)}
+        }; None
+    }
+    #[inline]
+    pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+        for (k, v) in &mut self.0 {
+            if key == k {return Some(v)}
+        }; None
+    }
+
+    #[inline]
+    pub fn insert(&mut self, key: K, value: V) -> Option<V> {
+        for (k, v) in &mut self.0 {
+            if &key == k {return Some(std::mem::replace(v, value))}
+        }; {self.0.push((key, value)); None}
+    }
+
+    #[inline]
+    pub fn remove(&mut self, key: K) -> Option<V> {
+        for i in 0..self.0.len() {
+            if &key == &unsafe {self.0.get_unchecked(i)}.0 {
+                return Some(self.0.swap_remove(i).1)
+            }
+        }; None
+    }
+
+    pub fn clear(&mut self) {
+        self.0.clear();
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &(K, V)> {
+        self.0.iter()
+    }
+}
+
+impl<K: PartialEq, V: PartialEq> PartialEq for TupleMap<K, V> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<K: Clone + PartialEq, V: Clone> Clone for TupleMap<K, V> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}

--- a/samples/petstore/src/main.rs
+++ b/samples/petstore/src/main.rs
@@ -46,7 +46,7 @@ async fn main() {
 
     let o = Ohkami::new((
         Logger,
-        Memory::new(db),
+        Context::new(db),
         "/pets"
             .GET(list_pets)
             .POST(create_pet),
@@ -68,7 +68,7 @@ async fn main() {
 #[openapi::operation({200: "All pets stored in this pet store"})]
 async fn list_pets(
     Query(q): Query<ListPetsMeta>,
-    Memory(db): Memory<'_, Arc<mock::DB>>,
+    Context(db): Context<'_, Arc<mock::DB>>,
 ) -> Result<JSON<Vec<Pet>>, Error> {
     let mut pets = db.read().await.values().cloned().collect::<Vec<_>>();
     if let Some(limit) = q.limit {
@@ -87,7 +87,7 @@ struct ListPetsMeta {
 #[openapi::operation(createPet)]
 async fn create_pet(
     JSON(req): JSON<CreatePetRequest<'_>>,
-    Memory(db): Memory<'_, Arc<mock::DB>>,
+    Context(db): Context<'_, Arc<mock::DB>>,
 ) -> Result<status::Created<JSON<Pet>>, Error> {
     if db.read().await.values().any(|p| p.name == req.name) {
         return Err(Error {
@@ -127,7 +127,7 @@ struct CreatePetRequest<'req> {
 /// The parameter `id` must be unsigned 64-bit integer.
 async fn show_pet_by_id(
     id: u64,
-    Memory(db): Memory<'_, Arc<mock::DB>>,
+    Context(db): Context<'_, Arc<mock::DB>>,
 ) -> Result<JSON<Pet>, Error> {
     let pet = db.read().await.get(&id)
         .cloned()

--- a/samples/realworld/src/handlers.rs
+++ b/samples/realworld/src/handlers.rs
@@ -5,7 +5,7 @@ mod articles;
 mod tags;
 
 use sqlx::PgPool;
-use ohkami::{Ohkami, Route, fang::Memory};
+use ohkami::{Ohkami, Route, fang::Context};
 use crate::fangs::Logger;
 
 pub fn realworld_ohkami(
@@ -14,7 +14,7 @@ pub fn realworld_ohkami(
     Ohkami::new(
         "/api".By(Ohkami::new((
             Logger,
-            Memory::new(pool),
+            Context::new(pool),
             "/users"   .By(users::users_ohkami()),
             "/user"    .By(user::user_ohkami()),
             "/profiles".By(profiles::profiles_ohkami()),

--- a/samples/realworld/src/handlers/articles.rs
+++ b/samples/realworld/src/handlers/articles.rs
@@ -36,8 +36,8 @@ pub fn articles_ohkami() -> Ohkami {
 
 async fn list_articles(
     Query(q): Query<ListArticlesQuery<'_>>,
-    Memory(auth): Memory<'_, Option<JWTPayload>>,
-    Memory(pool): Memory<'_, PgPool>,
+    Context(auth): Context<'_, Option<JWTPayload>>,
+    Context(pool): Context<'_, PgPool>,
 ) -> Result<JSON<MultipleArticlesResponse>, RealWorldError> {
     let user_and_followings = match auth {
         None => UserAndFollowings::None,
@@ -98,8 +98,8 @@ async fn list_articles(
 
 async fn feed_articles(
     Query(q): Query<FeedArticleQuery>,
-    Memory(auth): Memory<'_, JWTPayload>,
-    Memory(pool): Memory<'_, PgPool>,
+    Context(auth): Context<'_, JWTPayload>,
+    Context(pool): Context<'_, PgPool>,
 ) -> Result<JSON<MultipleArticlesResponse>, RealWorldError> {
     let uf = UserAndFollowings::from_user_id(auth.user_id, pool).await?;
 
@@ -120,7 +120,7 @@ async fn feed_articles(
 }
 
 async fn get_article_by_slug(slug: &str,
-    Memory(pool): Memory<'_, PgPool>,
+    Context(pool): Context<'_, PgPool>,
 ) -> Result<JSON<SingleArticleResponse>, RealWorldError> {
     let article = sqlx::QueryBuilder::new(ArticleEntity::base_query())
         .push(" HAVING a.slug = ").push_bind(slug)
@@ -136,8 +136,8 @@ async fn get_article_by_slug(slug: &str,
 
 async fn create_article(
     JSON(req): JSON<CreateArticleRequest<'_>>,
-    Memory(auth): Memory<'_, JWTPayload>,
-    Memory(pool): Memory<'_, PgPool>,
+    Context(auth): Context<'_, JWTPayload>,
+    Context(pool): Context<'_, PgPool>,
 ) -> Result<Created<JSON<SingleArticleResponse>>, RealWorldError> {
     let author_id = auth.user_id;
     let slug = req.slug();
@@ -230,8 +230,8 @@ async fn create_article(
 
 async fn update_article(slug: &str,
     JSON(body): JSON<UpdateArticleRequest<'_>>,
-    Memory(auth): Memory<'_, JWTPayload>,
-    Memory(pool): Memory<'_, PgPool>,
+    Context(auth): Context<'_, JWTPayload>,
+    Context(pool): Context<'_, PgPool>,
 ) -> Result<JSON<SingleArticleResponse>, RealWorldError> {
     let mut article = sqlx::QueryBuilder::new(ArticleEntity::base_query())
         .push(" HAVING a.slug = ").push_bind(slug)
@@ -286,8 +286,8 @@ async fn update_article(slug: &str,
 }
 
 async fn delete_article(slug: &str,
-    Memory(auth): Memory<'_, JWTPayload>,
-    Memory(pool): Memory<'_, PgPool>,
+    Context(auth): Context<'_, JWTPayload>,
+    Context(pool): Context<'_, PgPool>,
 ) -> Result<NoContent, RealWorldError> {
     let n = sqlx::query!("DELETE FROM articles WHERE author_id = $1 AND slug = $2", auth.user_id, slug)
         .execute(pool).await
@@ -303,8 +303,8 @@ async fn delete_article(slug: &str,
 
 async fn add_article_comment(slug: &str,
     JSON(body): JSON<AddCommentRequest<'_>>,
-    Memory(auth): Memory<'_, JWTPayload>,
-    Memory(pool): Memory<'_, PgPool>,
+    Context(auth): Context<'_, JWTPayload>,
+    Context(pool): Context<'_, PgPool>,
 ) -> Result<Created<JSON<SingleCommentResponse>>, RealWorldError> {
     let ariticle_id = article_id_by_slug(slug, pool).await?;
     let content = body.comment.content;
@@ -355,8 +355,8 @@ async fn add_article_comment(slug: &str,
 }
 
 async fn get_article_comments(slug: &str,
-    Memory(auth): Memory<'_, Option<JWTPayload>>,
-    Memory(pool): Memory<'_, PgPool>,
+    Context(auth): Context<'_, Option<JWTPayload>>,
+    Context(pool): Context<'_, PgPool>,
 ) -> Result<JSON<MultipleCommentsResponse>, RealWorldError> {
     let ariticle_id = article_id_by_slug(slug, pool).await?;
 
@@ -391,8 +391,8 @@ async fn get_article_comments(slug: &str,
 }
 
 async fn delete_article_comment_by_id((slug, id): (&str, usize),
-    Memory(auth): Memory<'_, JWTPayload>,
-    Memory(pool): Memory<'_, PgPool>,
+    Context(auth): Context<'_, JWTPayload>,
+    Context(pool): Context<'_, PgPool>,
 ) -> Result<NoContent, RealWorldError> {
     let ariticle_id = article_id_by_slug(slug, pool).await?;
 
@@ -415,8 +415,8 @@ async fn delete_article_comment_by_id((slug, id): (&str, usize),
 }
 
 async fn favorite_article(slug: &str,
-    Memory(auth): Memory<'_, JWTPayload>,
-    Memory(pool): Memory<'_, PgPool>,
+    Context(auth): Context<'_, JWTPayload>,
+    Context(pool): Context<'_, PgPool>,
 ) -> Result<JSON<SingleArticleResponse>, RealWorldError> {
     let ariticle_id = article_id_by_slug(slug, pool).await?;
 
@@ -442,8 +442,8 @@ async fn favorite_article(slug: &str,
 }
 
 async fn unfavorite_article(slug: &str,
-    Memory(auth): Memory<'_, JWTPayload>,
-    Memory(pool): Memory<'_, PgPool>,
+    Context(auth): Context<'_, JWTPayload>,
+    Context(pool): Context<'_, PgPool>,
 ) -> Result<JSON<SingleArticleResponse>, RealWorldError> {
     let ariticle_id = article_id_by_slug(slug, pool).await?;
 

--- a/samples/realworld/src/handlers/profiles.rs
+++ b/samples/realworld/src/handlers/profiles.rs
@@ -20,8 +20,8 @@ pub fn profiles_ohkami() -> Ohkami {
 }
 
 async fn get_profile(username: &str,
-    Memory(auth): Memory<'_, JWTPayload>,
-    Memory(pool): Memory<'_, PgPool>
+    Context(auth): Context<'_, JWTPayload>,
+    Context(pool): Context<'_, PgPool>
 ) -> Result<JSON<ProfileResponse>, RealWorldError> {
     let the_user = UserEntity::get_by_name(username, pool).await?;
 
@@ -44,8 +44,8 @@ async fn get_profile(username: &str,
 }
 
 async fn follow(username: &str,
-    Memory(auth): Memory<'_, JWTPayload>,
-    Memory(pool): Memory<'_, PgPool>,
+    Context(auth): Context<'_, JWTPayload>,
+    Context(pool): Context<'_, PgPool>,
 ) -> Result<JSON<ProfileResponse>, RealWorldError> {
     let by_existing_user = sqlx::query!(r#"
         SELECT EXISTS (
@@ -81,8 +81,8 @@ async fn follow(username: &str,
 }
 
 async fn unfollow(username: &str,
-    Memory(auth): Memory<'_, JWTPayload>,
-    Memory(pool): Memory<'_, PgPool>,
+    Context(auth): Context<'_, JWTPayload>,
+    Context(pool): Context<'_, PgPool>,
 ) -> Result<JSON<ProfileResponse>, RealWorldError> {
     let followee = UserEntity::get_by_name(username, pool).await?;
 

--- a/samples/realworld/src/handlers/tags.rs
+++ b/samples/realworld/src/handlers/tags.rs
@@ -11,7 +11,7 @@ pub fn tags_ohkami() -> Ohkami {
 }
 
 async fn get(
-    Memory(pool): Memory<'_, PgPool>
+    Context(pool): Context<'_, PgPool>
 ) -> Result<JSON<ListOfTagsResponse<'static>>, RealWorldError> {
     let tags = sqlx::query!(r#"
         SELECT name

--- a/samples/realworld/src/handlers/user.rs
+++ b/samples/realworld/src/handlers/user.rs
@@ -21,8 +21,8 @@ pub fn user_ohkami() -> Ohkami {
 }
 
 async fn get_user(
-    Memory(pool): Memory<'_, PgPool>,
-    Memory(auth): Memory<'_, JWTPayload>,
+    Context(pool): Context<'_, PgPool>,
+    Context(auth): Context<'_, JWTPayload>,
 ) -> Result<JSON<UserResponse>, RealWorldError> {
     let user = util::get_current_user(pool, auth).await?;
     Ok(JSON(UserResponse { user }))
@@ -30,8 +30,8 @@ async fn get_user(
 
 async fn update(
     JSON(req): JSON<UpdateProfileRequest<'_>>,
-    Memory(auth): Memory<'_, JWTPayload>,
-    Memory(pool): Memory<'_, PgPool>,
+    Context(auth): Context<'_, JWTPayload>,
+    Context(pool): Context<'_, PgPool>,
 ) -> Result<JSON<UserResponse>, RealWorldError> {
     let user_entity = {
         let UpdateProfileRequest {

--- a/samples/realworld/src/handlers/users.rs
+++ b/samples/realworld/src/handlers/users.rs
@@ -21,7 +21,7 @@ pub fn users_ohkami() -> Ohkami {
 }
 
 async fn login(
-    Memory(pool): Memory<'_, PgPool>,
+    Context(pool): Context<'_, PgPool>,
     JSON(LoginRequest {
         user: LoginRequestUser { email, password },
     }): JSON<LoginRequest<'_>>,
@@ -48,7 +48,7 @@ async fn login(
 }
 
 async fn register(
-    Memory(pool): Memory<'_, PgPool>,
+    Context(pool): Context<'_, PgPool>,
     JSON(RegisterRequest {
         user: RegisterRequestUser { username, email, password }
     }): JSON<RegisterRequest<'_>>,

--- a/samples/worker-with-openapi/src/lib.rs
+++ b/samples/worker-with-openapi/src/lib.rs
@@ -59,7 +59,7 @@ async fn show_user_profile(id: ID,
 
 async fn edit_profile(id: ID,
     JSON(req): JSON<EditProfileRequest<'_>>,
-    Memory(TokenAuthed { user_id, .. }): Memory<'_, TokenAuthed>,
+    Context(TokenAuthed { user_id, .. }): Context<'_, TokenAuthed>,
     Bindings { DB, .. }: Bindings,
 ) -> Result<(), APIError> {
     if *user_id != id {
@@ -155,7 +155,7 @@ async fn list_tweets(
 
 async fn post_tweet(
     JSON(req): JSON<PostTweetRequest<'_>>,
-    Memory(TokenAuthed { user_id, user_name }): Memory<'_, TokenAuthed>,
+    Context(TokenAuthed { user_id, user_name }): Context<'_, TokenAuthed>,
     Bindings { DB, .. }: Bindings,
 ) -> Result<status::Created<JSON<Tweet>>, APIError> {
     let timestamp = crate::model::timestamp_now();


### PR DESCRIPTION
This PR replaces `fang::Memory` into `fang::Context`. The user-interface does not change except for renaming itself, but internal implementation of `Request`'s store is updated to use `ohkami_lib::TupleMap` ( instead of `HashMap<_, _, BuildHasherDefault<TypeIdHasher>>` ) .

As the benchmark ( at benches/benches/tuplemap_vs_hashmap.rs; designed with most-used sizes of the store in mind ) shows, `HashMap<_, _, BuildHasherDefault<AsIsHasher>>` ( `AsIsHasher` is the same as `TypeIdHasher` ) is performant in same-level or somehow faster than `TupleMap` **at searching**, but **slower at creation ( initializing + extendings )** by a little larger differences than searching's one in most cases.

<details>
<summary>column</summary>
In this case, the `AsIsHasher` ( or TypeIdHasher ) makes a quite improvement at `HashMap`'s performance.

For instance, when we delete `, BuildHasherDefault<AsIsHasher>` in create_hashmap and search_hashmap in the benchmark code, the result will show apparent performance degradation of HashMaps. 
</details>