### PR TITLE
openapi: repname `Responses::enumerated` into `Responses::new`

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -73,15 +73,17 @@ tasks:
     dir: ./ohkami
     cmds:
       - cargo test --lib --features DEBUG,{{.maybe_nightly}}
-      - cargo test --lib --features DEBUG,sse,ws,{{.maybe_nightly}}
-      - cargo test --lib --features DEBUG,openapi,{{.maybe_nightly}}
+      - cargo test --lib --features DEBUG,sse,{{.maybe_nightly}}
+      - cargo test --lib --features DEBUG,ws,{{.maybe_nightly}}
+      - cargo test --lib --features DEBUG,sse,ws,openapi,{{.maybe_nightly}}
 
   test:rt:
     dir: ./ohkami
     cmds:
       - cargo test --lib --features rt_{{.rt}},DEBUG,{{.maybe_nightly}}
-      - cargo test --lib --features rt_{{.rt}},DEBUG,sse,ws,{{.maybe_nightly}}
-      - cargo test --lib --features rt_{{.rt}},DEBUG,openapi,{{.maybe_nightly}}
+      - cargo test --lib --features rt_{{.rt}},DEBUG,sse,{{.maybe_nightly}}
+      - cargo test --lib --features rt_{{.rt}},DEBUG,ws,{{.maybe_nightly}}
+      - cargo test --lib --features rt_{{.rt}},DEBUG,sse,ws,openapi,{{.maybe_nightly}}
 
 #### checks ####
   # Assure buildability without "DEBUG" feature
@@ -93,8 +95,9 @@ tasks:
     dir: ./ohkami
     cmds:
       - cargo check --lib {{.MAYBE_NIGHTLY_FEATURES}}
-      - cargo check --lib --features sse,ws,{{.maybe_nightly}}
-      - cargo check --lib --features openapi,{{.maybe_nightly}}
+      - cargo check --lib --features sse,{{.maybe_nightly}}
+      - cargo check --lib --features ws,{{.maybe_nightly}}
+      - cargo check --lib --features sse,ws,openapi,{{.maybe_nightly}}
 
   check:native_rt:
     dir: ./ohkami
@@ -102,8 +105,7 @@ tasks:
       - cargo check --lib --features rt_{{.native_rt}},{{.maybe_nightly}}
       - cargo check --lib --features rt_{{.native_rt}},sse,{{.maybe_nightly}}
       - cargo check --lib --features rt_{{.native_rt}},ws,{{.maybe_nightly}}
-      - cargo check --lib --features rt_{{.native_rt}},sse,ws,{{.maybe_nightly}}
-      - cargo check --lib --features rt_{{.native_rt}},openapi,{{.maybe_nightly}}
+      - cargo check --lib --features rt_{{.native_rt}},sse,ws,openapi,{{.maybe_nightly}}
 
   check:rt_worker:
     dir: ohkami
@@ -111,5 +113,4 @@ tasks:
       - cargo check --target wasm32-unknown-unknown --lib --features rt_worker,{{.maybe_nightly}}
       - cargo check --target wasm32-unknown-unknown --lib --features rt_worker,sse,{{.maybe_nightly}}
       - cargo check --target wasm32-unknown-unknown --lib --features rt_worker,ws,{{.maybe_nightly}}
-      - cargo check --target wasm32-unknown-unknown --lib --features rt_worker,sse,ws,{{.maybe_nightly}}
-      - cargo check --target wasm32-unknown-unknown --lib --features rt_worker,openapi,{{.maybe_nightly}}
+      - cargo check --target wasm32-unknown-unknown --lib --features rt_worker,sse,ws,openapi,{{.maybe_nightly}}

--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -18,9 +18,9 @@ features      = ["rt_tokio", "nightly", "sse", "ws"]
 
 [dependencies]
 # workspace members
-ohkami_lib     = { version = "=0.21.1", path = "../ohkami_lib" }
-ohkami_macros  = { version = "=0.21.1", path = "../ohkami_macros" }
-ohkami_openapi = { optional = true, version = "=0.21.1", path = "../ohkami_openapi" }
+ohkami_lib     = { version = "=0.22.0", path = "../ohkami_lib" }
+ohkami_macros  = { version = "=0.22.0", path = "../ohkami_macros" }
+ohkami_openapi = { optional = true, version = "=0.22.0", path = "../ohkami_openapi" }
 
 # workspace dependencies
 byte_reader = { workspace = true }

--- a/ohkami/src/fang/builtin/jwt.rs
+++ b/ohkami/src/fang/builtin/jwt.rs
@@ -492,7 +492,7 @@ impl<Payload: for<'de> Deserialize<'de>> JWT<Payload> {
 
             #[cfg(feature="openapi")]
             fn openapi_responses() -> crate::openapi::Responses {
-                crate::openapi::Responses::enumerated([
+                crate::openapi::Responses::new([
                     (500, crate::openapi::Response::when("User was not found")
                         .content("text/plain", crate::openapi::string()))
                 ])

--- a/ohkami/src/fang/handler/mod.rs
+++ b/ohkami/src/fang/handler/mod.rs
@@ -78,9 +78,9 @@ impl Handler {
             proc: (&*NOT_FOUND).proc.clone(),
 
             #[cfg(feature="openapi")]
-            openapi_operation: openapi::Operation::with(openapi::Responses::new(
+            openapi_operation: openapi::Operation::with(openapi::Responses::new([(
                 404, openapi::Response::when("default not found")
-            ))
+            )]))
         }
     }
 
@@ -136,7 +136,7 @@ impl Handler {
                 }
             })
         }, #[cfg(feature="openapi")] openapi::Operation::with(
-            openapi::Responses::enumerated([
+            openapi::Responses::new([
                 /* NEVER generate spec of OPTIONS operations */
             ])
         ))

--- a/ohkami/src/ohkami/routing.rs
+++ b/ohkami/src/ohkami/routing.rs
@@ -285,9 +285,11 @@ const _: () = {
                             }
                             res
                         }), #[cfg(feature="openapi")] {use crate::openapi;
-                            openapi::Operation::with(openapi::Responses::new(200, openapi::Response::when("OK")
-                                .content(this.mime, openapi::string().format("binary"))
-                            ))
+                            openapi::Operation::with(openapi::Responses::new([(
+                                200,
+                                openapi::Response::when("OK")
+                                    .content(this.mime, openapi::string().format("binary"))
+                            )]))
                         })
                     }
                 }

--- a/ohkami/src/response/into_response.rs
+++ b/ohkami/src/response/into_response.rs
@@ -83,7 +83,7 @@ impl<B: IntoBody> IntoResponse for B {
             };
             res = res.content(mime_type, Self::openapi_responsebody());
         }
-        openapi::Responses::new(200, res)
+        openapi::Responses::new([(200, res)])
     }
 }
 
@@ -94,7 +94,7 @@ impl IntoResponse for Response {
 
     #[cfg(feature="openapi")]
     fn openapi_responses() -> openapi::Responses {
-        openapi::Responses::new(200, openapi::Response::when("OK"))
+        openapi::Responses::new([(200, openapi::Response::when("OK"))])
     }
 }
 
@@ -105,7 +105,7 @@ impl IntoResponse for Status {
 
     #[cfg(feature="openapi")]
     fn openapi_responses() -> openapi::Responses {
-        openapi::Responses::new(200, openapi::Response::when("OK"))
+        openapi::Responses::new([(200, openapi::Response::when("OK"))])
     }
 }
 
@@ -133,7 +133,7 @@ impl IntoResponse for std::convert::Infallible {
 
     #[cfg(feature="openapi")]
     fn openapi_responses() -> openapi::Responses {
-        openapi::Responses::enumerated([])
+        openapi::Responses::new([])
     }
 }
 
@@ -184,6 +184,6 @@ impl IntoResponse for worker::Error {
 
     #[cfg(feature="openapi")]
     fn openapi_responses() -> openapi::Responses {
-        openapi::Responses::new(500, openapi::Response::when("Internal error in worker"))
+        openapi::Responses::new([(500, openapi::Response::when("Internal error in worker"))])
     }
 }

--- a/ohkami/src/sse/mod.rs
+++ b/ohkami/src/sse/mod.rs
@@ -73,11 +73,11 @@ impl<T: Data> crate::IntoResponse for DataStream<T> {
 
     #[cfg(feature="openapi")]
     fn openapi_responses() -> crate::openapi::Responses {
-        crate::openapi::Responses::new(
+        crate::openapi::Responses::new([(
             200,
             crate::openapi::Response::when("Streaming")
                 .content("text/event-stream", <T as crate::openapi::Schema>::schema())
-        )
+        )])
     }
 }
 

--- a/ohkami/src/typed/status.rs
+++ b/ohkami/src/typed/status.rs
@@ -31,7 +31,10 @@ macro_rules! generate_statuses_as_types_containing_value {
                     if B::CONTENT_TYPE != "" {
                         res = res.content(B::CONTENT_TYPE, B::openapi_responsebody())
                     }
-                    openapi::Responses::new(code.parse().unwrap(), res)
+                    openapi::Responses::new([(
+                        code.parse().unwrap(),
+                        res
+                    )])
                 }
             }
         )*
@@ -104,10 +107,10 @@ macro_rules! generate_statuses_as_types_with_no_value {
                 #[cfg(feature="openapi")]
                 fn openapi_responses() -> crate::openapi::Responses {
                     let (code, message) = $message.split_once(' ').unwrap();
-                    openapi::Responses::new(
+                    openapi::Responses::new([(
                         code.parse().unwrap(),
                         openapi::Response::when(message)
-                    )
+                    )])
                 }
             }
         )*
@@ -156,10 +159,10 @@ macro_rules! generate_redirects {
                 #[cfg(feature="openapi")]
                 fn openapi_responses() -> crate::openapi::Responses {
                     let (code, message) = $message.split_once(' ').unwrap();
-                    openapi::Responses::new(
+                    openapi::Responses::new([(
                         code.parse().unwrap(),
                         openapi::Response::when(message)
-                    )
+                    )])
                 }
             }
         )*

--- a/ohkami/src/util.rs
+++ b/ohkami/src/util.rs
@@ -86,11 +86,11 @@ const _: () = {
 
         #[cfg(feature="openapi")]
         fn openapi_responses() -> crate::openapi::Responses {
-            crate::openapi::Responses::new(
+            crate::openapi::Responses::new([(
                 500,
                 crate::openapi::Response::when("Something went wrong")
                     .content("text/plain", crate::openapi::string())
-            )
+            )])
         }
     }
 };

--- a/ohkami/src/ws/native.rs
+++ b/ohkami/src/ws/native.rs
@@ -123,9 +123,9 @@ impl crate::IntoResponse for WebSocket {
 
     #[cfg(feature="openapi")]
     fn openapi_responses() -> crate::openapi::Responses {
-        crate::openapi::Responses::new(
+        crate::openapi::Responses::new([(
             101,
             crate::openapi::Response::when("Upgrade to WebSocket")
-        )
+        )])
     }
 }

--- a/ohkami/src/ws/worker.rs
+++ b/ohkami/src/ws/worker.rs
@@ -167,6 +167,14 @@ impl crate::IntoResponse for WebSocket {
         // let `worker` crate and Cloudflare Workers to do around
         // headers and something other
     }
+
+    #[cfg(feature="openapi")]
+    fn openapi_responses() -> crate::openapi::Responses {
+        crate::openapi::Responses::new([(
+            101,
+            crate::openapi::Response::when("Upgrade to WebSocket")
+        )])
+    }
 }
 
 /// A utility struct for storing *session* instances of type `S` associated with `worker::WebSocket`s.

--- a/ohkami_openapi/src/_test.rs
+++ b/ohkami_openapi/src/_test.rs
@@ -30,9 +30,10 @@ macro_rules! assert_eq {
     .path("/users", paths::Operations::new()
         .get(
             Operation::with(
-                Responses::new(200, Response::when("A JSON array of user names")
-                    .content("application/json", array(string()))
-                )
+                Responses::new([(
+                    200, Response::when("A JSON array of user names")
+                        .content("application/json", array(string()))
+                )])
             )
             .summary("Returns a list of users.")
             .description("Optional extended description in CommonMark or HTML.")

--- a/ohkami_openapi/src/lib.rs
+++ b/ohkami_openapi/src/lib.rs
@@ -12,7 +12,7 @@ pub mod request;
 pub use request::{Parameter, RequestBody};
 
 pub mod response;
-pub use response::{Responses, Response};
+pub use response::{Responses, Response, Status};
 
 pub mod paths;
 pub use paths::Operation;

--- a/ohkami_openapi/src/response.rs
+++ b/ohkami_openapi/src/response.rs
@@ -55,12 +55,8 @@ pub struct ResponseHeader {
 }
 
 impl Responses {
-    pub fn new(code: u16, response: Response) -> Self {
-        Self(Map::from_iter([(Status::Code(code), response)]))
-    }
-
-    pub fn enumerated<const N: usize>(responses: [(u16, Response); N]) -> Self {
-        Self(Map::from_iter(responses.map(|(code, res)| (Status::Code(code), res))))
+    pub fn new<const N: usize>(code_responses: [(u16, Response); N]) -> Self {
+        Self(Map::from_iter(code_responses.map(|(code, res)| (Status::Code(code), res))))
     }
 
     pub fn or(mut self, code: u16, response: Response) -> Self {

--- a/samples/petstore/src/main.rs
+++ b/samples/petstore/src/main.rs
@@ -162,7 +162,7 @@ impl IntoResponse for Error {
             .with_json(self)
     }
     fn openapi_responses() -> openapi::Responses {
-        openapi::Responses::enumerated([])
+        openapi::Responses::new([])
             .or_default(openapi::Response::when("Unexpected error")
                 .content("application/json", <Self as openapi::Schema>::schema())
             )

--- a/samples/worker-with-openapi/src/error.rs
+++ b/samples/worker-with-openapi/src/error.rs
@@ -35,7 +35,7 @@ impl ohkami::IntoResponse for APIError {
     fn openapi_responses() -> ohkami::openapi::Responses {
         use ohkami::openapi::Response;
 
-        ohkami::openapi::Responses::enumerated([
+        ohkami::openapi::Responses::new([
             (500, Response::when("Worker's internal error")),
             (403, Response::when("Modyfing other user"))
         ])


### PR DESCRIPTION
removing previous `Responses::new`.

Before `Responses::enumerated([(code, response); N])` is more generic than `Responses::new(code, response)` and this `new` is useless. 