### PR TITLE
worker: better Durable Object

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members  = [
 exclude  = [
     "samples",
     "benches",
+    "benches_rt/async-std",
     "benches_rt/glommio",
     "benches_rt/nio",
     "benches_rt/smol",

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -35,7 +35,7 @@ tasks:
     cmds:
       - cd benches && cargo bench --features DEBUG --no-run
       - cd benches_rt/vs_actix-web && cargo check
-      - for: [tokio, smol, nio, glommio]
+      - for: [tokio, async-std, smol, nio, glommio]
         cmd: cd benches_rt/{{.ITEM}} && cargo check
 
   bench:
@@ -59,12 +59,12 @@ tasks:
       # not activating `openapi` feature for testability of README sample codes
 
   test:examples:
-    dir: examples
+    dir: ./examples
     cmds:
       - cargo test
 
   test:samples:
-    dir: samples
+    dir: ./samples
     cmds:
       - chmod +x ./test.sh
       - ./test.sh
@@ -108,7 +108,7 @@ tasks:
       - cargo check --lib --features rt_{{.native_rt}},sse,ws,openapi,{{.maybe_nightly}}
 
   check:rt_worker:
-    dir: ohkami
+    dir: ./ohkami
     cmds:
       - cargo check --target wasm32-unknown-unknown --lib --features rt_worker,{{.maybe_nightly}}
       - cargo check --target wasm32-unknown-unknown --lib --features rt_worker,sse,{{.maybe_nightly}}

--- a/benches_rt/async-std/Cargo.toml
+++ b/benches_rt/async-std/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name    = "ohkami_benches-with-smol"
+name    = "ohkami_benches-with-async-std"
 version = "0.0.0"
 edition = "2021"
 authors = ["kanarus <kanarus786@gmail.com>"]
 
 [dependencies]
 # set `default-features = false` to assure "DEBUG" feature be off even when DEBUGing `../ohkami`
-ohkami  = { path = "../../ohkami", default-features = false, features = ["rt_smol"] }
-smol    = { version = "2" }
+ohkami    = { path = "../../ohkami", default-features = false, features = ["rt_async-std"] }
+async-std = { version = "1", features = ["attributes"] }
 
 [profile.release]
 lto           = true

--- a/benches_rt/async-std/src/bin/param.rs
+++ b/benches_rt/async-std/src/bin/param.rs
@@ -1,0 +1,9 @@
+use ohkami::prelude::*;
+
+#[async_std::main]
+async fn main() {
+    Ohkami::new((
+        "/user/:id"
+            .GET(|id: String| async {id}),
+    )).howl("0.0.0.0:3000").await
+}

--- a/benches_rt/glommio/Cargo.toml
+++ b/benches_rt/glommio/Cargo.toml
@@ -10,15 +10,9 @@ ohkami  = { path = "../../ohkami", default-features = false, features = ["rt_glo
 glommio = { version = "0.9" }
 
 [profile.release]
-opt-level = 3
-debug = false
-debug-assertions = false
-lto = true
-panic = "abort"
-incremental = false
+lto           = true
+panic         = "abort"
 codegen-units = 1
-rpath = false
-strip = false
 
 [features]
 DEBUG = ["ohkami/DEBUG"]

--- a/benches_rt/nio/Cargo.toml
+++ b/benches_rt/nio/Cargo.toml
@@ -10,15 +10,9 @@ ohkami  = { path = "../../ohkami", default-features = false, features = ["rt_nio
 nio     = { version = "0.0" }
 
 [profile.release]
-opt-level = 3
-debug = false
-debug-assertions = false
-lto = true
-panic = "abort"
-incremental = false
+lto           = true
+panic         = "abort"
 codegen-units = 1
-rpath = false
-strip = false
 
 [features]
 DEBUG = ["ohkami/DEBUG"]

--- a/benches_rt/tokio/Cargo.toml
+++ b/benches_rt/tokio/Cargo.toml
@@ -10,15 +10,9 @@ ohkami  = { path = "../../ohkami", default-features = false, features = ["rt_tok
 tokio   = { version = "1", features = ["full"] }
 
 [profile.release]
-opt-level = 3
-debug = false
-debug-assertions = false
-lto = true
-panic = "abort"
-incremental = false
+lto           = true
+panic         = "abort"
 codegen-units = 1
-rpath = false
-strip = false
 
 [features]
 DEBUG = ["ohkami/DEBUG"]

--- a/benches_rt/vs_actix-web/Cargo.toml
+++ b/benches_rt/vs_actix-web/Cargo.toml
@@ -8,12 +8,6 @@ authors = ["kanarus <kanarus786@gmail.com>"]
 actix-web = { version = "4" }
 
 [profile.release]
-opt-level = 3
-debug = false
-debug-assertions = false
-lto = true
-panic = "abort"
-incremental = false
+lto           = true
+panic         = "abort"
 codegen-units = 1
-rpath = false
-strip = false

--- a/ohkami/src/ws/worker.rs
+++ b/ohkami/src/ws/worker.rs
@@ -34,6 +34,93 @@ impl<'req> super::WebSocketContext<'req> {
         WebSocket(session)
     }
 
+    /// WebSocket with a DurableObject.
+    /// 
+    /// ### example
+    /// 
+    /// *room.rs*
+    /// ```no_run
+    /// use ohkami::ws::SessionMap;
+    /// use ohkami::DurableObject; // <--
+    /// 
+    /// #[DurableObject]
+    /// struct Room {
+    ///     name:     Option<String>,
+    ///     state:    worker::State,
+    ///     sessions: SessionMap,
+    /// }
+    /// 
+    /// impl DurableObject for Room {
+    ///     fn new(state: worker::State, env: worker::Env) -> Self {
+    ///         let mut sessions = SessionMap::new();
+    /// 
+    ///         // restore sessions if woken up from hibernation
+    ///         for ws in state.get_websockets() {
+    ///             if let Some(session) = Session::restore(&ws) {
+    ///                 sessions.insert(ws, session).unwrap();
+    ///             }
+    ///         }
+    ///         
+    ///         Self { name: None, state, sessions }
+    ///     }
+    /// 
+    ///     async fn fetch(
+    ///         &mut self,
+    ///         req: worker::Request
+    ///     ) -> worker::Result<worker::Response> {
+    ///         todo!()
+    ///     }
+    /// 
+    ///     async fn websocket_message(
+    ///         &mut self,
+    ///         ws:      WebSocket,
+    ///         message: worker::WebSocketIncomingMessage,
+    ///     ) -> worker::Result<()> {
+    ///         todo!()
+    ///     }
+    /// }
+    /// ```
+    /// 
+    /// *wrangler.toml*
+    /// ```toml
+    /// #..........................#
+    /// 
+    /// [[durable_objects.bindings]]
+    /// name = "ROOMS"
+    /// class_name = "Room" # <-- struct name
+    /// 
+    /// [[migrations]]
+    /// tag = "v1"
+    /// new_classes = ["Room"]
+    /// 
+    /// #..........................#
+    /// ```
+    /// 
+    /// *lib.rs*
+    /// ```
+    /// use ohkami::prelude::*;
+    /// use ohkami::ws::{WebSocketContext, WebSocket};
+    /// 
+    /// #[ohkami::bindings]
+    /// struct Bindings;
+    /// 
+    /// #[ohkami::worker]
+    /// async fn main() -> Ohkami {
+    ///     Ohkami::new((
+    ///         "/ws/:room_name".GET(ws_chatroom)
+    ///     ))
+    /// }
+    /// 
+    /// async fn ws_chatroom(room_name: &str,
+    ///     ctx: WebSocketContext<'_>,
+    ///     Bindings { ROOMS, .. }: Bindings,
+    /// ) -> Result<WebSocket, worker::Error> {
+    ///     let room = ROOMS
+    ///         .id_from_name(room_name)?
+    ///         .get_stub()?;
+    ///     ctx.upgrade_durable(room).await
+    /// }
+    /// ```
     pub async fn upgrade_durable(
         self,
         durable_object: worker::Stub
@@ -45,6 +132,8 @@ impl<'req> super::WebSocketContext<'req> {
             ]))
         ).unwrap(), durable_object).await
     }
+    /// [`upgrade_durable`](crate::ws::worker::WebSocketContext::upgrade_durable)
+    /// with specified `worker::Request`.
     pub async fn upgrade_durable_with(
         self,
         req: worker::Request,

--- a/ohkami_macros/src/worker/durable.rs
+++ b/ohkami_macros/src/worker/durable.rs
@@ -1,0 +1,145 @@
+pub(super) enum DurableObjectType {
+    Fetch,
+    Alarm,
+    WebSocket,
+}
+impl syn::parse::Parse for DurableObjectType {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let ident = input.parse::<syn::Ident>()?;
+        match &*ident.to_string() {
+            "fetch" => Ok(Self::Fetch),
+            "alarm" => Ok(Self::Alarm),
+            "websocket" => Ok(Self::WebSocket),
+            _ => Err(syn::Error::new(ident.span(), "must have either 'fetch', 'alarm' or 'websocket' attribute, e.g. #[durable_object(websocket)]"))
+        }
+    }
+}
+
+pub(super) mod bindgen_methods {
+    use proc_macro2::TokenStream;
+    use quote::quote;
+
+    pub fn core() -> TokenStream {
+        quote! {
+            #[wasm_bindgen(constructor)]
+            pub fn new(
+                state: ::worker::worker_sys::DurableObjectState,
+                env:   ::worker::Env
+            ) -> Self {
+                <Self as ::ohkami::DurableObject>::new(
+                    ::worker::durable::State::from(state),
+                    env
+                )
+            }
+
+            #[wasm_bindgen(js_name = fetch)]
+            pub fn fetch(
+                &mut self,
+                req: ::worker::worker_sys::web_sys::Request
+            ) -> ::worker::js_sys::Promise {
+                // SAFETY:
+                // Durable Object will never be destroyed while there is still
+                // a running promise inside of it, therefore we can let a reference
+                // to the durable object escape into a static-lifetime future.
+                let static_self: &'static mut Self = unsafe {&mut *(self as *mut _)};
+
+                ::worker::wasm_bindgen_futures::future_to_promise(async move {
+                    <Self as ::ohkami::DurableObject>::fetch(static_self, req.into()).await
+                        .map(worker::worker_sys::web_sys::Response::from)
+                        .map(::worker::wasm_bindgen::JsValue::from)
+                        .map_err(::worker::wasm_bindgen::JsValue::from)
+                })
+            }
+        }
+    }
+
+    pub fn alarm() -> TokenStream {
+        quote! {
+            #[wasm_bindgen(js_name = alarm)]
+            pub fn alarm(&mut self) -> ::worker::js_sys::Promise {
+                // SAFETY:
+                // Durable Object will never be destroyed while there is still
+                // a running promise inside of it, therefore we can let a reference
+                // to the durable object escape into a static-lifetime future.
+                let static_self: &'static mut Self = unsafe {&mut *(self as *mut _)};
+
+                ::worker::wasm_bindgen_futures::future_to_promise(async move {
+                    <Self as ::ohkami::DurableObject>::alarm(static_self).await
+                        .map(::worker::worker_sys::web_sys::Response::from)
+                        .map(::worker::wasm_bindgen::JsValue::from)
+                        .map_err(::worker::wasm_bindgen::JsValue::from)
+                })
+            }
+        }
+    }
+
+    pub fn websocket() -> TokenStream {
+        quote! {
+            #[wasm_bindgen(js_name = webSocketMessage)]
+            pub fn websocket_message(
+                &mut self,
+                ws: ::worker::worker_sys::web_sys::WebSocket,
+                message: ::worker::wasm_bindgen::JsValue
+            ) -> ::worker::js_sys::Promise {
+                let message = match message.as_string() {
+                    Some(message) => ::worker::WebSocketIncomingMessage::String(message),
+                    None => ::worker::WebSocketIncomingMessage::Binary(
+                        ::worker::js_sys::Uint8Array::new(&message).to_vec()
+                    )
+                };
+
+                // SAFETY:
+                // Durable Object will never be destroyed while there is still
+                // a running promise inside of it, therefore we can let a reference
+                // to the durable object escape into a static-lifetime future.
+                let static_self: &'static mut Self = unsafe {&mut *(self as *mut _)};
+
+                ::worker::wasm_bindgen_futures::future_to_promise(async move {
+                    <Self as ::ohkami::DurableObject>::websocket_message(static_self, ws.into(), message).await
+                        .map(|_| ::worker::wasm_bindgen::JsValue::NULL)
+                        .map_err(::worker::wasm_bindgen::JsValue::from)
+                })
+            }
+
+            #[wasm_bindgen(js_name = webSocketClose)]
+            pub fn websocket_close(
+                &mut self,
+                ws: ::worker::worker_sys::web_sys::WebSocket,
+                code: usize,
+                reason: String,
+                was_clean: bool
+            ) -> ::worker::js_sys::Promise {
+                // SAFETY:
+                // Durable Object will never be destroyed while there is still
+                // a running promise inside of it, therefore we can let a reference
+                // to the durable object escape into a static-lifetime future.
+                let static_self: &'static mut Self = unsafe {&mut *(self as *mut _)};
+
+                ::worker::wasm_bindgen_futures::future_to_promise(async move {
+                    <Self as ::ohkami::DurableObject>::websocket_close(static_self, ws.into(), code, reason, was_clean).await
+                        .map(|_| ::worker::wasm_bindgen::JsValue::NULL)
+                        .map_err(::worker::wasm_bindgen::JsValue::from)
+                })
+            }
+
+            #[wasm_bindgen(js_name = webSocketError)]
+            pub fn websocket_error(
+                &mut self,
+                ws: ::worker::worker_sys::web_sys::WebSocket,
+                error: ::worker::wasm_bindgen::JsValue
+            ) -> ::worker::js_sys::Promise {
+                // SAFETY:
+                // Durable Object will never be destroyed while there is still
+                // a running promise inside of it, therefore we can let a reference
+                // to the durable object escape into a static-lifetime future.
+                let static_self: &'static mut Self = unsafe {&mut *(self as *mut _)};
+
+                ::worker::wasm_bindgen_futures::future_to_promise(async move {
+                    <Self as ::ohkami::DurableObject>::websocket_error(static_self, ws.into(), error.into()).await
+                        .map(|_| ::worker::wasm_bindgen::JsValue::NULL)
+                        .map_err(::worker::wasm_bindgen::JsValue::from)
+                })
+            }
+        }
+    }
+}

--- a/samples/test.sh
+++ b/samples/test.sh
@@ -42,9 +42,13 @@ cd $SAMPLES/worker-bindings && \
     cargo check
 test $? -ne 0 && exit 155 || :
 
+cd $SAMPLES/worker-durable-websocket && \
+    cargo check
+test $? -ne 0 && exit 156 || :
+
 cd $SAMPLES/worker-with-openapi && \
     cp wrangler.toml.sample wrangler.toml && \
     (test -f openapi.json || echo '{}' >> openapi.json) && \
     npm run openapi && \
     diff openapi.json openapi.json.sample
-test $? -ne 0 && exit 156 || :
+test $? -ne 0 && exit 157 || :

--- a/samples/worker-bindings/wrangler.toml
+++ b/samples/worker-bindings/wrangler.toml
@@ -1,12 +1,4 @@
-name = "ohkami-worker-with-openapi"
-main = "build/worker/shim.mjs"
-compatibility_date = "2024-04-19"
-
-# `worker-build` and `wasm-pack` is required
-# (run `cargo install wasm-pack worker-build` to install)
-
-[build]
-command = "test $OHKAMI_WORKER_DEV && worker-build --dev || worker-build -- --no-default-features"
+name = "worker-bindings-test"
 
 [vars]
 VARIABLE_1 = "hoge"

--- a/samples/worker-durable-websocket/.cargo/config.toml
+++ b/samples/worker-durable-websocket/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-unknown-unknown"

--- a/samples/worker-durable-websocket/Cargo.toml
+++ b/samples/worker-durable-websocket/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name    = "worker-with-openapi"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+# set `default-features = false` to assure "DEBUG" feature be off even when DEBUGing `../ohkami`
+ohkami = { path = "../../ohkami", default-features = false, features = ["rt_worker", "ws"] }
+worker = { version = "0.5" }

--- a/samples/worker-durable-websocket/package.json
+++ b/samples/worker-durable-websocket/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "ohkami-worker-durable-websocket",
+	"version": "0.1.0",
+	"private": true,
+	"scripts": {
+		"deploy": "export OHKAMI_WORKER_DEV='' && wrangler deploy",
+		"dev": "export OHKAMI_WORKER_DEV=1 && wrangler dev",
+		"openapi": "node ../../scripts/workers_openapi.js"
+	},
+	"devDependencies": {
+		"wrangler": "^3.50"
+	}
+}

--- a/samples/worker-durable-websocket/src/lib.rs
+++ b/samples/worker-durable-websocket/src/lib.rs
@@ -1,0 +1,24 @@
+mod room;
+
+use ohkami::prelude::*;
+use ohkami::ws::{WebSocketContext, WebSocket};
+
+#[ohkami::bindings]
+struct Bindings;
+
+#[ohkami::worker]
+async fn main() -> Ohkami {
+    Ohkami::new((
+        "/ws/:room_name".GET(ws_chatroom),
+    ))
+}
+
+async fn ws_chatroom(room_name: &str,
+    ctx: WebSocketContext<'_>,
+    Bindings { ROOMS, .. }: Bindings,
+) -> Result<WebSocket, worker::Error> {
+    let room = ROOMS
+        .id_from_name(room_name)?
+        .get_stub()?;
+    ctx.upgrade_durable(room).await
+}

--- a/samples/worker-durable-websocket/src/room.rs
+++ b/samples/worker-durable-websocket/src/room.rs
@@ -1,0 +1,47 @@
+#![allow(unused/* just for sample of WebSocket with `ohkami::DurableObject` */)]
+
+use ohkami::serde::{Serialize, Deserialize};
+use ohkami::ws::SessionMap;
+use ohkami::DurableObject; // <--
+
+#[DurableObject]
+struct Room {
+    name:     Option<String>,
+    state:    worker::State,
+    sessions: SessionMap<Session>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Session {
+    username: String,
+}
+
+impl DurableObject for Room {
+    fn new(state: worker::State, env: worker::Env) -> Self {
+        let mut sessions = SessionMap::new();
+
+        // restore sessions if woken up from hibernation
+        for ws in state.get_websockets() {
+            if let Ok(Some(session)) = ws.deserialize_attachment() {
+                sessions.insert(ws, session).unwrap();
+            }
+        }
+        
+        Self { name: None, state, sessions }
+    }
+
+    async fn fetch(
+        &mut self,
+        req: worker::Request
+    ) -> worker::Result<worker::Response> {
+        todo!()
+    }
+
+    async fn websocket_message(
+        &mut self,
+        ws:      worker::WebSocket,
+        message: worker::WebSocketIncomingMessage,
+    ) -> worker::Result<()> {
+        todo!()
+    }
+}

--- a/samples/worker-durable-websocket/wrangler.toml
+++ b/samples/worker-durable-websocket/wrangler.toml
@@ -1,0 +1,17 @@
+name = "ohkami-worker-durable-websocket"
+main = "build/worker/shim.mjs"
+compatibility_date = "2024-04-19"
+
+# `worker-build` and `wasm-pack` is required
+# (run `cargo install wasm-pack worker-build` to install)
+
+[build]
+command = "test $OHKAMI_WORKER_DEV && worker-build --dev || worker-build -- --no-default-features"
+
+[[durable_objects.bindings]]
+name       = "ROOMS"
+class_name = "Room"
+
+[[migrations]]
+tag         = "v1"
+new_classes = ["Room"]


### PR DESCRIPTION
Add `ohkami::{DurableObject, #[DurableObject]}`.

They are what I'm trying to update in `worker` crate itself, but the PR is not reviewed for a long time. So this PR ports them into `ohkami`. See https://github.com/cloudflare/workers-rs/pull/675 for detailed background.