### PR TITLE
openapi: tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,13 +151,14 @@ Only you have to
 - Derive `openapi::Schema` for all your schema structs
 - Make your `Ohkami` call `.generate(openapi::OpenAPI { ... })`
 
-to generate consistent OpenAPI document. You don't need to take care of writing accurate methods, paths, parameters, contents, ... for this OpenAPI feature; All they are done by Ohkami.
+to generate consistent OpenAPI document.
+
+You don't need to take care of writing accurate methods, paths, parameters, contents, ... for this OpenAPI feature; All they are done by Ohkami.
 
 Of course, you can flexibly customize schemas ( by hand-implemetation of `Schema` ), descriptions or other parts ( by `#[operation]` attribute and `openapi_*` hooks ).
 
 ```rust,ignore
 use ohkami::prelude::*;
-use ohkami::format::JSON;
 use ohkami::typed::status;
 use ohkami::openapi;
 
@@ -211,7 +212,7 @@ async fn main() {
     o.generate(openapi::OpenAPI {
         title: "Users Server",
         version: "0.1.0",
-        servers: vec![
+        servers: &[
             openapi::Server::at("localhost:5000"),
         ]
     });

--- a/ohkami/src/fang/builtin/basicauth.rs
+++ b/ohkami/src/fang/builtin/basicauth.rs
@@ -103,7 +103,7 @@ const _: () = {
         }
 
         #[cfg(feature="openapi")]
-        fn openapi_map_operation(operation: openapi::Operation) -> openapi::Operation {
+        fn openapi_map_operation(&self, operation: openapi::Operation) -> openapi::Operation {
             use openapi::security::SecurityScheme;
             operation.security(SecurityScheme::Basic("basicAuth"), &[])
         }
@@ -128,7 +128,7 @@ const _: () = {
         }
 
         #[cfg(feature="openapi")]
-        fn openapi_map_operation(operation: openapi::Operation) -> openapi::Operation {
+        fn openapi_map_operation(&self, operation: openapi::Operation) -> openapi::Operation {
             use openapi::security::SecurityScheme;
             operation.security(SecurityScheme::Basic("basicAuth"), &[])
         }

--- a/ohkami/src/fang/middleware/util.rs
+++ b/ohkami/src/fang/middleware/util.rs
@@ -86,7 +86,7 @@ pub trait FangAction: Clone + SendSyncOnNative + 'static {
     }
 
     #[cfg(feature="openapi")]
-    fn openapi_map_operation(operation: openapi::Operation) -> openapi::Operation {
+    fn openapi_map_operation(&self, operation: openapi::Operation) -> openapi::Operation {
         operation
     }
 }
@@ -102,7 +102,7 @@ const _: () = {
 
         #[cfg(feature="openapi")]
         fn openapi_map_operation(&self, operation: openapi::Operation) -> openapi::Operation {
-            <Self as FangAction>::openapi_map_operation(operation)
+            <Self as FangAction>::openapi_map_operation(self, operation)
         }
     }
 

--- a/ohkami_openapi/src/paths.rs
+++ b/ohkami_openapi/src/paths.rs
@@ -150,8 +150,8 @@ impl Operation {
         self.operationId = Some(operationId);
         self
     }
-    pub fn tags<const N: usize>(mut self, tags: [&'static str; N]) -> Self {
-        self.tags = tags.into();
+    pub fn with_tag(mut self, tag: &'static str) -> Self {
+        self.tags.push(tag);
         self
     }
     pub fn summary(mut self, summary: &'static str) -> Self {

--- a/samples/openapi-tags/.gitignore
+++ b/samples/openapi-tags/.gitignore
@@ -1,0 +1,1 @@
+openapi.json

--- a/samples/openapi-tags/Cargo.toml
+++ b/samples/openapi-tags/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name    = "openapi-tags"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+# set `default-features = false` to assure "DEBUG" feature be off even when DEBUGing `../ohkami`
+ohkami  = { path = "../../ohkami", default-features = false, features = ["rt_tokio", "openapi"] }

--- a/samples/openapi-tags/openapi.json.sample
+++ b/samples/openapi-tags/openapi.json.sample
@@ -1,0 +1,253 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Sample API",
+    "version": "0.0.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:6666"
+    }
+  ],
+  "paths": {
+    "/api": {
+      "get": {
+        "tags": [
+          "api"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tasks/list": {
+      "get": {
+        "tags": [
+          "tasks",
+          "api"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "title": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "title",
+                      "description"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tasks/{id}/edit": {
+      "put": {
+        "tags": [
+          "tasks",
+          "api"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        }
+      }
+    },
+    "/api/users": {
+      "get": {
+        "tags": [
+          "users",
+          "api"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "age": {
+                        "type": "integer"
+                      },
+                      "id": {
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "name"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "users",
+          "api"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "age": {
+                    "type": "integer"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "age": {
+                      "type": "integer"
+                    },
+                    "id": {
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/users/{id}": {
+      "get": {
+        "tags": [
+          "users",
+          "api"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "integer"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "age": {
+                      "type": "integer"
+                    },
+                    "id": {
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        }
+      }
+    }
+  }
+}

--- a/samples/openapi-tags/src/main.rs
+++ b/samples/openapi-tags/src/main.rs
@@ -1,0 +1,117 @@
+#![allow(unused/* just for demo of `openapi::Tag` */)]
+
+use ohkami::prelude::*;
+use ohkami::typed::status;
+use ohkami::openapi;
+
+mod users {
+    use super::*;
+
+    pub(super) fn ohkami() -> Ohkami {
+        Ohkami::new((
+            openapi::Tag("users"),
+            "/"
+                .GET(list_users)
+                .POST(create_user),
+            "/:id"
+                .GET(get_user_profile),
+        ))
+    }
+
+    #[derive(Serialize, openapi::Schema)]
+    struct User {
+        id:   i32,
+        name: String,
+        age:  Option<u8>,
+    }
+
+    #[derive(Deserialize, openapi::Schema)]
+    struct CreateUser<'req> {
+        name: &'req str,
+        age:  Option<u8>,
+    }
+
+    async fn list_users() -> JSON<Vec<User>> {
+        JSON(vec![])
+    }
+
+    async fn create_user(
+        JSON(req): JSON<CreateUser<'_>>,
+    ) -> status::Created<JSON<User>> {
+        status::Created(JSON(User {
+            id:   42,
+            name: req.name.into(),
+            age:  req.age
+        }))
+    }
+
+    async fn get_user_profile(id: i32) -> JSON<User> {
+        JSON(User {
+            id,
+            name: "unknown".into(),
+            age:  Some(42)
+        })
+    }
+}
+
+mod tasks {
+    use super::*;
+
+    pub(super) fn ohkami() -> Ohkami {
+        Ohkami::new((
+            openapi::Tag("tasks"),
+            "/list"
+                .GET(list_tasks),
+            "/:id/edit"
+                .PUT(edit_task),
+        ))
+    }
+
+    #[derive(Serialize, openapi::Schema)]
+    struct Task {
+        id:          i32,
+        title:       String,
+        description: String,
+    }
+
+    #[derive(Deserialize, openapi::Schema)]
+    struct EditTask<'req> {
+        title:       Option<&'req str>,
+        description: Option<&'req str>,
+    }
+
+    async fn list_tasks() -> JSON<Vec<Task>> {
+        JSON(vec![])
+    }
+
+    async fn edit_task(
+        JSON(req): JSON<EditTask<'_>>
+    ) -> status::NoContent {
+        status::NoContent
+    }
+}
+
+fn main() {
+    let users_ohkami = users::ohkami();
+    let tasks_ohkami = tasks::ohkami();
+
+    let api_ohkami = Ohkami::new((
+        openapi::Tag("api"),
+        "/"
+            .GET(|| async {"Hello, tags!"}),
+        "/users".By(users_ohkami),
+        "/tasks".By(tasks_ohkami),
+    ));
+
+    let o = Ohkami::new((
+        "/health"
+            .GET(|| async {status::NoContent}),
+        "/api".By(api_ohkami),
+    ));
+
+    o.generate(openapi::OpenAPI {
+        title:   "Sample API",
+        version: "0.0.0",
+        servers: &[openapi::Server::at("http://localhost:6666")]
+    })
+}

--- a/samples/petstore/src/main.rs
+++ b/samples/petstore/src/main.rs
@@ -57,7 +57,7 @@ async fn main() {
     o.generate(openapi::OpenAPI {
         title: "Petstore API",
         version: "1.0.0",
-        servers: vec![
+        servers: &[
             openapi::Server::at("http://localhost:5050")
         ]
     });

--- a/samples/readme-openapi/src/main.rs
+++ b/samples/readme-openapi/src/main.rs
@@ -53,7 +53,7 @@ async fn main() {
     o.generate(openapi::OpenAPI {
         title: "Users Server",
         version: "0.1.0",
-        servers: vec![
+        servers: &[
             openapi::Server::at("localhost:5000"),
         ]
     });

--- a/samples/readme-openapi/src/main.rs
+++ b/samples/readme-openapi/src/main.rs
@@ -1,5 +1,4 @@
 use ohkami::prelude::*;
-use ohkami::format::JSON;
 use ohkami::typed::status;
 use ohkami::openapi;
 

--- a/samples/streaming/src/main.rs
+++ b/samples/streaming/src/main.rs
@@ -12,7 +12,7 @@ async fn main() {
     o.generate(OpenAPI {
         title:   "Streaming Sample API",
         version: "0.1.0",
-        servers: vec![Server::at("http://localhost:8080")]
+        servers: &[Server::at("http://localhost:8080")]
     });
 
     o.howl("localhost:8080").await

--- a/samples/test.sh
+++ b/samples/test.sh
@@ -4,6 +4,11 @@ set -Ceu
 
 SAMPLES=$(pwd)
 
+cd $SAMPLES/openapi-tags && \
+    cargo run && \
+    diff openapi.json openapi.json.sample
+test $? -ne 0 && exit 150 || :
+
 cd $SAMPLES/petstore && \
     cargo build && \
     cd client && \

--- a/samples/worker-with-openapi/src/fang.rs
+++ b/samples/worker-with-openapi/src/fang.rs
@@ -43,7 +43,7 @@ impl FangAction for TokenAuth {
     }
 
     #[cfg(feature="openapi")]
-    fn openapi_map_operation(operation: openapi::Operation) -> openapi::Operation {
+    fn openapi_map_operation(&self, operation: openapi::Operation) -> openapi::Operation {
         operation.security(
             openapi::SecurityScheme::Bearer("tokenAuth", Some("JSON (user_id, token)")),
             &[]


### PR DESCRIPTION
Support tag in OpenAPI:

*lib.rs*
```rust
mod openapi {
...

    /// A fang to set OpenAPI tag for handlers of a `Ohkami`
    /// 
    /// ## note
    /// 
    /// * OpenAPI tags are inherited and stacked for child `Ohkami`s (if any).
    /// * This is a fang, but introduces NO runtime overhead.
    /// 
    /// ## example
    /// 
    /// ```ignore
    /// use ohkami::prelude::*;
    /// use ohkami::openapi;
    /// 
    /// #[tokio::main]
    /// async fn main() {
    ///     let users_ohkami = Ohkami::new((
    ///         openapi::Tag("users"),
    ///         "/"
    ///             .GET(list_users),
    ///             .POST(create_user),
    ///         "/:id"
    ///             .GET(get_user_profile),
    ///     ));
    ///     
    ///     Ohkami::new((
    ///         "/users".By(users_ohkami),
    ///         
    ///         // ...
    ///     )).howl("localhost:5050").await
    /// }
    /// # async fn list_users() {}
    /// # async fn create_user() {}
    /// # async fn get_user_profile() {}
    /// ```
    pub struct Tag(pub &'static str);
    impl<I: crate::FangProc> crate::Fang<I> for Tag {
        /// just pass `inner` through
        type Proc = I;
        fn chain(&self, inner: I) -> Self::Proc {inner}

        /// add tag for operations of `Ohkami` having this `Tag`
        fn openapi_map_operation(&self, operation: Operation) -> Operation {
            operation.with_tag(self.0)
        }
    }
}
```