### PR TITLE
chore(openapi): worker_openapi.js: add `--skip-login` option for diff test

### DIFF
--- a/samples/test.sh
+++ b/samples/test.sh
@@ -54,6 +54,6 @@ test $? -ne 0 && exit 156 || :
 cd $SAMPLES/worker-with-openapi && \
     cp wrangler.toml.sample wrangler.toml && \
     (test -f openapi.json || echo '{}' >> openapi.json) && \
-    npm run openapi && \
+    npm run openapi -- --skip-login && \
     diff openapi.json openapi.json.sample
 test $? -ne 0 && exit 157 || :

--- a/samples/test.sh
+++ b/samples/test.sh
@@ -55,5 +55,14 @@ cd $SAMPLES/worker-with-openapi && \
     cp wrangler.toml.sample wrangler.toml && \
     (test -f openapi.json || echo '{}' >> openapi.json) && \
     npm run openapi -- --skip-login && \
-    diff openapi.json openapi.json.sample
+    diff openapi.json openapi.json.sample && \
+    # FIXME : to generic way (this is a stopgap for testing
+    # this functionality in at least my local env)
+    (test $(whoami) = kanarus && \
+        npm run openapi && \
+        cp openapi.json.loggedin.sample tmp.json && \
+        sed -i "s/{{ ACCOUNT_NAME }}/kanarus/" tmp.json && \
+        diff openapi.json tmp.json \
+        ; (test -f tmp.json && rm tmp.json) \
+    || :)
 test $? -ne 0 && exit 157 || :

--- a/samples/worker-with-openapi/openapi.json.loggedin.sample
+++ b/samples/worker-with-openapi/openapi.json.loggedin.sample
@@ -1,0 +1,314 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "ohkami-worker-with-openapi",
+    "version": "0.1.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:8787",
+      "description": "local dev"
+    },
+    {
+      "url": "https://ohkami-worker-with-openapi.{{ ACCOUNT_NAME }}.workers.dev",
+      "description": "production"
+    }
+  ],
+  "paths": {
+    "/api/tweets": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Tweet"
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Modyfing other user"
+          },
+          "500": {
+            "description": "Worker's internal error"
+          }
+        }
+      },
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "content": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "content"
+                ]
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tokenAuth": []
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Tweet"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Modyfing other user"
+          },
+          "500": {
+            "description": "Worker's internal error"
+          }
+        }
+      }
+    },
+    "/api/users": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/UserProfile"
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Modyfing other user"
+          },
+          "500": {
+            "description": "Worker's internal error"
+          }
+        }
+      },
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "token": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "token"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserProfile"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Modyfing other user"
+          },
+          "500": {
+            "description": "Worker's internal error"
+          }
+        }
+      }
+    },
+    "/api/users/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "integer"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserProfile"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Modyfing other user"
+          },
+          "500": {
+            "description": "Worker's internal error"
+          }
+        }
+      },
+      "put": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "integer"
+            },
+            "required": true
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "age": {
+                    "type": "integer"
+                  },
+                  "location": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "tokenAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "403": {
+            "description": "Modyfing other user"
+          },
+          "500": {
+            "description": "Worker's internal error"
+          }
+        }
+      }
+    },
+    "/openapi.json": {
+      "get": {
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Tweet": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "posted_at": {
+            "type": "string"
+          },
+          "user_id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "user_name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "user_id",
+          "user_name",
+          "content",
+          "posted_at"
+        ]
+      },
+      "UserProfile": {
+        "type": "object",
+        "properties": {
+          "age": {
+            "type": "integer"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "location": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ]
+      }
+    },
+    "securitySchemes": {
+      "basicAuth": {
+        "type": "http",
+        "scheme": "basic"
+      },
+      "tokenAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JSON (user_id, token)"
+      }
+    }
+  }
+}

--- a/scripts/workers_openapi.js
+++ b/scripts/workers_openapi.js
@@ -16,6 +16,9 @@ const app = (() => {
         /** @type {string} */
         #outputPath = "openapi.json";
 
+        /** @type {boolean} */
+        #skipLogin = false;
+
         /** @type {[string]} */
         #additionalOptions = [];
 
@@ -67,6 +70,10 @@ const app = (() => {
                             this.#outputPath = process.argv[i + 1];
                             i += 2;
                             break;
+                        case "--skip-login":
+                            this.#skipLogin = true;
+                            i += 1;
+                            break;
                         case "--":
                             this.#additionalOptions = process.argv.slice(i + 1);
                             i = process.argv.length;
@@ -85,6 +92,11 @@ const app = (() => {
             return this.#outputPath;
         }
 
+        /** @returns {boolean} */
+        get skipLogin() {
+            return this.#skipLogin;
+        }
+
         /** @returns {string} */
         get additionalOptions() {
             return this.#additionalOptions;
@@ -100,7 +112,7 @@ const app = (() => {
             return this.#workerName;
         }
 
-        /** @returns {string | null} */
+        /** @returns {string | undefined} */
         get cloudflareAccountName() {
             return this.#cloudflareAccountName;
         }
@@ -141,6 +153,11 @@ const app = (() => {
 })();
 
 try {
+    if (app.skipLogin) {
+        /* goto `catch` and skip `wrangler whoami` */
+        throw "specified `--skip-login`";
+    }
+
     const e = new TextDecoder();
 
     const wrangler_whoami = spawn("npx", ["wrangler", "whoami"]);
@@ -179,7 +196,7 @@ try {
         });
     });
 } catch (e) {
-    app.warn(`Error or unexpected output of wrangler: ${e}`);
+    app.warn(`skipping login: ${e}`);
 }
 
 try {


### PR DESCRIPTION
By default, `worker_openapi.js` automatically runs `npx wrangler login` and gets cloudflare account name to generate

```json
,
{
  "url": "https://{worker-name}.{account-name}.workers.dev",
  "description": "production"
}
```

in `openapi.json` if needed.

But this makes an difference between results in local and one in remote CI due to existence of Cloudflare credential, so before we can't make this part contained in `openapi.json.sample` for remote CI without login, while had to temporarily adding it only just before local diff-test for with login.

This PR eliminates that annoying hand process by introducing `--skip-login` option.

## note

Currently local diff test with logged in is temporary, executed only in my ( @kanarus 's ) local env; FIXME to generic way