### PR TITLE
worker: Support manual binding in `#[bindings]`

### DIFF
--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -76,7 +76,7 @@ rt_glommio = ["__rt_native__",
     "dep:num_cpus",
 ]
 rt_worker = ["__rt__",
-    "dep:worker",
+    "dep:worker", "worker/d1", "worker/queue",
     "ohkami_macros/worker",
 ]
 rt_lambda = ["__rt__",

--- a/ohkami/src/x_worker.rs
+++ b/ohkami/src/x_worker.rs
@@ -5,14 +5,14 @@ pub use ::ohkami_macros::{worker, bindings, DurableObject};
 pub mod bindings {
     pub type Var           = &'static str;
     pub type AI            = ::worker::Ai;
-    pub type D1            = ::worker::d1::D1Database;
     pub type KV            = ::worker::kv::KvStore;
     pub type R2            = ::worker::Bucket;
-    pub type Queue         = ::worker::Queue;
     pub type Service       = ::worker::Fetcher;
     pub type DurableObject = ::worker::ObjectNamespace;
+    pub type D1            = ::worker::d1::D1Database;
+    pub type Queue         = ::worker::Queue;
 }
-    
+
 #[doc(hidden)]
 #[allow(non_camel_case_types)]
 pub trait has_DurableObject_attribute {}

--- a/ohkami/src/x_worker.rs
+++ b/ohkami/src/x_worker.rs
@@ -1,6 +1,17 @@
 #![cfg(feature="rt_worker")]
 
 pub use ::ohkami_macros::{worker, bindings, DurableObject};
+
+pub mod bindings {
+    pub type Var           = &'static str;
+    pub type AI            = ::worker::Ai;
+    pub type D1            = ::worker::d1::D1Database;
+    pub type KV            = ::worker::kv::KvStore;
+    pub type R2            = ::worker::Bucket;
+    pub type Queue         = ::worker::Queue;
+    pub type Service       = ::worker::Fetcher;
+    pub type DurableObject = ::worker::ObjectNamespace;
+}
     
 #[doc(hidden)]
 #[allow(non_camel_case_types)]

--- a/ohkami_macros/src/lib.rs
+++ b/ohkami_macros/src/lib.rs
@@ -260,7 +260,7 @@ pub fn DurableObject(args: proc_macro::TokenStream, input: proc_macro::TokenStre
 ///   For that, all you have to do is just **deleting `;` and immediate restoring it**.
 #[proc_macro_attribute]
 pub fn bindings(env_name: proc_macro::TokenStream, bindings_struct: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    worker::bindings(env.into(), bindings_struct.into())
+    worker::bindings(env_name.into(), bindings_struct.into())
         .unwrap_or_else(syn::Error::into_compile_error)
         .into()
 }

--- a/ohkami_macros/src/worker.rs
+++ b/ohkami_macros/src/worker.rs
@@ -2,8 +2,10 @@
 
 mod meta;
 mod durable;
+mod binding;
 
 use crate::util;
+
 use proc_macro2::{Span, TokenStream};
 use syn::{spanned::Spanned, Error, Ident, ItemFn, ItemStruct, Result};
 use quote::quote;
@@ -85,7 +87,9 @@ pub fn worker(args: TokenStream, ohkami_fn: TokenStream) -> Result<TokenStream> 
     })
 }
 
-pub fn bindings(env: TokenStream, bindings_struct: TokenStream) -> Result<TokenStream> {
+pub fn bindings(env_name: TokenStream, bindings_struct: TokenStream) -> Result<TokenStream> {
+    use self::binding::Binding;
+
     fn callsite(msg: impl std::fmt::Display) -> Error {
         Error::new(Span::call_site(), msg)
     }
@@ -93,20 +97,11 @@ pub fn bindings(env: TokenStream, bindings_struct: TokenStream) -> Result<TokenS
         Error::new(Span::call_site(), "Invalid wrangler.toml")
     }
 
-    let env: Option<Ident> = (!env.is_empty()).then(|| syn::parse2(env)).transpose()?;
-
     let bindings_struct: ItemStruct = syn::parse2(bindings_struct)?; {
         if !bindings_struct.generics.params.is_empty() {
             return Err(Error::new(
                 bindings_struct.generics.params.span(),
                 "`#[bindings]` doesn't support generics"
-            ))
-        }
-        if !bindings_struct.fields.is_empty() {
-            return Err(Error::new(
-                bindings_struct.span(),
-                "`#[bindings]` doesn't support input structs with fields. \
-                Use unit struct like `struct Bindings;`."
             ))
         }
     }
@@ -121,140 +116,27 @@ pub fn bindings(env: TokenStream, bindings_struct: TokenStream) -> Result<TokenS
             .map_err(|_| callsite("Failed to read wrangler.toml"))?
     };
 
-    let config: &toml::Table = {
+    let env: &toml::Table = {        
         let top_level = wrangler_toml.as_table().ok_or_else(invalid_wrangler_toml)?;
-        match env {
+        let env_name: Option<Ident> = (!env_name.is_empty()).then(|| syn::parse2(env_name)).transpose()?;
+        match env_name {
             None      => top_level,
-            Some(env) => top_level
-                .get("env").ok_or_else(|| callsite(format!("env `{env}` is not found in wrangler.toml")))?
-                .as_table().ok_or_else(invalid_wrangler_toml)?
-                .get(&env.to_string()).ok_or_else(|| callsite(format!("env `{env}` is not found in wrangler.toml")))?
-                .as_table().ok_or_else(invalid_wrangler_toml)?
+            Some(env) => top_level.get("env")
+                .and_then(|e| e.as_table())
+                .and_then(|t| t.get(&env.to_string()))
+                .and_then(|e| e.as_table())
+                .ok_or_else(|| callsite(format!("env `{env}` is not found in wrangler.toml")))?
         }
     };
-
-    enum Binding {
-        Variable(String),
-        AI,
-        D1,
-        KV,
-        R2,
-        Service,
-        Queue,
-        DurableObject,
-    }
 
     let name = &bindings_struct.ident;
     let vis  = &bindings_struct.vis;
 
-    let bindings: Vec<(Ident, Binding)> = {
-        let mut bindings = Vec::new();
-
-        if let Some(toml::Value::Table(vars)) = config.get("vars") {
-            for (name, value) in vars {
-                let value = value.as_str().ok_or_else(|| callsite("`#[bindings]` doesn't support JSON values in `vars` binding"))?;
-                bindings.push((
-                    syn::parse_str(name).map_err(|e| callsite(format!("Can't bind binding `{name}` into struct: {e}")))?,
-                    Binding::Variable(value.into())
-                ))
-            }
-        }
-        if let Some(toml::Value::Table(ai)) = config.get("ai") {
-            let name = ai
-                .get("binding").ok_or_else(|| callsite("Invalid wrangler.toml: a binding doesn't have `binding = \"...\"`"))?
-                .as_str().ok_or_else(invalid_wrangler_toml)?;
-            bindings.push((
-                syn::parse_str(name).map_err(|e| callsite(format!("Can't bind binding `{name}` into struct: {e}")))?,
-                Binding::AI
-            ))
-        }
-        if let Some(toml::Value::Array(d1_databases)) = config.get("d1_databases") {
-            for binding in d1_databases {
-                let name = binding.as_table().ok_or_else(invalid_wrangler_toml)?
-                    .get("binding").ok_or_else(|| callsite("Invalid wrangler.toml: a binding doesn't have `binding = \"...\"`"))?
-                    .as_str().ok_or_else(invalid_wrangler_toml)?;
-                bindings.push((
-                    syn::parse_str(name).map_err(|e| callsite(format!("Can't bind binding `{name}` into struct: {e}")))?,
-                    Binding::D1
-                ))
-            }
-        }
-        if let Some(toml::Value::Array(kv_namespaces)) = config.get("kv_namespaces") {
-            for binding in kv_namespaces {
-                let name = binding.as_table().ok_or_else(invalid_wrangler_toml)?
-                    .get("binding").ok_or_else(|| callsite("Invalid wrangler.toml: a binding doesn't have `binding = \"...\"`"))?
-                    .as_str().ok_or_else(invalid_wrangler_toml)?;
-                bindings.push((
-                    syn::parse_str(name).map_err(|e| callsite(format!("Can't bind binding `{name}` into struct: {e}")))?,
-                    Binding::KV
-                ))
-            }
-        }
-        if let Some(toml::Value::Array(r2_buckets)) = config.get("r2_buckets") {
-            for binding in r2_buckets {
-                let name = binding.as_table().ok_or_else(invalid_wrangler_toml)?
-                    .get("binding").ok_or_else(|| callsite("Invalid wrangler.toml: a binding doesn't have `binding = \"...\"`"))?
-                    .as_str().ok_or_else(invalid_wrangler_toml)?;
-                bindings.push((
-                    syn::parse_str(name).map_err(|e| callsite(format!("Can't bind binding `{name}` into struct: {e}")))?,
-                    Binding::R2
-                ))
-            }
-        }
-        if let Some(toml::Value::Array(services)) = config.get("services") {
-            for binding in services {
-                let name = binding.as_table().ok_or_else(invalid_wrangler_toml)?
-                    .get("binding").ok_or_else(|| callsite("Invalid wrangler.toml: a binding doesn't have `binding = \"...\"`"))?
-                    .as_str().ok_or_else(invalid_wrangler_toml)?;
-                bindings.push((
-                    syn::parse_str(name).map_err(|e| callsite(format!("Can't bind binding `{name}` into struct: {e}")))?,
-                    Binding::Service
-                ))
-            }
-        }
-        if let Some(toml::Value::Table(queues)) = config.get("queues") {
-            if let Some(toml::Value::Array(producers)) = queues.get("producers") {
-                for binding in producers {
-                    let name = binding.as_table().ok_or_else(invalid_wrangler_toml)?
-                        .get("binding").ok_or_else(|| callsite("Invalid wrangler.toml: a binding doesn't have `binding = \"...\"`"))?
-                        .as_str().ok_or_else(invalid_wrangler_toml)?;
-                    bindings.push((
-                        syn::parse_str(name).map_err(|e| callsite(format!("Can't bind binding `{name}` into struct: {e}")))?,
-                        Binding::Queue
-                    ))
-                }
-            }
-        }
-        if let Some(toml::Value::Table(durable_objects)) = config.get("durable_objects") {
-            if let Some(toml::Value::Array(durable_object_bindings)) = durable_objects.get("bindings") {
-                for binding in durable_object_bindings {
-                    let name = binding.as_table().ok_or_else(invalid_wrangler_toml)?
-                        .get("name").ok_or_else(|| callsite("Invalid wrangler.toml: a binding doesn't have `binding = \"...\"`"))?
-                        .as_str().ok_or_else(invalid_wrangler_toml)?;
-                    bindings.push((
-                        syn::parse_str(name).map_err(|e| callsite(format!("Can't bind binding `{name}` into struct: {e}")))?,
-                        Binding::DurableObject
-                    ))
-                }
-            }
-        }
-
-        bindings
-    };
+    let bindings: Vec<(Ident, Binding)> = Binding::collect_from_env(&env)?;
 
     let declare_struct = {
         let fields = bindings.iter().map(|(name, binding)| {
-            let ty = match binding {
-                Binding::Variable(_)   => quote!(&'static str),
-                Binding::AI            => quote!(::worker::Ai),
-                Binding::D1            => quote!(::worker::d1::D1Database),
-                Binding::KV            => quote!(::worker::kv::KvStore),
-                Binding::R2            => quote!(::worker::Bucket),
-                Binding::Queue         => quote!(::worker::Queue),
-                Binding::Service       => quote!(::worker::Fetcher),
-                Binding::DurableObject => quote!(::worker::ObjectNamespace),
-            };
-
+            let ty = binding.tokens_ty();
             quote! {
                 #vis #name: #ty
             }
@@ -287,28 +169,7 @@ pub fn bindings(env: TokenStream, bindings_struct: TokenStream) -> Result<TokenS
 
     let impl_from_request = {
         let extract = bindings.iter().map(|(name, binding)| {
-            let name_str = name.to_string();
-
-            let from_env = |get: TokenStream| quote! {
-                #name: match req.env().#get {
-                    Ok(binding) => binding,
-                    Err(e) => {
-                        ::worker::console_error!("{e}");
-                        return ::std::option::Option::Some(::std::result::Result::Err(::ohkami::Response::InternalServerError()));
-                    }
-                }
-            };
-
-            match binding {
-                Binding::Variable(value) => quote! { #name: #value },
-                Binding::AI              => from_env(quote! { ai(#name_str) }),
-                Binding::D1              => from_env(quote! { d1(#name_str) }),
-                Binding::KV              => from_env(quote! { kv(#name_str) }),
-                Binding::R2              => from_env(quote! { bucket(#name_str) }),
-                Binding::Queue           => from_env(quote! { queue(#name_str) }),
-                Binding::Service         => from_env(quote! { service(#name_str) }),
-                Binding::DurableObject   => from_env(quote! { durable_object(#name_str) }),
-            }
+            binding.tokens_extract_as_field(name)
         });
 
         quote! {

--- a/ohkami_macros/src/worker.rs
+++ b/ohkami_macros/src/worker.rs
@@ -200,7 +200,7 @@ pub fn bindings(env_name: TokenStream, bindings_struct: TokenStream) -> Result<T
             });
 
         quote! {
-            #[allow(non_snake_case)]
+            #[allow(non_upper_case_globals)]
             impl #name {
                 #( #consts )*
             }

--- a/ohkami_macros/src/worker/binding.rs
+++ b/ohkami_macros/src/worker/binding.rs
@@ -1,0 +1,146 @@
+use proc_macro2::{TokenStream, Span};
+use quote::quote;
+use syn::{Ident, LitStr};
+
+pub enum Binding {
+    Variable(String),
+    AI,
+    D1,
+    KV,
+    R2,
+    Service,
+    Queue,
+    DurableObject,
+}
+
+impl Binding {
+    pub fn tokens_ty(&self) -> TokenStream {
+        match self {
+            Self::Variable(_)   => quote!(&'static str),
+            Self::AI            => quote!(::worker::Ai),
+            Self::D1            => quote!(::worker::d1::D1Database),
+            Self::KV            => quote!(::worker::kv::KvStore),
+            Self::R2            => quote!(::worker::Bucket),
+            Self::Queue         => quote!(::worker::Queue),
+            Self::Service       => quote!(::worker::Fetcher),
+            Self::DurableObject => quote!(::worker::ObjectNamespace),
+        }
+    }
+
+    pub fn tokens_extract_as_field(&self, name: &Ident) -> TokenStream {
+        let name_str = LitStr::new(&name.to_string(), name.span());
+
+        let from_env = |getter: TokenStream| quote! {
+            #name: match req.env().#getter {
+                Ok(binding) => binding,
+                Err(e) => {
+                    ::worker::console_error!("{e}");
+                    return ::std::option::Option::Some(::std::result::Result::Err(::ohkami::Response::InternalServerError()));
+                }
+            }
+        };
+
+        match self {
+            Self::Variable(value) => quote! { #name: #value },
+            Self::AI              => from_env(quote! { ai(#name_str) }),
+            Self::D1              => from_env(quote! { d1(#name_str) }),
+            Self::KV              => from_env(quote! { kv(#name_str) }),
+            Self::R2              => from_env(quote! { bucket(#name_str) }),
+            Self::Queue           => from_env(quote! { queue(#name_str) }),
+            Self::Service         => from_env(quote! { service(#name_str) }),
+            Self::DurableObject   => from_env(quote! { durable_object(#name_str) }),
+        }
+    }
+
+    pub fn collect_from_env(env: &toml::Table) -> Result<Vec<(Ident, Self)>, syn::Error> {
+        fn invalid_wrangler_toml() -> syn::Error {
+            syn::Error::new(
+                "Invalid wrangler.toml: a binding doesn't have `binding = \"...\"`, or some unexpected structure",
+                Span::call_site()
+            )
+        }
+
+        fn invalid_name(name: &str) -> syn::Error {
+            syn::Error::new(
+                format!("Can't bind binding `{name}` into Rust struct field"),
+                Span::call_site()
+            )
+        }
+
+        ///////////////////////////////////////////////////////////////////////////////////////////
+
+        fn get_field_as_ident(t: &toml::Table, field: &str) -> Result<Ident, syn::Error> {
+            t.get(field)
+                .and_then(|b| b.as_str())
+                .ok_or_else(invalid_wrangler_toml)
+                .and_then(|b| syn::parse_str::<Ident>(name))
+                .map_err(|_| invalid_name(name))
+        }
+
+        fn binding_of(t: &toml::Table) -> Result<Ident, syn::Error> {
+            get_field_as_ident(t, "binding")
+        }
+        fn name_of(t: &toml::Table) -> Result<Ident, syn::Error> {
+            get_field_as_ident(t, "name")
+        }
+
+        fn table_array(a: &toml::Array) -> Result<impl IntoIterator<Item = &toml::Table>, syn::Error> {
+            a.iter()
+                .map(|v| v.as_table().ok_or_else(invalid_wrangler_toml))
+                .collect()
+        }
+
+        ///////////////////////////////////////////////////////////////////////////////////////////
+
+        let mut bindings = Vec::new();
+
+        if let Some(toml::Value::Table(vars)) = env.get("vars") {
+            for (name, value) in vars {
+                let value = value.as_str().ok_or_else(|| callsite("`#[bindings]` doesn't support JSON values in `vars` binding"))?;
+                bindings.push((
+                    syn::parse_str(name).map_err(|_| invalid_name(name))?,
+                    Self::Variable(value.into())
+                ))
+            }
+        }
+        if let Some(toml::Value::Table(ai)) = env.get("ai") {
+            bindings.push((binding_of(ai)?, Self::AI))
+        }
+        if let Some(toml::Value::Array(d1_databases)) = env.get("d1_databases") {
+            for d1 in table_array(d1_databases)? {
+                bindings.push((binding_of(d1)?, Self::D1))
+            }
+        }
+        if let Some(toml::Value::Array(kv_namespaces)) = env.get("kv_namespaces") {
+            for kv in table_array(kv_namespaces)? {
+                bindings.push((binding_of(kv)?, Self::KV))
+            }
+        }
+        if let Some(toml::Value::Array(r2_buckets)) = env.get("r2_buckets") {
+            for r2 in table_array(r2_buckets)? {
+                bindings.push((binding_of(r2)?, Self::R2))
+            }
+        }
+        if let Some(toml::Value::Array(services)) = env.get("services") {
+            for service in table_array(services)? {
+                bindings.push((binding_of(service)?, Self::Service))
+            }
+        }
+        if let Some(toml::Value::Table(queues)) = env.get("queues") {
+            if let Some(toml::Value::Array(producers)) = queues.get("producers") {
+                for producer in table_array(producers)? {
+                    bindings.push((binding_of(producer)?, Self::Queue))
+                }
+            }
+        }
+        if let Some(toml::Value::Table(durable_objects)) = env.get("durable_objects") {
+            if let Some(toml::Value::Array(durable_object_bindings)) = durable_objects.get("bindings") {
+                for durable_object in table_array(durable_object_bindings)? {
+                    bindings.push((name_of(durable_object)?, Self::DurableObject))
+                }
+            }
+        }
+
+        Ok(bindings)
+    }
+}

--- a/samples/worker-bindings/src/lib.rs
+++ b/samples/worker-bindings/src/lib.rs
@@ -1,5 +1,14 @@
-#[ohkami::bindings]
-struct Bindings;
+use ohkami::bindings;
+
+#[bindings]
+struct AutoBindings;
+
+#[bindings]
+struct ManualBindings {
+    VARIABLE_1: bindings::Var,
+    DB: bindings::D1,
+    MY_KVSTORE: bindings::KV,
+}
 
 macro_rules! static_assert_eq_str {
     ($left:expr, $right:literal) => {
@@ -19,12 +28,12 @@ macro_rules! static_assert_eq_str {
     };
 }
 
-fn __test_bindings__(bindings: Bindings) {
+fn __test_auto_bindings__(bindings: AutoBindings) {
     fn assert_send_sync<T: Send + Sync>() {}
-    assert_send_sync::<Bindings>();
+    assert_send_sync::<AutoBindings>();
 
-    static_assert_eq_str!(Bindings::VARIABLE_1, "hoge");
-    static_assert_eq_str!(Bindings::VARIABLE_2, "super fun");
+    static_assert_eq_str!(AutoBindings::VARIABLE_1, "hoge");
+    static_assert_eq_str!(AutoBindings::VARIABLE_2, "super fun");
 
     let _: worker::Ai = bindings.INTELIGENT;
 
@@ -39,4 +48,15 @@ fn __test_bindings__(bindings: Bindings) {
     let _: worker::Queue = bindings.MY_QUEUE;
 
     let _: worker::ObjectNamespace = bindings.RATE_LIMITER;
+}
+
+fn __test_manual_bindings__(bindings: ManualBindings) {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<ManualBindings>();
+
+    static_assert_eq_str!(ManualBindings::VARIABLE_1, "hoge");
+
+    let _: worker::D1Database = bindings.DB;
+
+    let _: worker::kv::KvStore = bindings.MY_KVSTORE;
 }


### PR DESCRIPTION
Before `#[bindings]` just accept unit struct and collect all bindings of wrangler.toml. But this has a problem: the code itself is difficult to read around bindings because they're defined in implicit fields generated by attribute.

```rust
#[ohkami::bindings]
struct Bindings;

async fn handler(b: Bindings) -> String {
    // this `MY_KV` requires readers to check wrangler.toml to understand this code
    let data = b.MY_KV.get("data").text().await
        .expect("Failed to get data");

    //...
}
```

This PR introduces *manual binding* mode of `#[binding]` to resolve it for more readability and potability:

```rust
use ohkami::bindings;

#[bindings]
struct Bindings {
    MY_KV: bindings::KV,
}

async fn handler(b: Bindings) -> String {
    let data = b.MY_KV.get("data").text().await
        .expect("Failed to get data");

    //...
}
```

For struct with named fields, `#[bindings]` collect and bind bindings **into the fields**, already written in the code!

Additionally, defines and exposes `bindings` module that has intuitive aliases of binding types `worker` crate:

```rust
pub type Var           = &'static str;
pub type AI            = ::worker::Ai;
pub type D1            = ::worker::d1::D1Database;
pub type KV            = ::worker::kv::KvStore;
pub type R2            = ::worker::Bucket;
pub type Queue         = ::worker::Queue;
pub type Service       = ::worker::Fetcher;
pub type DurableObject = ::worker::ObjectNamespace;
```