### PR TITLE
rename: `Response::of` -> `Response::new`

### DIFF
--- a/ohkami/src/response/into_response.rs
+++ b/ohkami/src/response/into_response.rs
@@ -100,7 +100,7 @@ impl IntoResponse for Response {
 
 impl IntoResponse for Status {
     #[inline(always)] fn into_response(self) -> Response {
-        Response::of(self)
+        Response::new(self)
     }
 
     #[cfg(feature="openapi")]

--- a/ohkami/src/response/mod.rs
+++ b/ohkami/src/response/mod.rs
@@ -113,7 +113,7 @@ pub struct Response {
 
 impl Response {
     #[inline(always)]
-    pub fn of(status: Status) -> Self {
+    pub fn new(status: Status) -> Self {
         Self {
             status,
             headers: ResponseHeaders::new(),

--- a/ohkami/src/typed/status.rs
+++ b/ohkami/src/typed/status.rs
@@ -150,7 +150,7 @@ macro_rules! generate_redirects {
             impl IntoResponse for $status {
                 #[inline]
                 fn into_response(self) -> Response {
-                    let mut res = Response::of(Status::$status);
+                    let mut res = Response::new(Status::$status);
                     res.headers.set()
                         .Location(self.location);
                     res

--- a/samples/petstore/src/main.rs
+++ b/samples/petstore/src/main.rs
@@ -158,7 +158,7 @@ struct Error {
 }
 impl IntoResponse for Error {
     fn into_response(self) -> Response {
-        Response::of(Status::from(self.status_code))
+        Response::new(Status::from(self.status_code))
             .with_json(self)
     }
     fn openapi_responses() -> openapi::Responses {


### PR DESCRIPTION
`new` will be more expected and intuitive for most Rustaceans.