### PR TITLE
openapi: make `{Response, Status}::openapi_responses` return empty `Responses`

### DIFF
--- a/ohkami/src/response/into_response.rs
+++ b/ohkami/src/response/into_response.rs
@@ -94,7 +94,7 @@ impl IntoResponse for Response {
 
     #[cfg(feature="openapi")]
     fn openapi_responses() -> openapi::Responses {
-        openapi::Responses::new([(200, openapi::Response::when("OK"))])
+        openapi::Responses::new([])
     }
 }
 
@@ -105,7 +105,7 @@ impl IntoResponse for Status {
 
     #[cfg(feature="openapi")]
     fn openapi_responses() -> openapi::Responses {
-        openapi::Responses::new([(200, openapi::Response::when("OK"))])
+        openapi::Responses::new([])
     }
 }
 


### PR DESCRIPTION
instead of with `200`.
handlers returning `Response` and `Status` can respond with any HTTP status, so inconsistent documentation will be more avoidable by just empty `openapi::Responses`.