### PR TITLE
fix: unify `x_lambda::ohkami_service_*` tests into single one

### DIFF
--- a/ohkami/src/x_lambda.rs
+++ b/ohkami/src/x_lambda.rs
@@ -512,9 +512,7 @@ mod ws {
 */
 
 #[cfg(feature="nightly"/* `noop_waker` is stabilized in 1.85.0 and then remove this cfg */)]
-#[cfg(test)]
-/// FIXME
-/// this is flaky; sometimes cause a timing conflict around `static ROUTER` (in ohkami/mod.rs, used for Service impl)
+#[cfg(test)]`
 mod tests {
     use super::*;
     use crate::{Ohkami, Route, Method};

--- a/ohkami/src/x_lambda.rs
+++ b/ohkami/src/x_lambda.rs
@@ -512,7 +512,7 @@ mod ws {
 */
 
 #[cfg(feature="nightly"/* `noop_waker` is stabilized in 1.85.0 and then remove this cfg */)]
-#[cfg(test)]`
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::{Ohkami, Route, Method};


### PR DESCRIPTION
to avoid conflict around static `ROUTER`

releated to https://github.com/ohkami-rs/ohkami/issues/331