### PR TITLE
activate `Cow::Borrowed` via `IntoBody`

### DIFF
--- a/ohkami/src/format/builtin/html.rs
+++ b/ohkami/src/format/builtin/html.rs
@@ -6,11 +6,11 @@ use crate::openapi;
 
 pub struct HTML<T = String>(pub T);
 
-impl<T: Into<std::borrow::Cow<'static, str>>> IntoBody for HTML<T> {
+impl<T: Into<String>> IntoBody for HTML<T> {
     const CONTENT_TYPE: &'static str = "text/html; charset=UTF-8";
+
     fn into_body(self) -> Result<Vec<u8>, impl std::fmt::Display> {
-        let cow: std::borrow::Cow<'static, str> = self.0.into();
-        Ok::<_, std::convert::Infallible>(cow.into_owned().into_bytes())
+        Result::<_, std::convert::Infallible>::Ok(self.0.into().into_bytes())
     }
 
     #[cfg(feature="openapi")]

--- a/ohkami/src/format/builtin/html.rs
+++ b/ohkami/src/format/builtin/html.rs
@@ -1,4 +1,5 @@
 use crate::IntoBody;
+use std::borrow::Cow;
 
 #[cfg(feature="openapi")]
 use crate::openapi;
@@ -6,11 +7,14 @@ use crate::openapi;
 
 pub struct HTML<T = String>(pub T);
 
-impl<T: Into<String>> IntoBody for HTML<T> {
+impl<T: Into<Cow<'static, str>>> IntoBody for HTML<T> {
     const CONTENT_TYPE: &'static str = "text/html; charset=UTF-8";
 
-    fn into_body(self) -> Result<Vec<u8>, impl std::fmt::Display> {
-        Result::<_, std::convert::Infallible>::Ok(self.0.into().into_bytes())
+    fn into_body(self) -> Result<Cow<'static, [u8]>, impl std::fmt::Display> {
+        Result::<_, std::convert::Infallible>::Ok(match self.0.into() {
+            Cow::Owned(s) => Cow::Owned(s.into_bytes()),
+            Cow::Borrowed(s) => Cow::Borrowed(s.as_bytes()),
+        })
     }
 
     #[cfg(feature="openapi")]

--- a/ohkami/src/format/builtin/json.rs
+++ b/ohkami/src/format/builtin/json.rs
@@ -1,5 +1,6 @@
 use crate::{FromBody, IntoBody};
 use super::bound::{self, Incoming, Outgoing};
+use std::borrow::Cow;
 
 #[cfg(feature="openapi")]
 use crate::openapi;
@@ -25,8 +26,8 @@ impl<T: Outgoing> IntoBody for JSON<T> {
     const CONTENT_TYPE: &'static str = "application/json";
 
     #[inline]
-    fn into_body(self) -> Result<Vec<u8>, impl std::fmt::Display> {
-        serde_json::to_vec(&self.0)
+    fn into_body(self) -> Result<Cow<'static, [u8]>, impl std::fmt::Display> {
+        serde_json::to_vec(&self.0).map(Cow::Owned)
     }
 
     #[cfg(feature="openapi")]

--- a/ohkami/src/format/builtin/text.rs
+++ b/ohkami/src/format/builtin/text.rs
@@ -1,4 +1,5 @@
 use crate::{FromBody, IntoBody};
+use std::borrow::Cow;
 
 #[cfg(feature="openapi")]
 use crate::openapi;
@@ -8,7 +9,7 @@ pub struct Text<T>(pub T);
 
 impl<'req, T: From<&'req str>> FromBody<'req> for Text<T> {
     const MIME_TYPE: &'static str = "text/plain";
-    
+
     fn from_body(body: &'req [u8]) -> Result<Self, impl std::fmt::Display> {
         std::str::from_utf8(body).map(|s| Text(s.into()))
     }
@@ -19,11 +20,14 @@ impl<'req, T: From<&'req str>> FromBody<'req> for Text<T> {
     }
 }
 
-impl<T: Into<String>> IntoBody for Text<T> {
+impl<T: Into<Cow<'static, str>>> IntoBody for Text<T> {
     const CONTENT_TYPE: &'static str = "text/plain; charset=UTF-8";
 
-    fn into_body(self) -> Result<Vec<u8>, impl std::fmt::Display> {
-        Result::<_, std::convert::Infallible>::Ok(self.0.into().into_bytes())
+    fn into_body(self) -> Result<Cow<'static, [u8]>, impl std::fmt::Display> {
+        Result::<_, std::convert::Infallible>::Ok(match self.0.into() {
+            Cow::Owned(s) => Cow::Owned(s.into_bytes()),
+            Cow::Borrowed(s) => Cow::Borrowed(s.as_bytes()),
+        })
     }
 
     #[cfg(feature="openapi")]

--- a/ohkami/src/format/builtin/text.rs
+++ b/ohkami/src/format/builtin/text.rs
@@ -8,6 +8,7 @@ pub struct Text<T>(pub T);
 
 impl<'req, T: From<&'req str>> FromBody<'req> for Text<T> {
     const MIME_TYPE: &'static str = "text/plain";
+    
     fn from_body(body: &'req [u8]) -> Result<Self, impl std::fmt::Display> {
         std::str::from_utf8(body).map(|s| Text(s.into()))
     }
@@ -18,11 +19,11 @@ impl<'req, T: From<&'req str>> FromBody<'req> for Text<T> {
     }
 }
 
-impl<T: Into<std::borrow::Cow<'static, str>>> IntoBody for Text<T> {
+impl<T: Into<String>> IntoBody for Text<T> {
     const CONTENT_TYPE: &'static str = "text/plain; charset=UTF-8";
+
     fn into_body(self) -> Result<Vec<u8>, impl std::fmt::Display> {
-        let cow: std::borrow::Cow<'static, str> = self.0.into();
-        Ok::<_, std::convert::Infallible>(cow.into_owned().into_bytes())
+        Result::<_, std::convert::Infallible>::Ok(self.0.into().into_bytes())
     }
 
     #[cfg(feature="openapi")]

--- a/ohkami/src/format/builtin/urlencoded.rs
+++ b/ohkami/src/format/builtin/urlencoded.rs
@@ -10,6 +10,7 @@ pub struct URLEncoded<T: bound::Schema>(pub T);
 
 impl<'req, T: Incoming<'req>> FromBody<'req> for URLEncoded<T> {
     const MIME_TYPE: &'static str = "application/x-www-form-urlencoded";
+    
     fn from_body(body: &'req [u8]) -> Result<Self, impl std::fmt::Display> {
         serde_urlencoded::from_bytes(body).map(URLEncoded)
     }
@@ -22,6 +23,7 @@ impl<'req, T: Incoming<'req>> FromBody<'req> for URLEncoded<T> {
 
 impl<T: Outgoing> IntoBody for URLEncoded<T> {
     const CONTENT_TYPE: &'static str = "application/x-www-form-urlencoded";
+
     fn into_body(self) -> Result<Vec<u8>, impl std::fmt::Display> {
         serde_urlencoded::to_string(&self.0).map(String::into_bytes)
     }

--- a/ohkami/src/format/builtin/urlencoded.rs
+++ b/ohkami/src/format/builtin/urlencoded.rs
@@ -1,6 +1,7 @@
 use crate::{FromBody, IntoBody};
 use super::bound::{self, Incoming, Outgoing};
 use ohkami_lib::serde_urlencoded;
+use std::borrow::Cow;
 
 #[cfg(feature="openapi")]
 use crate::openapi;
@@ -10,7 +11,7 @@ pub struct URLEncoded<T: bound::Schema>(pub T);
 
 impl<'req, T: Incoming<'req>> FromBody<'req> for URLEncoded<T> {
     const MIME_TYPE: &'static str = "application/x-www-form-urlencoded";
-    
+
     fn from_body(body: &'req [u8]) -> Result<Self, impl std::fmt::Display> {
         serde_urlencoded::from_bytes(body).map(URLEncoded)
     }
@@ -24,8 +25,8 @@ impl<'req, T: Incoming<'req>> FromBody<'req> for URLEncoded<T> {
 impl<T: Outgoing> IntoBody for URLEncoded<T> {
     const CONTENT_TYPE: &'static str = "application/x-www-form-urlencoded";
 
-    fn into_body(self) -> Result<Vec<u8>, impl std::fmt::Display> {
-        serde_urlencoded::to_string(&self.0).map(String::into_bytes)
+    fn into_body(self) -> Result<Cow<'static, [u8]>, impl std::fmt::Display> {
+        serde_urlencoded::to_string(&self.0).map(|s| Cow::Owned(s.into_bytes()))
     }
 
     #[cfg(feature="openapi")]

--- a/ohkami/src/request/from_request.rs
+++ b/ohkami/src/request/from_request.rs
@@ -15,7 +15,6 @@ use crate::openapi;
 /// 
 /// <br>
 /// 
-/// ---
 /// *example.rs*
 /// ```
 /// use ohkami::prelude::*;
@@ -31,11 +30,12 @@ use crate::openapi;
 ///     }
 /// }
 /// ```
-/// ---
 /// 
 /// <br>
 /// 
-/// NOTE: *MUST NOT impl both `FromRequest` and `FromParam` or `FromHeader`*.
+/// ### Note
+/// 
+/// *MUST NOT impl both `FromRequest` and `FromParam`*.
 pub trait FromRequest<'req>: Sized {
     /// If this extraction never fails, `std::convert::Infallible` is recomended.
     type Error: IntoResponse;


### PR DESCRIPTION
Before `IntoBody::into_body` returned `Result<Vec<u8>, _>`, where make any body into owned. But `Response` itself can hold `&'static _` by `Content::Payload({CowSlice})`, so this PR changes the `Vec<u8>` into `Cow<'static, [u8]>` and enables to respond with a static reference.

This doesn't degrade performance in already-owned cases, thanks to Rust's very low cost enum dispatching.