### PR TITLE
openapi(operation): replace `override_*` to map signature

### DIFF
--- a/ohkami_macros/src/openapi.rs
+++ b/ohkami_macros/src/openapi.rs
@@ -508,23 +508,23 @@ pub(super) fn operation(meta: TokenStream, handler: TokenStream) -> syn::Result<
                 },
                 DescriptionTarget::RequestBody => {
                     quote! {
-                        op.override_requestBody_description(#value);
+                        op = op.requestBody_description(#value);
                     }
                 },
                 DescriptionTarget::DefaultResponse => {
                     quote! {
-                        op.override_response_description("default", #value);
+                        op = op.response_description("default", #value);
                     }
                 },
                 DescriptionTarget::Response { status } => {
                     quote! {
-                        op.override_response_description(#status, #value);
+                        op = op.response_description(#status, #value);
                     }
                 },
                 DescriptionTarget::Param { name } => {
                     let name = LitStr::new(&name, Span::call_site());
                     quote! {
-                        op.override_param_description(#name, #value);
+                        op = op.param_description(#name, #value);
                     }
                 },
             });

--- a/ohkami_openapi/src/paths.rs
+++ b/ohkami_openapi/src/paths.rs
@@ -232,3 +232,15 @@ impl Operation {
             .chain(self.responses.refize_schemas())
     }
 }
+
+#[cfg(test)]
+#[test] fn map_openapi_operation_compiles() {
+    #[allow(unused)]
+    fn map_openapi_operation(op: Operation) -> Operation {
+        op
+        .operationId("list_users")
+        .description("This doc comment is used for the\n`description` field of OpenAPI document")
+        .summary("...")
+        .response_description(200, "List of all users")
+    }
+}

--- a/ohkami_openapi/src/paths.rs
+++ b/ohkami_openapi/src/paths.rs
@@ -184,20 +184,32 @@ impl Operation {
         }
     }
 
+    pub fn param_description(
+        mut self,
+        name: &'static str,
+        new_description: &'static str
+    ) -> Self {
+        if let Some(param) = self.parameters.iter_mut().find(|p| p.name == name) {
+            param.set_description(new_description);
+        }
+        self
+    }
+    pub fn requestBody_description(
+        mut self,
+        new_description: &'static str
+    ) -> Self {
+        if let Some(requestBody) = &mut self.requestBody {
+            requestBody.set_description(new_description);
+        }
+        self
+    }
     pub fn response_description(
         mut self,
         status: impl Into<super::response::Status>,
-        description: &'static str
+        new_description: &'static str
     ) -> Self {
-        self.override_response_description(status, description);
+        self.responses.override_response_description(status, new_description);
         self
-    }
-
-    #[doc(hidden)]
-    pub fn replace_empty_param_name_with(&mut self, name: &'static str) {
-        if let Some(empty_param) = self.parameters.iter_mut().find(|p| p.name.is_empty()) {
-            empty_param.name = name;
-        }
     }
 
     #[doc(hidden)]
@@ -218,22 +230,5 @@ impl Operation {
             .chain(self.parameters.iter_mut().map(|p| p.schema.refize()).flatten())
             .chain(self.requestBody.as_mut().map(RequestBody::refize_schemas).into_iter().flatten())
             .chain(self.responses.refize_schemas())
-    }
-
-    #[doc(hidden)]
-    pub fn override_param_description(&mut self, name: &'static str, new_description: &'static str) {
-        if let Some(param) = self.parameters.iter_mut().find(|p| p.name == name) {
-            param.set_description(new_description);
-        }
-    }
-    #[doc(hidden)]
-    pub fn override_requestBody_description(&mut self, new_description: &'static str) {
-        if let Some(requestBody) = &mut self.requestBody {
-            requestBody.set_description(new_description);
-        }
-    }
-    #[doc(hidden)]
-    pub fn override_response_description(&mut self, status: impl Into<super::response::Status>, new_description: &'static str) {
-        self.responses.override_response_description(status, new_description);
     }
 }

--- a/ohkami_openapi/src/paths.rs
+++ b/ohkami_openapi/src/paths.rs
@@ -184,6 +184,15 @@ impl Operation {
         }
     }
 
+    pub fn response_description(
+        mut self,
+        status: impl Into<super::response::Status>,
+        description: &'static str
+    ) -> Self {
+        self.override_response_description(status, description);
+        self
+    }
+
     #[doc(hidden)]
     pub fn replace_empty_param_name_with(&mut self, name: &'static str) {
         if let Some(empty_param) = self.parameters.iter_mut().find(|p| p.name.is_empty()) {

--- a/ohkami_openapi/src/paths.rs
+++ b/ohkami_openapi/src/paths.rs
@@ -213,6 +213,13 @@ impl Operation {
     }
 
     #[doc(hidden)]
+    pub fn replace_empty_param_name_with(&mut self, name: &'static str) {
+        if let Some(empty_param) = self.parameters.iter_mut().find(|p| p.name.is_empty()) {
+            empty_param.name = name;
+        }
+    }
+
+    #[doc(hidden)]
     pub fn iter_securitySchemes(&self) -> impl Iterator<Item = SecurityScheme> {
         self.security.clone().into_iter()
             .map(|map| {


### PR DESCRIPTION
Thinking about manual `map_openapi_operation` instead of `#[operation]` like

```rust
use ohkami::handler::IntoHandler;

struct ListUsers;
impl ListUsers {
    async fn handle() -> JSON<Vec<User>> {
        JSON(vec![])
    }
}
impl IntoHandler<ListUsers> for ListUsers {
    fn into_handler(self) -> ohkami::handler::Handler {
        (Self::handle).into_handler().map_openapi_operation(|mut op| {
            op = op
                .operationId("list_users")
                .description("This doc comment is used for the\n`description` field of OpenAPI document")
                .summary("...");
            op.override_response_description(200, "List of all users");
            op
        })
    }
}
```

`override_*` methods are unfriendly for this use, while are needed to be the signature ( `fn (&mut Self, ...)` ).

So this PR changes them to `fn (Self, ...) -> Self` to enable to write `map_openapi_operation` by a single method chain.