### PR TITLE
openapi: remove `name` argument of `Parameter::{in_path, maybe_in_path}`

### DIFF
--- a/ohkami/src/request/from_request.rs
+++ b/ohkami/src/request/from_request.rs
@@ -122,7 +122,7 @@ pub trait FromParam<'p>: Sized {
 
     #[cfg(feature="openapi")]
     fn openapi_param() -> openapi::Parameter {
-        openapi::Parameter::in_path("", openapi::string())
+        openapi::Parameter::in_path(openapi::string())
     }
 }
 const _: () = {
@@ -184,7 +184,7 @@ const _: () = {
 
                     #[cfg(feature="openapi")]
                     fn openapi_param() -> openapi::Parameter {
-                        openapi::Parameter::in_path("", openapi::integer())
+                        openapi::Parameter::in_path(openapi::integer())
                     }
                 }
             )*
@@ -207,7 +207,7 @@ const _: () = {
 
                     #[cfg(feature="openapi")]
                     fn openapi_param() -> openapi::Parameter {
-                        openapi::Parameter::in_path("", openapi::integer())
+                        openapi::Parameter::in_path(openapi::integer())
                     }
                 }
             )*

--- a/ohkami/src/router/final.rs
+++ b/ohkami/src/router/final.rs
@@ -108,7 +108,7 @@ impl Router {
                 crate::DEBUG!("[gen_openapi_doc] found");
                         
                 for param_name in &openapi_path_param_names {
-                    operation.replace_empty_param_name_with(param_name);
+                    operation.assign_path_param_name(param_name);
                 }
                 for security_scheme in operation.iter_securitySchemes() {
                     doc.register_securityScheme_component(security_scheme);

--- a/ohkami_openapi/src/paths.rs
+++ b/ohkami_openapi/src/paths.rs
@@ -213,8 +213,11 @@ impl Operation {
     }
 
     #[doc(hidden)]
-    pub fn replace_empty_param_name_with(&mut self, name: &'static str) {
-        if let Some(empty_param) = self.parameters.iter_mut().find(|p| p.name.is_empty()) {
+    pub fn assign_path_param_name(&mut self, name: &'static str) {
+        if let Some(empty_param) = self.parameters.iter_mut()
+            .filter(|p| p.is_path())
+            .find(|p| p.name.is_empty())
+        {
             empty_param.name = name;
         }
     }

--- a/ohkami_openapi/src/request.rs
+++ b/ohkami_openapi/src/request.rs
@@ -26,13 +26,38 @@ pub struct Parameter {
 
 #[derive(Serialize, Clone)]
 enum ParameterKind {
+    path,
     query,
     header,
-    path,
     cookie,
 }
 
 impl Parameter {
+    pub(crate) fn is_path(&self) -> bool {
+        matches!(self.kind, ParameterKind::path)
+    }
+}
+
+impl Parameter {
+    pub fn in_path(schema: impl Into<SchemaRef>) -> Self {
+        Self {
+            kind: ParameterKind::path,
+            name: "", // initialize with empty name (will be assigned later by `Operation::assign_path_param_name`)
+            schema:schema.into(),
+            required: true,
+            description:None, deprecated:false, style:None, explode:false,
+        }
+    }
+    pub fn maybe_in_path(schema: impl Into<SchemaRef>) -> Self {
+        Self {
+            kind: ParameterKind::path,
+            name: "", // initialize with empty name (will be assigned later by `Operation::assign_path_param_name`)
+            schema:schema.into(),
+            required: false,
+            description:None, deprecated:false, style:None, explode:false,
+        }
+    }
+
     pub fn in_query(name: &'static str, schema: impl Into<SchemaRef>) -> Self {
         Self {
             kind: ParameterKind::query,
@@ -61,23 +86,6 @@ impl Parameter {
     pub fn maybe_in_header(name: &'static str, schema: impl Into<SchemaRef>) -> Self {
         Self {
             kind: ParameterKind::header,
-            name, schema:schema.into(),
-            required: false,
-            description:None, deprecated:false, style:None, explode:false,
-        }
-    }
-    
-    pub fn in_path(name: &'static str, schema: impl Into<SchemaRef>) -> Self {
-        Self {
-            kind: ParameterKind::path,
-            name, schema:schema.into(),
-            required: true,
-            description:None, deprecated:false, style:None, explode:false,
-        }
-    }
-    pub fn maybe_in_path(name: &'static str, schema: impl Into<SchemaRef>) -> Self {
-        Self {
-            kind: ParameterKind::path,
             name, schema:schema.into(),
             required: false,
             description:None, deprecated:false, style:None, explode:false,


### PR DESCRIPTION
Before any `FromParam` impls of path param types returns `Parameter::{in_path, maybe_in_path}("", ...)` from `openapi_param()`. This is required for name assigning step later, but always `""` is unfriendly. This PR removes it.