### PR TITLE
Check the number of required path params

### DIFF
--- a/ohkami/src/fang/handler/into_handler.rs
+++ b/ohkami/src/fang/handler/into_handler.rs
@@ -7,7 +7,7 @@ use crate::openapi;
 
 
 pub trait IntoHandler<T> {
-    const N_PARAMS: usize;
+    fn n_params(&self) -> usize;
     fn into_handler(self) -> Handler;
 }
 
@@ -34,7 +34,7 @@ const _: (/* no args */) = {
         Body: IntoResponse,
         Fut:  Future<Output = Body> + SendOnNative + 'static,
     {
-        const N_PARAMS: usize = 0;
+        fn n_params(&self) -> usize {0}
 
         fn into_handler(self) -> Handler {
             Handler::new(move |_| {
@@ -56,7 +56,7 @@ const _: (/* FromParam */) = {
         Body: IntoResponse,
         Fut:  Future<Output = Body> + SendOnNative + 'static,
     {
-        const N_PARAMS: usize = 1;
+        fn n_params(&self) -> usize {1}
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
@@ -80,7 +80,7 @@ const _: (/* FromParam */) = {
         Body: IntoResponse,
         Fut:  Future<Output = Body> + SendOnNative + 'static,
     {
-        const N_PARAMS: usize = 1;
+        fn n_params(&self) -> usize {1}
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
@@ -104,7 +104,7 @@ const _: (/* FromParam */) = {
         F:   Fn((P1, P2)) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
-        const N_PARAMS: usize = 2;
+        fn n_params(&self) -> usize {2}
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
@@ -131,7 +131,7 @@ const _: (/* FromRequest items */) = {
         F:   Fn(Item1) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
-        const N_PARAMS: usize = 0;
+        fn n_params(&self) -> usize {0}
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
@@ -154,7 +154,7 @@ const _: (/* FromRequest items */) = {
         F:   Fn(Item1, Item2) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
-        const N_PARAMS: usize = 0;
+        fn n_params(&self) -> usize {0}
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
@@ -179,7 +179,7 @@ const _: (/* FromRequest items */) = {
         F:   Fn(Item1, Item2, Item3) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
-        const N_PARAMS: usize = 0;
+        fn n_params(&self) -> usize {0}
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
@@ -206,7 +206,7 @@ const _: (/* FromRequest items */) = {
         F:   Fn(Item1, Item2, Item3, Item4) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
-        const N_PARAMS: usize = 0;
+        fn n_params(&self) -> usize {0}
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
@@ -237,7 +237,7 @@ const _: (/* one FromParam without tuple and FromRequest items */) = {
         F:   Fn(P1, Item1) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
-        const N_PARAMS: usize = 1;
+        fn n_params(&self) -> usize {1}
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
@@ -265,7 +265,7 @@ const _: (/* one FromParam without tuple and FromRequest items */) = {
         F:   Fn(P1, Item1, Item2) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
-        const N_PARAMS: usize = 1;
+        fn n_params(&self) -> usize {1}
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
@@ -295,7 +295,7 @@ const _: (/* one FromParam without tuple and FromRequest items */) = {
         F:   Fn(P1, Item1, Item2, Item3) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
-        const N_PARAMS: usize = 1;
+        fn n_params(&self) -> usize {1}
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
@@ -327,7 +327,7 @@ const _: (/* one FromParam without tuple and FromRequest items */) = {
         F:   Fn(P1, Item1, Item2, Item3, Item4) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
-        const N_PARAMS: usize = 1;
+        fn n_params(&self) -> usize {1}
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
@@ -363,7 +363,7 @@ const _: (/* one FromParam and FromRequest items */) = {
         F:   Fn((P1,), Item1) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
-        const N_PARAMS: usize = 1;
+        fn n_params(&self) -> usize {1}
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
@@ -391,7 +391,7 @@ const _: (/* one FromParam and FromRequest items */) = {
         F:   Fn((P1,), Item1, Item2) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
-        const N_PARAMS: usize = 1;
+        fn n_params(&self) -> usize {1}
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
@@ -421,7 +421,7 @@ const _: (/* one FromParam and FromRequest items */) = {
         F:   Fn((P1,), Item1, Item2, Item3) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
-        const N_PARAMS: usize = 1;
+        fn n_params(&self) -> usize {1}
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
@@ -453,7 +453,7 @@ const _: (/* one FromParam and FromRequest items */) = {
         F:   Fn((P1,), Item1, Item2, Item3, Item4) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
-        const N_PARAMS: usize = 1;
+        fn n_params(&self) -> usize {1}
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
@@ -489,7 +489,7 @@ const _: (/* two PathParams and FromRequest items */) = {
         F:   Fn((P1, P2), Item1) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
-        const N_PARAMS: usize = 2;
+        fn n_params(&self) -> usize {2}
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
@@ -519,7 +519,7 @@ const _: (/* two PathParams and FromRequest items */) = {
         F:   Fn((P1, P2), Item1, Item2) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
-        const N_PARAMS: usize = 2;
+        fn n_params(&self) -> usize {2}
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
@@ -551,7 +551,7 @@ const _: (/* two PathParams and FromRequest items */) = {
         F:   Fn((P1, P2), Item1, Item2, Item3) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
-        const N_PARAMS: usize = 2;
+        fn n_params(&self) -> usize {2}
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
@@ -585,7 +585,7 @@ const _: (/* two PathParams and FromRequest items */) = {
         F:   Fn((P1, P2), Item1, Item2, Item3, Item4) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
-        const N_PARAMS: usize = 2;
+        fn n_params(&self) -> usize {2}
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {

--- a/ohkami/src/fang/handler/into_handler.rs
+++ b/ohkami/src/fang/handler/into_handler.rs
@@ -7,6 +7,7 @@ use crate::openapi;
 
 
 pub trait IntoHandler<T> {
+    const N_PARAMS: usize;
     fn into_handler(self) -> Handler;
 }
 
@@ -33,6 +34,8 @@ const _: (/* no args */) = {
         Body: IntoResponse,
         Fut:  Future<Output = Body> + SendOnNative + 'static,
     {
+        const N_PARAMS: usize = 0;
+
         fn into_handler(self) -> Handler {
             Handler::new(move |_| {
                 let res = self();
@@ -53,6 +56,8 @@ const _: (/* FromParam */) = {
         Body: IntoResponse,
         Fut:  Future<Output = Body> + SendOnNative + 'static,
     {
+        const N_PARAMS: usize = 1;
+
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
                 match P1::from_raw_param(unsafe {req.path.assume_one_param()}) {
@@ -75,6 +80,8 @@ const _: (/* FromParam */) = {
         Body: IntoResponse,
         Fut:  Future<Output = Body> + SendOnNative + 'static,
     {
+        const N_PARAMS: usize = 1;
+
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
                 // SAFETY: Due to the architecture of `Router`,
@@ -98,6 +105,8 @@ const _: (/* FromParam */) = {
         F:   Fn((P1, P2)) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
+        const N_PARAMS: usize = 2;
+
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
                 let (p1, p2) = unsafe {req.path.assume_two_params()};
@@ -123,6 +132,8 @@ const _: (/* FromRequest items */) = {
         F:   Fn(Item1) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
+        const N_PARAMS: usize = 0;
+
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
                 match from_request::<Item1>(req) {
@@ -144,6 +155,8 @@ const _: (/* FromRequest items */) = {
         F:   Fn(Item1, Item2) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
+        const N_PARAMS: usize = 0;
+
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
                 match (from_request::<Item1>(req), from_request::<Item2>(req)) {
@@ -167,6 +180,8 @@ const _: (/* FromRequest items */) = {
         F:   Fn(Item1, Item2, Item3) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
+        const N_PARAMS: usize = 0;
+
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
                 match (from_request::<Item1>(req), from_request::<Item2>(req), from_request::<Item3>(req)) {
@@ -192,6 +207,8 @@ const _: (/* FromRequest items */) = {
         F:   Fn(Item1, Item2, Item3, Item4) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
+        const N_PARAMS: usize = 0;
+
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
                 match (from_request::<Item1>(req), from_request::<Item2>(req), from_request::<Item3>(req), from_request::<Item4>(req)) {
@@ -221,6 +238,8 @@ const _: (/* one FromParam without tuple and FromRequest items */) = {
         F:   Fn(P1, Item1) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
+        const N_PARAMS: usize = 1;
+
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
                 // SAFETY: Due to the architecture of `Router`,
@@ -248,6 +267,8 @@ const _: (/* one FromParam without tuple and FromRequest items */) = {
         F:   Fn(P1, Item1, Item2) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
+        const N_PARAMS: usize = 1;
+
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
                 // SAFETY: Due to the architecture of `Router`,
@@ -277,6 +298,8 @@ const _: (/* one FromParam without tuple and FromRequest items */) = {
         F:   Fn(P1, Item1, Item2, Item3) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
+        const N_PARAMS: usize = 1;
+
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
                 // SAFETY: Due to the architecture of `Router`,
@@ -308,6 +331,8 @@ const _: (/* one FromParam without tuple and FromRequest items */) = {
         F:   Fn(P1, Item1, Item2, Item3, Item4) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
+        const N_PARAMS: usize = 1;
+
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
                 // SAFETY: Due to the architecture of `Router`,
@@ -343,6 +368,8 @@ const _: (/* one FromParam and FromRequest items */) = {
         F:   Fn((P1,), Item1) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
+        const N_PARAMS: usize = 1;
+
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
                 // SAFETY: Due to the architecture of `Router`,
@@ -370,6 +397,8 @@ const _: (/* one FromParam and FromRequest items */) = {
         F:   Fn((P1,), Item1, Item2) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
+        const N_PARAMS: usize = 1;
+
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
                 // SAFETY: Due to the architecture of `Router`,
@@ -399,6 +428,8 @@ const _: (/* one FromParam and FromRequest items */) = {
         F:   Fn((P1,), Item1, Item2, Item3) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
+        const N_PARAMS: usize = 1;
+
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
                 // SAFETY: Due to the architecture of `Router`,
@@ -430,6 +461,8 @@ const _: (/* one FromParam and FromRequest items */) = {
         F:   Fn((P1,), Item1, Item2, Item3, Item4) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
+        const N_PARAMS: usize = 1;
+
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
                 // SAFETY: Due to the architecture of `Router`,
@@ -465,6 +498,8 @@ const _: (/* two PathParams and FromRequest items */) = {
         F:   Fn((P1, P2), Item1) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
+        const N_PARAMS: usize = 2;
+
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
                 // SAFETY: Due to the architecture of `Router`,
@@ -494,6 +529,8 @@ const _: (/* two PathParams and FromRequest items */) = {
         F:   Fn((P1, P2), Item1, Item2) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
+        const N_PARAMS: usize = 2;
+
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
                 // SAFETY: Due to the architecture of `Router`,
@@ -525,6 +562,8 @@ const _: (/* two PathParams and FromRequest items */) = {
         F:   Fn((P1, P2), Item1, Item2, Item3) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
+        const N_PARAMS: usize = 2;
+
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
                 // SAFETY: Due to the architecture of `Router`,
@@ -558,6 +597,8 @@ const _: (/* two PathParams and FromRequest items */) = {
         F:   Fn((P1, P2), Item1, Item2, Item3, Item4) -> Fut + SendSyncOnNative + 'static,
         Fut: Future<Output = Body> + SendOnNative + 'static,
     {
+        const N_PARAMS: usize = 2;
+
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
                 // SAFETY: Due to the architecture of `Router`,

--- a/ohkami/src/fang/handler/into_handler.rs
+++ b/ohkami/src/fang/handler/into_handler.rs
@@ -84,8 +84,7 @@ const _: (/* FromParam */) = {
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
-                // SAFETY: Due to the architecture of `Router`,
-                // `params` has already `append`ed once before this code
+                // SAFETY: `crate::Route` has already checked the number of params
                 match P1::from_raw_param(unsafe {req.path.assume_one_param()}) {
                     Ok(p1) => {
                         let res = self((p1,));
@@ -242,8 +241,7 @@ const _: (/* one FromParam without tuple and FromRequest items */) = {
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
-                // SAFETY: Due to the architecture of `Router`,
-                // `params` has already `append`ed once before this code
+                // SAFETY: `crate::Route` has already checked the number of params
                 let p1 = unsafe {req.path.assume_one_param()};
 
                 match (P1::from_raw_param(p1), from_request(req)) {
@@ -271,8 +269,7 @@ const _: (/* one FromParam without tuple and FromRequest items */) = {
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
-                // SAFETY: Due to the architecture of `Router`,
-                // `params` has already `append`ed once before this code
+                // SAFETY: `crate::Route` has already checked the number of params
                 let p1 = unsafe {req.path.assume_one_param()};
 
                 match (P1::from_raw_param(p1), from_request::<Item1>(req), from_request::<Item2>(req)) {
@@ -302,8 +299,7 @@ const _: (/* one FromParam without tuple and FromRequest items */) = {
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
-                // SAFETY: Due to the architecture of `Router`,
-                // `params` has already `append`ed once before this code
+                // SAFETY: `crate::Route` has already checked the number of params
                 let p1 = unsafe {req.path.assume_one_param()};
 
                 match (P1::from_raw_param(p1), from_request::<Item1>(req), from_request::<Item2>(req), from_request::<Item3>(req)) {
@@ -335,8 +331,7 @@ const _: (/* one FromParam without tuple and FromRequest items */) = {
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
-                // SAFETY: Due to the architecture of `Router`,
-                // `params` has already `append`ed once before this code
+                // SAFETY: `crate::Route` has already checked the number of params
                 let p1 = unsafe {req.path.assume_one_param()};
 
                 match (P1::from_raw_param(p1), from_request::<Item1>(req), from_request::<Item2>(req), from_request::<Item3>(req), from_request::<Item4>(req)) {
@@ -372,8 +367,7 @@ const _: (/* one FromParam and FromRequest items */) = {
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
-                // SAFETY: Due to the architecture of `Router`,
-                // `params` has already `append`ed once before this code
+                // SAFETY: `crate::Route` has already checked the number of params
                 let p1 = unsafe {req.path.assume_one_param()};
 
                 match (P1::from_raw_param(p1), from_request::<Item1>(req)) {
@@ -401,8 +395,7 @@ const _: (/* one FromParam and FromRequest items */) = {
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
-                // SAFETY: Due to the architecture of `Router`,
-                // `params` has already `append`ed once before this code
+                // SAFETY: `crate::Route` has already checked the number of params
                 let p1 = unsafe {req.path.assume_one_param()};
 
                 match (P1::from_raw_param(p1), from_request::<Item1>(req), from_request::<Item2>(req)) {
@@ -432,8 +425,7 @@ const _: (/* one FromParam and FromRequest items */) = {
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
-                // SAFETY: Due to the architecture of `Router`,
-                // `params` has already `append`ed once before this code
+                // SAFETY: `crate::Route` has already checked the number of params
                 let p1 = unsafe {req.path.assume_one_param()};
                 
                 match (P1::from_raw_param(p1), from_request::<Item1>(req), from_request::<Item2>(req), from_request::<Item3>(req)) {
@@ -465,8 +457,7 @@ const _: (/* one FromParam and FromRequest items */) = {
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
-                // SAFETY: Due to the architecture of `Router`,
-                // `params` has already `append`ed once before this code
+                // SAFETY: `crate::Route` has already checked the number of params
                 let p1 = unsafe {req.path.assume_one_param()};
                 
                 match (P1::from_raw_param(p1), from_request::<Item1>(req), from_request::<Item2>(req), from_request::<Item3>(req), from_request::<Item4>(req)) {
@@ -502,8 +493,7 @@ const _: (/* two PathParams and FromRequest items */) = {
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
-                // SAFETY: Due to the architecture of `Router`,
-                // `params` has already `append`ed twice before this code
+                // SAFETY: `crate::Route` has already checked the number of params
                 let (p1, p2) = unsafe {req.path.assume_two_params()};
 
                 match (FromParam::from_raw_param(p1), FromParam::from_raw_param(p2), from_request::<Item1>(req)) {
@@ -533,8 +523,7 @@ const _: (/* two PathParams and FromRequest items */) = {
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
-                // SAFETY: Due to the architecture of `Router`,
-                // `params` has already `append`ed twice before this code
+                // SAFETY: `crate::Route` has already checked the number of params
                 let (p1, p2) = unsafe {req.path.assume_two_params()};
 
                 match (FromParam::from_raw_param(p1), FromParam::from_raw_param(p2), from_request::<Item1>(req), from_request::<Item2>(req)) {
@@ -566,8 +555,7 @@ const _: (/* two PathParams and FromRequest items */) = {
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
-                // SAFETY: Due to the architecture of `Router`,
-                // `params` has already `append`ed twice before this code
+                // SAFETY: `crate::Route` has already checked the number of params
                 let (p1, p2) = unsafe {req.path.assume_two_params()};
 
                 match (FromParam::from_raw_param(p1), FromParam::from_raw_param(p2), from_request::<Item1>(req), from_request::<Item2>(req), from_request::<Item3>(req)) {
@@ -601,8 +589,7 @@ const _: (/* two PathParams and FromRequest items */) = {
 
         fn into_handler(self) -> Handler {
             Handler::new(move |req| {
-                // SAFETY: Due to the architecture of `Router`,
-                // `params` has already `append`ed twice before this code
+                // SAFETY: `crate::Route` has already checked the number of params
                 let (p1, p2) = unsafe {req.path.assume_two_params()};
 
                 match (FromParam::from_raw_param(p1), FromParam::from_raw_param(p2), from_request::<Item1>(req), from_request::<Item2>(req), from_request::<Item3>(req), from_request::<Item4>(req)) {

--- a/ohkami/src/fang/handler/with_local_fangs.rs
+++ b/ohkami/src/fang/handler/with_local_fangs.rs
@@ -6,7 +6,7 @@ impl<H: IntoHandler<T>, T, F1> IntoHandler<(F1, H, T)> for (F1, H)
 where
     F1: Fang<BoxedFPC>
 {
-    const N_PARAMS: usize = H::N_PARAMS;
+    fn n_params(&self) -> usize {self.1.n_params()}
 
     fn into_handler(self) -> Handler {
         let (f, h) = self;
@@ -24,7 +24,7 @@ where
     F1: Fang<F2::Proc>,
     F2: Fang<BoxedFPC>,
 {
-    const N_PARAMS: usize = H::N_PARAMS;
+    fn n_params(&self) -> usize {self.2.n_params()}
 
     fn into_handler(self) -> Handler {
         let (f1, f2, h) = self;
@@ -44,7 +44,7 @@ where
     F2: Fang<F3::Proc>,
     F3: Fang<BoxedFPC>,
 {
-    const N_PARAMS: usize = H::N_PARAMS;
+    fn n_params(&self) -> usize {self.3.n_params()}
 
     fn into_handler(self) -> Handler {
         let (f1, f2, f3, h) = self;
@@ -65,7 +65,7 @@ where
     F3: Fang<F4::Proc>,
     F4: Fang<BoxedFPC>,
 {
-    const N_PARAMS: usize = H::N_PARAMS;
+    fn n_params(&self) -> usize {self.4.n_params()}
 
     fn into_handler(self) -> Handler {
         let (f1, f2, f3, f4, h) = self;

--- a/ohkami/src/fang/handler/with_local_fangs.rs
+++ b/ohkami/src/fang/handler/with_local_fangs.rs
@@ -6,6 +6,8 @@ impl<H: IntoHandler<T>, T, F1> IntoHandler<(F1, H, T)> for (F1, H)
 where
     F1: Fang<BoxedFPC>
 {
+    const N_PARAMS: usize = H::N_PARAMS;
+
     fn into_handler(self) -> Handler {
         let (f, h) = self;
         let h = h.into_handler();
@@ -22,6 +24,8 @@ where
     F1: Fang<F2::Proc>,
     F2: Fang<BoxedFPC>,
 {
+    const N_PARAMS: usize = H::N_PARAMS;
+
     fn into_handler(self) -> Handler {
         let (f1, f2, h) = self;
         let h = h.into_handler();
@@ -40,6 +44,8 @@ where
     F2: Fang<F3::Proc>,
     F3: Fang<BoxedFPC>,
 {
+    const N_PARAMS: usize = H::N_PARAMS;
+
     fn into_handler(self) -> Handler {
         let (f1, f2, f3, h) = self;
         let h = h.into_handler();
@@ -59,6 +65,8 @@ where
     F3: Fang<F4::Proc>,
     F4: Fang<BoxedFPC>,
 {
+    const N_PARAMS: usize = H::N_PARAMS;
+
     fn into_handler(self) -> Handler {
         let (f1, f2, f3, f4, h) = self;
         let h = h.into_handler();

--- a/ohkami/src/ohkami/_test.rs
+++ b/ohkami/src/ohkami/_test.rs
@@ -749,3 +749,20 @@ fn method_dependent_fang_applying() {
         }
     });
 }
+
+#[test]
+#[should_panic =
+    "handler `ohkami::ohkami::_test::panics_unexpected_path_params::hello_name` \
+    requires 1 path param(s) \
+    BUT the route `/hello` captures only 0 param(s)"
+]
+fn panics_unexpected_path_params() {
+    async fn hello_name(name: &str) -> String {
+        format!("Hello, {name}!")
+    }
+
+    let _ = Ohkami::new((
+        "/hello".GET(hello_name),
+    ));
+}
+

--- a/ohkami/src/ohkami/_test.rs
+++ b/ohkami/src/ohkami/_test.rs
@@ -763,19 +763,32 @@ fn panics_unexpected_path_params() {
 
     let _ = Ohkami::new((
         "/hello".GET(hello_name),
-    ));
+    )).test(); /* panics here on finalize */
 }
 
 #[test]
+#[should_panic =
+    "handler `ohkami::ohkami::_test::check_path_params_counted_accumulatedly::hello_name_age` \
+    requires 2 path param(s) \
+    BUT the route `/hello/:name` captures only 1 param(s)"
+]
 fn check_path_params_counted_accumulatedly() {
     async fn hello_name(name: &str) -> String {
         format!("Hello, {name}!")
     }
+    async fn hello_name_age((name, age): (&str, u8)) -> String {
+        format!("Hello, {name} ({age})!")
+    }
 
-    /* should_not_panic */
     let _ = Ohkami::new((
         "/hello/:name".By(Ohkami::new((
             "/".GET(hello_name),
         ))),
-    ));
+    )).test(); /* NOT panics here */
+
+    let _ = Ohkami::new((
+        "/hello/:name".By(Ohkami::new((
+            "/".GET(hello_name_age),
+        ))),
+    )).test(); /* panics here */
 }

--- a/ohkami/src/ohkami/_test.rs
+++ b/ohkami/src/ohkami/_test.rs
@@ -765,4 +765,3 @@ fn panics_unexpected_path_params() {
         "/hello".GET(hello_name),
     ));
 }
-

--- a/ohkami/src/ohkami/_test.rs
+++ b/ohkami/src/ohkami/_test.rs
@@ -765,3 +765,17 @@ fn panics_unexpected_path_params() {
         "/hello".GET(hello_name),
     ));
 }
+
+#[test]
+fn check_path_params_counted_accumulatedly() {
+    async fn hello_name(name: &str) -> String {
+        format!("Hello, {name}!")
+    }
+
+    /* should_not_panic */
+    let _ = Ohkami::new((
+        "/hello/:name".By(Ohkami::new((
+            "/".GET(hello_name),
+        ))),
+    ));
+}

--- a/ohkami/src/ohkami/mod.rs
+++ b/ohkami/src/ohkami/mod.rs
@@ -531,7 +531,7 @@ impl Ohkami {
 
         crate::DEBUG!("[openapi_document_bytes] routes = {routes:#?}, router = {router:#?}");
 
-        let doc = router.gen_openapi_doc(routes, openapi);
+        let doc = router.gen_openapi_doc(routes.into_keys(), openapi);
 
         let mut bytes = ::serde_json::to_vec_pretty(&doc).expect("failed to serialize OpenAPI document");
         bytes.push(b'\n');

--- a/ohkami/src/ohkami/mod.rs
+++ b/ohkami/src/ohkami/mod.rs
@@ -531,7 +531,7 @@ impl Ohkami {
 
         crate::DEBUG!("[openapi_document_bytes] routes = {routes:#?}, router = {router:#?}");
 
-        let doc = router.gen_openapi_doc(routes.into_keys(), openapi);
+        let doc = router.gen_openapi_doc(routes.keys().map(|r| &**r), openapi);
 
         let mut bytes = ::serde_json::to_vec_pretty(&doc).expect("failed to serialize OpenAPI document");
         bytes.push(b'\n');

--- a/ohkami/src/ohkami/routing.rs
+++ b/ohkami/src/ohkami/routing.rs
@@ -14,10 +14,10 @@ pub(crate) struct HandlerMeta {
     pub(crate) n_params: usize,
 }
 impl HandlerMeta {
-    fn new<T, H: IntoHandler<T>>() -> Self {
+    fn new<T, H: IntoHandler<T>>(h: &H) -> Self {
         Self {
             name: std::any::type_name::<H>(),
-            n_params: <H as IntoHandler<T>>::N_PARAMS,
+            n_params: h.n_params(),
         }
     }
 }
@@ -53,10 +53,8 @@ macro_rules! HandlerSet {
         impl HandlerSet {
             $(
                 pub fn $method<T, H: IntoHandler<T>>(mut self, handler: H) -> Self {
-                    self.$method = Some((
-                        handler.into_handler(),
-                        HandlerMeta::new::<T, H>()
-                    ));
+                    let meta = HandlerMeta::new::<T, H>(&handler);
+                    self.$method = Some((handler.into_handler(), meta));
                     self
                 }
             )*
@@ -293,7 +291,7 @@ const _: () = {
                 }
                 
                 impl IntoHandler<std::fs::File> for StaticFileHandler {
-                    const N_PARAMS: usize = 0;
+                    fn n_params(&self) -> usize {0}
                 
                     fn into_handler(self) -> Handler {
                         let this: &'static StaticFileHandler

--- a/ohkami/src/request/path.rs
+++ b/ohkami/src/request/path.rs
@@ -143,13 +143,17 @@ const _: () = {
     }
     
     impl Path {
-        #[cfg(any(
-            all(feature="__rt_native__", feature="DEBUG", test),
-            all(feature="__rt__", feature="openapi"),
-        ))]
+        #[cfg(all(feature="__rt_native__", feature="DEBUG", test))]
         pub(crate) fn from_literal(literal: &'static str) -> Self {
+            // SAFETY: `literal` is 'static
+            unsafe {Self::from_str_unchecked(literal)}
+        }
+    
+        #[allow(unused)]
+        /// SAFETY: `s` outlives the actual (used) lifetime of `Path`
+        pub(crate) unsafe fn from_str_unchecked(s: &str) -> Self {
             Self(MaybeUninit::new(PathInner {
-                raw:    Slice::from_bytes(literal.as_bytes()),
+                raw:    Slice::from_bytes(s.trim_end_matches('/').as_bytes()),
                 params: Params::init(),
             }))
         }

--- a/ohkami/src/router/base.rs
+++ b/ohkami/src/router/base.rs
@@ -402,13 +402,13 @@ impl Pattern {
     #[cfg(feature="__rt_native__")]
     pub(super) fn merge_statics(self, child: Pattern) -> Option<Pattern> {
         match (self, child) {
-            (Pattern::Static(s1), Pattern::Static(s2)) => Some(
-                Pattern::Static(Cow::Owned([
-                    s1.trim_end_matches('/'),
-                    "/",
-                    s2.trim_start_matches('/')
-                ].concat().trim_end_matches('/').to_string()))
-            ),
+            (Pattern::Static(s1), Pattern::Static(s2)) => Some(Pattern::Static(Cow::Owned({
+                let mut merged = format!("{}/{}", s1.trim_end_matches('/'), s2.trim_start_matches('/'));
+                if merged != "/" && merged.ends_with('/') {
+                    let _ = merged.pop();
+                }
+                merged
+            }))),
             _ => None
         }
     }

--- a/ohkami/src/router/final.rs
+++ b/ohkami/src/router/final.rs
@@ -64,7 +64,7 @@ impl Router {
         );
 
         for route in routes {
-            crate::DEBUG!("[gen_openapi_doc] route = `{method} {route}`");
+            crate::DEBUG!("[gen_openapi_doc] route = `{route}`");
 
             assert!(route.starts_with('/'));
 

--- a/ohkami/src/router/final.rs
+++ b/ohkami/src/router/final.rs
@@ -1,4 +1,4 @@
-use super::{util, base, segments::RouteSegments};
+use super::{util, base};
 use crate::fang::{FangProcCaller, BoxedFPC, handler::Handler};
 use crate::{request::Path, response::Content};
 use crate::{Method, Request, Response};
@@ -52,9 +52,9 @@ impl Router {
     }
 
     #[cfg(feature="openapi")]
-    pub(crate) fn gen_openapi_doc(
+    pub(crate) fn gen_openapi_doc<'r>(
         &self,
-        routes: impl Iterator<Item = RouteSegments>,
+        routes: impl Iterator<Item = &'r str>,
         metadata: crate::openapi::OpenAPI,
     ) -> crate::openapi::document::Document {
         let mut doc = crate::openapi::document::Document::new(

--- a/ohkami/src/router/final.rs
+++ b/ohkami/src/router/final.rs
@@ -1,4 +1,4 @@
-use super::{util, base};
+use super::{util, base, segments::RouteSegments};
 use crate::fang::{FangProcCaller, BoxedFPC, handler::Handler};
 use crate::{request::Path, response::Content};
 use crate::{Method, Request, Response};
@@ -54,7 +54,7 @@ impl Router {
     #[cfg(feature="openapi")]
     pub(crate) fn gen_openapi_doc(
         &self,
-        routes:   impl IntoIterator<Item = &'static str>,
+        routes: impl Iterator<Item = RouteSegments>,
         metadata: crate::openapi::OpenAPI,
     ) -> crate::openapi::document::Document {
         let mut doc = crate::openapi::document::Document::new(
@@ -64,7 +64,7 @@ impl Router {
         );
 
         for route in routes {
-            crate::DEBUG!("[gen_openapi_doc] route = `{route}`");
+            crate::DEBUG!("[gen_openapi_doc] route = `{method} {route}`");
 
             assert!(route.starts_with('/'));
 
@@ -90,11 +90,11 @@ impl Router {
                 ("patch",  &self.PATCH),
                 ("delete", &self.DELETE),
             ] {
-                let mut path = crate::request::Path::from_literal(
+                let mut path = unsafe {crate::request::Path::from_str_unchecked(
                     // this is intended even when route == "/", then to "",
                     // samely as `Path::init_with_request_bytes`
                     route.trim_end_matches('/')
-                );
+                )};
 
                 crate::DEBUG!("[gen_openapi_doc] searching `{openapi_method} {route}`");
 
@@ -108,7 +108,7 @@ impl Router {
                 crate::DEBUG!("[gen_openapi_doc] found");
                         
                 for param_name in &openapi_path_param_names {
-                    operation.assign_path_param_name(param_name);
+                    operation.assign_path_param_name(param_name.to_string());
                 }
                 for security_scheme in operation.iter_securitySchemes() {
                     doc.register_securityScheme_component(security_scheme);
@@ -118,7 +118,7 @@ impl Router {
                 }
                 operations.register(openapi_method, operation);
             }
-            
+
             doc = doc.path(openapi_path, operations);
         }
 
@@ -311,8 +311,11 @@ const _: (/* conversions */) = {
     impl From<base::Pattern> for Pattern {
         fn from(base: base::Pattern) -> Self {
             match base {
-                base::Pattern::Static(s) => Self::Static(s.as_bytes()),
-                base::Pattern::Param(_)  => Self::Param
+                base::Pattern::Param(_)  => Self::Param,
+                base::Pattern::Static(s) => Self::Static(match s {
+                    std::borrow::Cow::Borrowed(s) => s.as_bytes(),
+                    std::borrow::Cow::Owned(s) => s.leak().as_bytes(),
+                }),
             }
         }
     }

--- a/ohkami/src/router/segments.rs
+++ b/ohkami/src/router/segments.rs
@@ -53,7 +53,7 @@ impl RouteSegments {
             self.literal().trim_end_matches('/'),
             another.literal().trim_start_matches('/')
         ));
-        if literal.ends_with('/') {
+        if literal != "/" && literal.ends_with('/') {
             let _ = literal.to_mut().pop();
         }
 
@@ -67,6 +67,11 @@ impl std::ops::Deref for RouteSegments {
     type Target = str;
     fn deref(&self) -> &Self::Target {
         &self.literal
+    }
+}
+impl std::fmt::Display for RouteSegments {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(&**self)
     }
 }
 

--- a/ohkami/src/router/segments.rs
+++ b/ohkami/src/router/segments.rs
@@ -1,13 +1,14 @@
-use std::collections::VecDeque;
+use std::{borrow::Cow, collections::VecDeque};
 
-
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) struct RouteSegments {
-    literal: &'static str,
+    literal:  Cow<'static, str>,
     segments: VecDeque<RouteSegment>,
 }
 impl RouteSegments {
-    pub(crate) fn from_literal(literal: &'static str) -> Self {        
+    pub(crate) fn from_literal(literal: impl Into<Cow<'static, str>>) -> Self {
+        let literal: Cow<'static, str> = literal.into();
+
         if literal.is_empty() {panic!("found an empty route")}
 
         if literal == "/" {
@@ -25,16 +26,19 @@ impl RouteSegments {
             .skip(1)
             .chain(Some(literal.len()))
         {
-            segments.push_back(RouteSegment::new(&literal[prev_slash..slash])
-                .expect(&format!("invalid route `{literal}`")));
+            segments.push_back(RouteSegment::new(match &literal {
+                Cow::Borrowed(s) => Cow::Borrowed(&s[prev_slash..slash]),
+                Cow::Owned(s) => Cow::Owned((&s[prev_slash..slash]).to_owned())
+            }).expect(&format!("invalid route `{literal}`")));
+
             prev_slash = slash;
         }
 
         Self { literal, segments }
     }
 
-    pub(crate) fn literal(&self) -> &'static str {
-        self.literal
+    pub(crate) fn literal(&self) -> &str {
+        &self.literal
     }
 
     pub(crate) fn n_params(&self) -> usize {
@@ -42,15 +46,37 @@ impl RouteSegments {
             .filter(|s| matches!(s, RouteSegment::Param(_)))
             .count()
     }
+
+    pub(crate) fn merged(self, another: Self) -> Self {
+        let mut literal: Cow<'_, str> = Cow::Owned(format!(
+            "{}/{}",
+            self.literal().trim_end_matches('/'),
+            another.literal().trim_start_matches('/')
+        ));
+        if literal.ends_with('/') {
+            let _ = literal.to_mut().pop();
+        }
+
+        let mut segments = self.segments;
+        segments.extend(another);
+
+        Self { literal, segments }
+    }
+}
+impl std::ops::Deref for RouteSegments {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        &self.literal
+    }
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub(crate) enum RouteSegment {
-    Static(&'static str),
-    Param (&'static str),
+    Static(Cow<'static, str>),
+    Param (Cow<'static, str>),
 }
 impl RouteSegment {
-    pub(crate) fn new(segment: &'static str) -> Result<Self, String> {
+    pub(crate) fn new(segment: Cow<'static, str>) -> Result<Self, String> {
         fn validate_segment_name(mut name: impl DoubleEndedIterator<Item = char>) -> Result<(), String> {
             let is_invalid_head_or_tail_char = |c: char| !/* NOT */ matches!(c,
                 '0'..='9' | 'a'..='z' | 'A'..='Z'

--- a/ohkami_lib/src/lib.rs
+++ b/ohkami_lib/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod map;
+pub use map::TupleMap;
 
 pub mod mime;
 

--- a/ohkami_lib/src/map.rs
+++ b/ohkami_lib/src/map.rs
@@ -44,6 +44,12 @@ impl<K: PartialEq, V> TupleMap<K, V> {
         }; None
     }
 
+    pub fn append(&mut self, another: Self) {
+        for (k, v) in another.into_iter() {
+            self.insert(k, v);
+        }
+    }
+
     pub fn clear(&mut self) {
         self.0.clear();
     }

--- a/ohkami_lib/src/map.rs
+++ b/ohkami_lib/src/map.rs
@@ -74,6 +74,18 @@ impl<K: Clone + PartialEq, V: Clone> Clone for TupleMap<K, V> {
     }
 }
 
+impl<K:PartialEq, V> std::fmt::Debug for TupleMap<K, V>
+where
+    K: std::fmt::Debug,
+    V: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_map()
+            .entries(self.iter().map(|&(ref k, ref v)| (k, v)))
+            .finish()
+    }
+}
+
 impl<'de, K:PartialEq, V> serde::Deserialize<'de> for TupleMap<K, V>
 where
     K: serde::Deserialize<'de>,

--- a/ohkami_macros/src/openapi.rs
+++ b/ohkami_macros/src/openapi.rs
@@ -545,6 +545,10 @@ pub(super) fn operation(meta: TokenStream, handler: TokenStream) -> syn::Result<
             }
 
             impl ::ohkami::handler::IntoHandler<#handler_name> for #handler_name {
+                fn n_params(&self) -> usize {
+                    ::ohkami::handler::IntoHandler::n_params(&operation::#handler_name)
+                }
+
                 fn into_handler(self) -> ::ohkami::handler::Handler {
                     ::ohkami::handler::IntoHandler::into_handler(operation::#handler_name)
                         .map_openapi_operation(|mut op| { #modify_op op })

--- a/ohkami_openapi/src/paths.rs
+++ b/ohkami_openapi/src/paths.rs
@@ -213,12 +213,12 @@ impl Operation {
     }
 
     #[doc(hidden)]
-    pub fn assign_path_param_name(&mut self, name: &'static str) {
+    pub fn assign_path_param_name(&mut self, name: impl Into<std::borrow::Cow<'static, str>>) {
         if let Some(empty_param) = self.parameters.iter_mut()
             .filter(|p| p.is_path())
             .find(|p| p.name.is_empty())
         {
-            empty_param.name = name;
+            empty_param.name = name.into();
         }
     }
 

--- a/ohkami_openapi/src/request.rs
+++ b/ohkami_openapi/src/request.rs
@@ -7,7 +7,7 @@ pub struct Parameter {
     #[serde(rename = "in")]
     kind: ParameterKind,
 
-    pub(crate) name: &'static str,
+    pub(crate) name: std::borrow::Cow<'static, str>,
     pub(crate) schema: SchemaRef,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -42,8 +42,8 @@ impl Parameter {
     pub fn in_path(schema: impl Into<SchemaRef>) -> Self {
         Self {
             kind: ParameterKind::path,
-            name: "", // initialize with empty name (will be assigned later by `Operation::assign_path_param_name`)
-            schema:schema.into(),
+            name: "".into(), // initialize with empty name (will be assigned later by `Operation::assign_path_param_name`)
+            schema: schema.into(),
             required: true,
             description:None, deprecated:false, style:None, explode:false,
         }
@@ -51,8 +51,8 @@ impl Parameter {
     pub fn maybe_in_path(schema: impl Into<SchemaRef>) -> Self {
         Self {
             kind: ParameterKind::path,
-            name: "", // initialize with empty name (will be assigned later by `Operation::assign_path_param_name`)
-            schema:schema.into(),
+            name: "".into(), // initialize with empty name (will be assigned later by `Operation::assign_path_param_name`)
+            schema: schema.into(),
             required: false,
             description:None, deprecated:false, style:None, explode:false,
         }
@@ -61,7 +61,8 @@ impl Parameter {
     pub fn in_query(name: &'static str, schema: impl Into<SchemaRef>) -> Self {
         Self {
             kind: ParameterKind::query,
-            name, schema:schema.into(),
+            name: name.into(),
+            schema: schema.into(),
             required: true,
             description:None, deprecated:false, style:None, explode:false,
         }
@@ -69,7 +70,8 @@ impl Parameter {
     pub fn maybe_in_query(name: &'static str, schema: impl Into<SchemaRef>) -> Self {
         Self {
             kind: ParameterKind::query,
-            name, schema:schema.into(),
+            name: name.into(),
+            schema: schema.into(),
             required: false,
             description:None, deprecated:false, style:None, explode:false,
         }
@@ -78,7 +80,8 @@ impl Parameter {
     pub fn in_header(name: &'static str, schema: impl Into<SchemaRef>) -> Self {
         Self {
             kind: ParameterKind::header,
-            name, schema:schema.into(),
+            name: name.into(),
+            schema: schema.into(),
             required: true,
             description:None, deprecated:false, style:None, explode:false,
         }
@@ -86,7 +89,8 @@ impl Parameter {
     pub fn maybe_in_header(name: &'static str, schema: impl Into<SchemaRef>) -> Self {
         Self {
             kind: ParameterKind::header,
-            name, schema:schema.into(),
+            name: name.into(),
+            schema: schema.into(),
             required: false,
             description:None, deprecated:false, style:None, explode:false,
         }
@@ -95,7 +99,8 @@ impl Parameter {
     pub fn in_cookie(name: &'static str, schema: impl Into<SchemaRef>) -> Self {
         Self {
             kind: ParameterKind::cookie,
-            name, schema:schema.into(),
+            name: name.into(),
+            schema: schema.into(),
             required: true,
             description:None, deprecated:false, style:None, explode:false,
         }
@@ -103,7 +108,8 @@ impl Parameter {
     pub fn maybe_in_cookie(name: &'static str, schema: impl Into<SchemaRef>) -> Self {
         Self {
             kind: ParameterKind::cookie,
-            name, schema:schema.into(),
+            name: name.into(),
+            schema: schema.into(),
             required: false,
             description:None, deprecated:false, style:None, explode:false,
         }

--- a/samples/worker-bindings/src/lib.rs
+++ b/samples/worker-bindings/src/lib.rs
@@ -3,6 +3,7 @@ use ohkami::bindings;
 #[bindings]
 struct AutoBindings;
 
+#[allow(unused)]
 #[bindings]
 struct ManualBindings {
     VARIABLE_1: bindings::Var,


### PR DESCRIPTION
Before, mismatch of path params at registration like

```rust
// requires 1 path param
async fn hello(name: &str) -> String {
    format!("Hello, {name}!")
}

// capture 0 path params
Ohkami::new((
    "/hello".GET(hello),
))
```

causes *undefined behavior*, actually ( Ohkami trusted users TOO much that they never write such codes ) .

This PR:

- adds `n_params` to `IntoHandler` and store it in `HandlerSet`.
- updates `base::Router`'s `routes` to hold `HashMap<RouteSegments, TupleMap<Method, HandlerMeta>>`, here `HandlerMeta` stores `n_params`
- updates `base::Router::finalize` to check that each handler's `n_params` doesn't exceeds the number of param segments of corresponded `RouteSegments`. if exceeds, safely panic with friendly message.

The `n_params`s exist only in preparing step, and the check is executed before starting serving. So this PR does NOT affect the performance.