### PR TITLE
openapi: Fix #[derive(Schema)] bugs

### DIFF
--- a/ohkami_openapi/src/schema.rs
+++ b/ohkami_openapi/src/schema.rs
@@ -173,6 +173,7 @@ impl SchemaRef {
         let mut component_schemas = vec![];
         match self {
             SchemaRef::Inline(raw) => {
+                raw.properties.values_mut().for_each(|s| component_schemas.extend(s.refize()));
                 raw.anyOf.iter_mut().for_each(|s| component_schemas.extend(s.refize()));
                 raw.allOf.iter_mut().for_each(|s| component_schemas.extend(s.refize()));
                 raw.oneOf.iter_mut().for_each(|s| component_schemas.extend(s.refize()));

--- a/samples/openapi-schema-enums/Cargo.toml
+++ b/samples/openapi-schema-enums/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name    = "openapi-schema-enums"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+# set `default-features = false` to assure "DEBUG" feature be off even when DEBUGing `../ohkami`
+ohkami  = { path = "../../ohkami", default-features = false, features = ["rt_tokio", "openapi"] }

--- a/samples/openapi-schema-enums/openapi.json
+++ b/samples/openapi-schema-enums/openapi.json
@@ -237,6 +237,30 @@
           }
         }
       }
+    },
+    "/user-or-task-untagged-newtype": {
+      "get": {
+        "operationId": "dummy",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/User"
+                    },
+                    {
+                      "$ref": "#/components/schemas/Task"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/samples/openapi-schema-enums/openapi.json
+++ b/samples/openapi-schema-enums/openapi.json
@@ -1,0 +1,408 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Dummy Server for testing #[derive(Schema)] for enums",
+    "version": "0"
+  },
+  "servers": [],
+  "paths": {
+    "/color": {
+      "get": {
+        "operationId": "dummy",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "enum": [
+                    "red",
+                    "blue",
+                    "green"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "dummy",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ColorComponent"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user-or-task": {
+      "get": {
+        "operationId": "dummy",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "User": {
+                          "type": "object",
+                          "properties": {
+                            "age": {
+                              "type": "integer"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "age"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "User"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "Task": {
+                          "type": "object",
+                          "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "title": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "title"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "Task"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "dummy",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserOrTaskComponent"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user-or-task-newtype": {
+      "get": {
+        "operationId": "dummy",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "User": {
+                          "type": "object",
+                          "properties": {
+                            "age": {
+                              "type": "integer"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "age"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "User"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "Task": {
+                          "type": "object",
+                          "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "title": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "title"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "Task"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "dummy",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserOrTaskNewtypeComponent"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user-or-task-untagged": {
+      "get": {
+        "operationId": "dummy",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "age": {
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "age"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "title"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "dummy",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserOrTaskUntaggedComponent"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ColorComponent": {
+        "type": "string",
+        "enum": [
+          "red",
+          "blue",
+          "green"
+        ]
+      },
+      "UserOrTaskComponent": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "User": {
+                "type": "object",
+                "properties": {
+                  "age": {
+                    "type": "integer"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "age"
+                ]
+              }
+            },
+            "required": [
+              "User"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "Task": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "title"
+                ]
+              }
+            },
+            "required": [
+              "Task"
+            ]
+          }
+        ]
+      },
+      "UserOrTaskNewtypeComponent": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "User": {
+                "type": "object",
+                "properties": {
+                  "age": {
+                    "type": "integer"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "age"
+                ]
+              }
+            },
+            "required": [
+              "User"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "Task": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "title"
+                ]
+              }
+            },
+            "required": [
+              "Task"
+            ]
+          }
+        ]
+      },
+      "UserOrTaskUntaggedComponent": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "age": {
+                "type": "integer"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "age"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/samples/openapi-schema-enums/openapi.json
+++ b/samples/openapi-schema-enums/openapi.json
@@ -135,19 +135,7 @@
                       "type": "object",
                       "properties": {
                         "User": {
-                          "type": "object",
-                          "properties": {
-                            "age": {
-                              "type": "integer"
-                            },
-                            "name": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "name",
-                            "age"
-                          ]
+                          "$ref": "#/components/schemas/User"
                         }
                       },
                       "required": [
@@ -158,18 +146,7 @@
                       "type": "object",
                       "properties": {
                         "Task": {
-                          "type": "object",
-                          "properties": {
-                            "description": {
-                              "type": "string"
-                            },
-                            "title": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "title"
-                          ]
+                          "$ref": "#/components/schemas/Task"
                         }
                       },
                       "required": [
@@ -272,6 +249,35 @@
           "green"
         ]
       },
+      "Task": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ]
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "age": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "age"
+        ]
+      },
       "UserOrTaskComponent": {
         "oneOf": [
           {
@@ -327,19 +333,7 @@
             "type": "object",
             "properties": {
               "User": {
-                "type": "object",
-                "properties": {
-                  "age": {
-                    "type": "integer"
-                  },
-                  "name": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "name",
-                  "age"
-                ]
+                "$ref": "#/components/schemas/User"
               }
             },
             "required": [
@@ -350,18 +344,7 @@
             "type": "object",
             "properties": {
               "Task": {
-                "type": "object",
-                "properties": {
-                  "description": {
-                    "type": "string"
-                  },
-                  "title": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "title"
-                ]
+                "$ref": "#/components/schemas/Task"
               }
             },
             "required": [

--- a/samples/openapi-schema-enums/openapi.json.sample
+++ b/samples/openapi-schema-enums/openapi.json.sample
@@ -1,0 +1,415 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Dummy Server for testing #[derive(Schema)] for enums",
+    "version": "0"
+  },
+  "servers": [],
+  "paths": {
+    "/color": {
+      "get": {
+        "operationId": "dummy",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "enum": [
+                    "red",
+                    "blue",
+                    "green"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "dummy",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ColorComponent"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user-or-task": {
+      "get": {
+        "operationId": "dummy",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "User": {
+                          "type": "object",
+                          "properties": {
+                            "age": {
+                              "type": "integer"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "age"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "User"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "Task": {
+                          "type": "object",
+                          "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "title": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "title"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "Task"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "dummy",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserOrTaskComponent"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user-or-task-newtype": {
+      "get": {
+        "operationId": "dummy",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "User": {
+                          "$ref": "#/components/schemas/User"
+                        }
+                      },
+                      "required": [
+                        "User"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "Task": {
+                          "$ref": "#/components/schemas/Task"
+                        }
+                      },
+                      "required": [
+                        "Task"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "dummy",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserOrTaskNewtypeComponent"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user-or-task-untagged": {
+      "get": {
+        "operationId": "dummy",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "age": {
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "age"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "description": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "title"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "dummy",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserOrTaskUntaggedComponent"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user-or-task-untagged-newtype": {
+      "get": {
+        "operationId": "dummy",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/User"
+                    },
+                    {
+                      "$ref": "#/components/schemas/Task"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ColorComponent": {
+        "type": "string",
+        "enum": [
+          "red",
+          "blue",
+          "green"
+        ]
+      },
+      "Task": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ]
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "age": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "age"
+        ]
+      },
+      "UserOrTaskComponent": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "User": {
+                "type": "object",
+                "properties": {
+                  "age": {
+                    "type": "integer"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "age"
+                ]
+              }
+            },
+            "required": [
+              "User"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "Task": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "title"
+                ]
+              }
+            },
+            "required": [
+              "Task"
+            ]
+          }
+        ]
+      },
+      "UserOrTaskNewtypeComponent": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "User": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "required": [
+              "User"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "Task": {
+                "$ref": "#/components/schemas/Task"
+              }
+            },
+            "required": [
+              "Task"
+            ]
+          }
+        ]
+      },
+      "UserOrTaskUntaggedComponent": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "age": {
+                "type": "integer"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "age"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "description": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/samples/openapi-schema-enums/src/main.rs
+++ b/samples/openapi-schema-enums/src/main.rs
@@ -1,0 +1,133 @@
+#![allow(unused/* just generating openapi.json for dummy handlers */)]
+
+use ohkami::prelude::*;
+use ohkami::openapi;
+
+#[derive(Serialize, openapi::Schema)]
+enum Color {
+    #[serde(rename = "red")]
+    Red,
+    #[serde(rename = "blue")]
+    Blue,
+    #[serde(rename = "green")]
+    Green,
+}
+
+#[derive(Serialize, openapi::Schema)]
+#[openapi(component)]
+enum ColorComponent {
+    #[serde(rename = "red")]
+    Red,
+    #[serde(rename = "blue")]
+    Blue,
+    #[serde(rename = "green")]
+    Green,
+}
+
+#[derive(Serialize, openapi::Schema)]
+enum UserOrTask {
+    User {
+        name: String,
+        age:  u8,
+    },
+    Task {
+        title: String,
+        description: Option<String>,
+    },
+}
+
+#[derive(Serialize, openapi::Schema)]
+#[serde(untagged)]
+enum UserOrTaskUntagged {
+    User {
+        name: String,
+        age:  u8,
+    },
+    Task {
+        title: String,
+        description: Option<String>,
+    },
+}
+
+#[derive(Serialize, openapi::Schema)]
+#[openapi(component)]
+enum UserOrTaskComponent {
+    User {
+        name: String,
+        age:  u8,
+    },
+    Task {
+        title: String,
+        description: Option<String>,
+    },
+}
+
+#[derive(Serialize, openapi::Schema)]
+#[openapi(component)]
+#[serde(untagged)]
+enum UserOrTaskUntaggedComponent {
+    User {
+        name: String,
+        age:  u8,
+    },
+    Task {
+        title: String,
+        description: Option<String>,
+    },
+}
+
+#[derive(Serialize, openapi::Schema)]
+enum UserOrTaskNewtype {
+    User(User),
+    Task(Task),
+}
+
+#[derive(Serialize, openapi::Schema)]
+#[openapi(component)]
+enum UserOrTaskNewtypeComponent {
+    User(User),
+    Task(Task),
+}
+
+#[derive(Serialize, openapi::Schema)]
+#[openapi(component)]
+struct User {
+    name: String,
+    age:  u8,
+}
+
+#[derive(Serialize, openapi::Schema)]
+#[openapi(component)]
+struct Task {
+    title:       String,
+    description: Option<String>,
+}
+
+fn main() {
+    macro_rules! dummy_handler {
+        ($return_type:ty) => {
+            {async fn dummy() -> JSON<$return_type> {todo!()}; dummy}
+        };
+    }
+
+    let o = Ohkami::new((
+        "/color"
+            .GET(dummy_handler!(Color))
+            .PUT(dummy_handler!(ColorComponent)),
+        "/user-or-task"
+            .GET(dummy_handler!(UserOrTask))
+            .PUT(dummy_handler!(UserOrTaskComponent)),
+        "/user-or-task-untagged"
+            .GET(dummy_handler!(UserOrTaskUntagged))
+            .PUT(dummy_handler!(UserOrTaskUntaggedComponent)),
+        "/user-or-task-newtype"
+            .GET(dummy_handler!(UserOrTaskNewtype))
+            .PUT(dummy_handler!(UserOrTaskNewtypeComponent)),
+    ));
+
+    o.generate(openapi::OpenAPI {
+        title: "Dummy Server for testing #[derive(Schema)] for enums",
+        version: "0",
+        servers: &[],
+    });
+}

--- a/samples/openapi-schema-enums/src/main.rs
+++ b/samples/openapi-schema-enums/src/main.rs
@@ -83,6 +83,13 @@ enum UserOrTaskNewtype {
 }
 
 #[derive(Serialize, openapi::Schema)]
+#[serde(untagged)]
+enum UserOrTaskUntaggedNewtype {
+    User(User),
+    Task(Task),
+}
+
+#[derive(Serialize, openapi::Schema)]
 #[openapi(component)]
 enum UserOrTaskNewtypeComponent {
     User(User),
@@ -123,6 +130,8 @@ fn main() {
         "/user-or-task-newtype"
             .GET(dummy_handler!(UserOrTaskNewtype))
             .PUT(dummy_handler!(UserOrTaskNewtypeComponent)),
+        "/user-or-task-untagged-newtype"
+            .GET(dummy_handler!(UserOrTaskUntaggedNewtype)),
     ));
 
     o.generate(openapi::OpenAPI {

--- a/samples/test.sh
+++ b/samples/test.sh
@@ -4,10 +4,15 @@ set -Ceu
 
 SAMPLES=$(pwd)
 
-cd $SAMPLES/openapi-tags && \
+cd $SAMPLES/openapi-schema-enums && \
     cargo run && \
     diff openapi.json openapi.json.sample
 test $? -ne 0 && exit 150 || :
+
+cd $SAMPLES/openapi-tags && \
+    cargo run && \
+    diff openapi.json openapi.json.sample
+test $? -ne 0 && exit 151 || :
 
 cd $SAMPLES/petstore && \
     cargo build && \
@@ -21,14 +26,14 @@ cd $SAMPLES/petstore && \
         npm run main
 # FIXME
 # this is a little flaky; sometimes cause connection refused
-test $? -ne 0 && exit 151 || :
+test $? -ne 0 && exit 152 || :
 
 cd $SAMPLES/readme-openapi && \
     cargo build && \
     (timeout -sKILL 1 cargo run &) && \
     sleep 1 && \
     diff openapi.json openapi.json.sample
-test $? -ne 0 && exit 152 || :
+test $? -ne 0 && exit 153 || :
 
 cd $SAMPLES/realworld && \
     docker compose up -d && \
@@ -36,22 +41,22 @@ cd $SAMPLES/realworld && \
     sqlx migrate run && \
     cargo test && \
     docker compose down
-test $? -ne 0 && exit 153 || :
+test $? -ne 0 && exit 154 || :
 
 cd $SAMPLES/streaming && \
     cargo build && \
     (timeout -sKILL 1 cargo run &) && \
     sleep 1 && \
     diff openapi.json openapi.json.sample
-test $? -ne 0 && exit 154 || :
+test $? -ne 0 && exit 155 || :
 
 cd $SAMPLES/worker-bindings && \
     cargo check
-test $? -ne 0 && exit 155 || :
+test $? -ne 0 && exit 156 || :
 
 cd $SAMPLES/worker-durable-websocket && \
     cargo check
-test $? -ne 0 && exit 156 || :
+test $? -ne 0 && exit 157 || :
 
 cd $SAMPLES/worker-with-openapi && \
     cp wrangler.toml.sample wrangler.toml && \
@@ -67,4 +72,4 @@ cd $SAMPLES/worker-with-openapi && \
         diff openapi.json tmp.json \
         ; (test -f tmp.json && rm tmp.json) \
     || :)
-test $? -ne 0 && exit 157 || :
+test $? -ne 0 && exit 158 || :


### PR DESCRIPTION
Fix

- resolve `#[openapi(component)]` of properties
- specialize simple enum's `Schema` as string enum in OpenAPI
- `#[serde]` intercept: `rename_all` of container's and variant's

and add sample samples/openapi-schema-enums and diff test for it in samples/test.sh