### PR TITLE
openapi(#[derive(Schema)]): Support intercepting `from`, `into`, `try_into` serde helper attributes

### DIFF
--- a/samples/openapi-schema-enums/openapi.json
+++ b/samples/openapi-schema-enums/openapi.json
@@ -56,30 +56,30 @@
                     {
                       "type": "object",
                       "properties": {
-                        "User": {
+                        "user": {
                           "type": "object",
                           "properties": {
                             "age": {
                               "type": "integer"
                             },
-                            "name": {
+                            "username": {
                               "type": "string"
                             }
                           },
                           "required": [
-                            "name",
+                            "username",
                             "age"
                           ]
                         }
                       },
                       "required": [
-                        "User"
+                        "user"
                       ]
                     },
                     {
                       "type": "object",
                       "properties": {
-                        "Task": {
+                        "task": {
                           "type": "object",
                           "properties": {
                             "description": {
@@ -95,7 +95,7 @@
                         }
                       },
                       "required": [
-                        "Task"
+                        "task"
                       ]
                     }
                   ]

--- a/samples/openapi-schema-enums/openapi.json.sample
+++ b/samples/openapi-schema-enums/openapi.json.sample
@@ -56,30 +56,30 @@
                     {
                       "type": "object",
                       "properties": {
-                        "User": {
+                        "user": {
                           "type": "object",
                           "properties": {
                             "age": {
                               "type": "integer"
                             },
-                            "name": {
+                            "username": {
                               "type": "string"
                             }
                           },
                           "required": [
-                            "name",
+                            "username",
                             "age"
                           ]
                         }
                       },
                       "required": [
-                        "User"
+                        "user"
                       ]
                     },
                     {
                       "type": "object",
                       "properties": {
-                        "Task": {
+                        "task": {
                           "type": "object",
                           "properties": {
                             "description": {
@@ -95,7 +95,7 @@
                         }
                       },
                       "required": [
-                        "Task"
+                        "task"
                       ]
                     }
                   ]

--- a/samples/openapi-schema-enums/src/main.rs
+++ b/samples/openapi-schema-enums/src/main.rs
@@ -26,10 +26,13 @@ enum ColorComponent {
 
 #[derive(Serialize, openapi::Schema)]
 enum UserOrTask {
+    #[serde(rename = "user")]
     User {
+        #[serde(rename = "username")]
         name: String,
         age:  u8,
     },
+    #[serde(rename = "task")]
     Task {
         title: String,
         description: Option<String>,

--- a/samples/openapi-schema-from-into/Cargo.toml
+++ b/samples/openapi-schema-from-into/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name    = "openapi-schema-from-into"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+# set `default-features = false` to assure "DEBUG" feature be off even when DEBUGing `../ohkami`
+ohkami  = { path = "../../ohkami", default-features = false, features = ["rt_tokio", "openapi"] }

--- a/samples/openapi-schema-from-into/openapi.json
+++ b/samples/openapi-schema-from-into/openapi.json
@@ -1,0 +1,111 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Dummy Server for serde From & Into",
+    "version": "0"
+  },
+  "servers": [],
+  "paths": {
+    "/from": {
+      "get": {
+        "operationId": "dummy",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "age": {
+                    "type": "integer"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "age"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/into": {
+      "get": {
+        "operationId": "dummy",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "user": {
+                      "type": "object",
+                      "properties": {
+                        "age": {
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "age"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "user"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/try_from": {
+      "get": {
+        "operationId": "dummy",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "age": {
+                    "type": "integer"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "age"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/samples/openapi-schema-from-into/openapi.json.sample
+++ b/samples/openapi-schema-from-into/openapi.json.sample
@@ -1,0 +1,111 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Dummy Server for serde From & Into",
+    "version": "0"
+  },
+  "servers": [],
+  "paths": {
+    "/from": {
+      "get": {
+        "operationId": "dummy",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "age": {
+                    "type": "integer"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "age"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/into": {
+      "get": {
+        "operationId": "dummy",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "user": {
+                      "type": "object",
+                      "properties": {
+                        "age": {
+                          "type": "integer"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "age"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "user"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/try_from": {
+      "get": {
+        "operationId": "dummy",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "age": {
+                    "type": "integer"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "age"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/samples/openapi-schema-from-into/src/main.rs
+++ b/samples/openapi-schema-from-into/src/main.rs
@@ -1,0 +1,122 @@
+#![allow(unused/* just generating openapi.json for dummy handlers */)]
+
+use ohkami::prelude::*;
+use ohkami::serde::json;
+use ohkami::openapi;
+
+#[derive(Deserialize, openapi::Schema)]
+struct RawCreateUser<'req> {
+    name: &'req str,
+    age:  u8,
+}
+
+#[derive(Deserialize, openapi::Schema, Debug, PartialEq)]
+#[serde(from = "RawCreateUser")]
+struct CreateUser<'req> {
+    username: &'req str,
+    age: u8,
+}
+impl<'req> From<RawCreateUser<'req>> for CreateUser<'req> {
+    fn from(raw: RawCreateUser<'req>) -> Self {
+        Self {
+            username: raw.name,
+            age: raw.age,
+        }
+    }
+}
+
+#[derive(Deserialize, openapi::Schema)]
+#[serde(try_from = "RawCreateUser")]
+struct ValidatedCreateUser<'req> {
+    username: &'req str,
+    age:  u8,
+}
+impl<'req> TryFrom<RawCreateUser<'req>> for ValidatedCreateUser<'req> {
+    type Error = String;
+
+    fn try_from(raw: RawCreateUser<'req>) -> Result<Self, Self::Error> {
+        if raw.age < 18 {
+            return Err(format!("User's age must be 18 or more"))
+        }
+
+        Ok(Self {
+            username: raw.name,
+            age: raw.age,
+        })
+    }
+}
+
+#[derive(Serialize, openapi::Schema, Clone)]
+#[serde(into = "UserResponse")]
+struct User {
+    name: String,
+    age:  u8,
+}
+
+#[derive(Serialize, openapi::Schema)]
+struct UserResponse {
+    user: UserResponseUser,
+}
+#[derive(Serialize, openapi::Schema)]
+struct UserResponseUser {
+    name: String,
+    age: u8,
+}
+impl From<User> for UserResponse {
+    fn from(user: User) -> Self {
+        Self {
+            user: UserResponseUser {
+                name: user.name,
+                age: user.age,
+            }
+        }
+    }
+}
+
+fn main() {
+    macro_rules! dummy_handler {
+        (-> $return_type:ty) => {
+            {async fn dummy() -> JSON<$return_type> {todo!()}; dummy}
+        };
+        ($req_type:ty) => {
+            {async fn dummy(_: JSON<$req_type>) {}; dummy}
+        };
+    }
+
+    let o = Ohkami::new((
+        "/from".GET(dummy_handler!(CreateUser<'_>)),
+        "/try_from".GET(dummy_handler!(ValidatedCreateUser<'_>)),
+        "/into".GET(dummy_handler!(-> UserResponse)),
+    ));
+
+    assert!(Result::is_err(&json::from_str::<CreateUser>(r#"{
+        "username": "ohkami",
+        "age": 4
+    }"#)));
+    assert_eq!(json::from_str::<CreateUser>(r#"{
+        "name": "ohkami",
+        "age": 4
+    }"#).unwrap(), CreateUser {
+        username: "ohkami",
+        age: 4
+    });
+
+    let u = User {
+        name: format!("ohkami"),
+        age:  4
+    };
+    assert_ne!(
+        json::to_string(&u).unwrap(),
+        r#"{"name":"ohkami","age":4}"#
+    );
+    assert_eq!(
+        json::to_string(&u).unwrap(),
+        r#"{"user":{"name":"ohkami","age":4}}"#
+    );
+
+    o.generate(openapi::OpenAPI {
+        title: "Dummy Server for serde From & Into",
+        version: "0",
+        servers: &[],
+    });
+}

--- a/samples/test.sh
+++ b/samples/test.sh
@@ -9,10 +9,15 @@ cd $SAMPLES/openapi-schema-enums && \
     diff openapi.json openapi.json.sample
 test $? -ne 0 && exit 150 || :
 
-cd $SAMPLES/openapi-tags && \
+cd $SAMPLES/openapi-schema-from-into && \
     cargo run && \
     diff openapi.json openapi.json.sample
 test $? -ne 0 && exit 151 || :
+
+cd $SAMPLES/openapi-tags && \
+    cargo run && \
+    diff openapi.json openapi.json.sample
+test $? -ne 0 && exit 152 || :
 
 cd $SAMPLES/petstore && \
     cargo build && \
@@ -26,14 +31,14 @@ cd $SAMPLES/petstore && \
         npm run main
 # FIXME
 # this is a little flaky; sometimes cause connection refused
-test $? -ne 0 && exit 152 || :
+test $? -ne 0 && exit 153 || :
 
 cd $SAMPLES/readme-openapi && \
     cargo build && \
     (timeout -sKILL 1 cargo run &) && \
     sleep 1 && \
     diff openapi.json openapi.json.sample
-test $? -ne 0 && exit 153 || :
+test $? -ne 0 && exit 154 || :
 
 cd $SAMPLES/realworld && \
     docker compose up -d && \
@@ -41,22 +46,22 @@ cd $SAMPLES/realworld && \
     sqlx migrate run && \
     cargo test && \
     docker compose down
-test $? -ne 0 && exit 154 || :
+test $? -ne 0 && exit 155 || :
 
 cd $SAMPLES/streaming && \
     cargo build && \
     (timeout -sKILL 1 cargo run &) && \
     sleep 1 && \
     diff openapi.json openapi.json.sample
-test $? -ne 0 && exit 155 || :
+test $? -ne 0 && exit 156 || :
 
 cd $SAMPLES/worker-bindings && \
     cargo check
-test $? -ne 0 && exit 156 || :
+test $? -ne 0 && exit 157 || :
 
 cd $SAMPLES/worker-durable-websocket && \
     cargo check
-test $? -ne 0 && exit 157 || :
+test $? -ne 0 && exit 158 || :
 
 cd $SAMPLES/worker-with-openapi && \
     cp wrangler.toml.sample wrangler.toml && \
@@ -72,4 +77,4 @@ cd $SAMPLES/worker-with-openapi && \
         diff openapi.json tmp.json \
         ; (test -f tmp.json && rm tmp.json) \
     || :)
-test $? -ne 0 && exit 158 || :
+test $? -ne 0 && exit 159 || :


### PR DESCRIPTION
When

- `#[serde(into = "...")]`
- `#[serde(from = "...")]`
- `#[serde(try_from = "...")]`

specified, `#[derive(Schema)]` now outputs the partner's schema