### PR TITLE
builtin: security headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,48 +284,6 @@ async fn main() {
 
 ## Snippets
 
-### Middlewares
-
-Ohkami's request handling system is called "**fang**s", and middlewares are implemented on this.
-
-*builtin fang* : `Context`, `CORS`, `JWT`, `BasicAuth`, `Timeout`, `Enamel` *( experimantal )*
-
-```rust,no_run
-use ohkami::prelude::*;
-
-#[derive(Clone)]
-struct GreetingFang(usize);
-
-/* utility trait; automatically impl `Fang` trait */
-impl FangAction for GreetingFang {
-    async fn fore<'a>(&'a self, req: &'a mut Request) -> Result<(), Response> {
-        let Self(id) = self;
-        println!("[{id}] Welcome request!: {req:?}");
-        Ok(())
-    }
-    async fn back<'a>(&'a self, res: &'a mut Response) {
-        let Self(id) = self;
-        println!("[{id}] Go, response!: {res:?}");
-    }
-}
-
-#[tokio::main]
-async fn main() {
-    Ohkami::new((
-        // register fangs to a Ohkami
-        GreetingFang(1),
-        
-        "/hello"
-            .GET(|| async {"Hello, fangs!"})
-            .POST((
-                // register *local fangs* to a handler
-                GreetingFang(2),
-                || async {"I'm `POST /hello`!"}
-            ))
-    )).howl("localhost:3000").await
-}
-```
-
 ### Typed payload
 
 *builtin payload* : `JSON`, `Text`, `HTML`, `URLEncoded`, `Multipart`
@@ -401,6 +359,53 @@ async fn search(
     JSON(vec![
         SearchResult { title: String::from("ohkami") },
     ])
+}
+```
+
+### Middlewares
+
+Ohkami's request handling system is called "**fang**s", and middlewares are implemented on this.
+
+*builtin fang* :
+
+- `Context` *( typed interaction with reuqest context )*
+- `CORS`, `JWT`, `BasicAuth`
+- `Timeout` *( native runtime )*
+- `Enamel` *( experimantal; security headers )*
+
+```rust,no_run
+use ohkami::prelude::*;
+
+#[derive(Clone)]
+struct GreetingFang(usize);
+
+/* utility trait; automatically impl `Fang` trait */
+impl FangAction for GreetingFang {
+    async fn fore<'a>(&'a self, req: &'a mut Request) -> Result<(), Response> {
+        let Self(id) = self;
+        println!("[{id}] Welcome request!: {req:?}");
+        Ok(())
+    }
+    async fn back<'a>(&'a self, res: &'a mut Response) {
+        let Self(id) = self;
+        println!("[{id}] Go, response!: {res:?}");
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    Ohkami::new((
+        // register fangs to a Ohkami
+        GreetingFang(1),
+        
+        "/hello"
+            .GET(|| async {"Hello, fangs!"})
+            .POST((
+                // register *local fangs* to a handler
+                GreetingFang(2),
+                || async {"I'm `POST /hello`!"}
+            ))
+    )).howl("localhost:3000").await
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ async fn main() {
 
 Ohkami's request handling system is called "**fang**s", and middlewares are implemented on this.
 
-*builtin fang* : `CORS`, `JWT`, `BasicAuth`, `Timeout`, `Context`
+*builtin fang* : `Context`, `CORS`, `JWT`, `BasicAuth`, `Timeout`, `Enamel` *( experimantal )*
 
 ```rust,no_run
 use ohkami::prelude::*;
@@ -366,10 +366,10 @@ use ohkami::prelude::*;
 #[tokio::main]
 async fn main() {
     Ohkami::new((
-        "/hello/:name"
-            .GET(hello),
         "/hello/:name/:n"
             .GET(hello_n),
+        "/hello/:name"
+            .GET(hello),
         "/search"
             .GET(search),
     )).howl("localhost:5000").await

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -10,7 +10,7 @@ pub use jwt::{JWT, JWTToken};
 mod context;
 pub use context::Context;
 
-mod helmet;
+pub mod helmet;
 pub use helmet::Helmet;
 
 #[cfg(feature="__rt_native__")]

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -10,8 +10,8 @@ pub use jwt::{JWT, JWTToken};
 mod context;
 pub use context::Context;
 
-pub mod helmet;
-pub use helmet::Helmet;
+pub mod enamel;
+pub use enamel::Enamel;
 
 #[cfg(feature="__rt_native__")]
 mod timeout;

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -10,6 +10,9 @@ pub use jwt::{JWT, JWTToken};
 mod context;
 pub use context::Context;
 
+mod helmet;
+pub use helmet::Helmet;
+
 #[cfg(feature="__rt_native__")]
 mod timeout;
 #[cfg(feature="__rt_native__")]

--- a/ohkami/src/fang/builtin/enamel.rs
+++ b/ohkami/src/fang/builtin/enamel.rs
@@ -489,6 +489,7 @@ pub mod src {
 
 
 #[cfg(test)]
+#[cfg(feature="__rt_native__")]
 mod test {
     use super::*;
     use crate::prelude::*;

--- a/ohkami/src/fang/builtin/enamel.rs
+++ b/ohkami/src/fang/builtin/enamel.rs
@@ -509,7 +509,7 @@ mod test {
                 let res = t.oneshot(req).await;
                 assert_eq!(res.status().code(), 200);
                 assert_eq!(res.text().unwrap(), "Hello, enamel!");
-                assert_eq!(res.headers().collect::<HashSet<_>>(), HashSet::from_iter([
+                assert_eq!(res.headers().filter(|(h, _)| *h != "Date").collect::<HashSet<_>>(), HashSet::from_iter([
                     ("Cross-Origin-Embedder-Policy", "require-corp"),
                     ("Cross-Origin-Resource-Policy", "same-origin"),
                     ("Referrer-Policy", "no-referrer"),
@@ -528,13 +528,15 @@ mod test {
                 let res = t.oneshot(req).await;
                 assert_eq!(res.status().code(), 404);
                 assert_eq!(res.text(), None);
-                assert_eq!(res.headers().collect::<HashSet<_>>(), HashSet::from_iter([
+                assert_eq!(res.headers().filter(|(h, _)| *h != "Date").collect::<HashSet<_>>(), HashSet::from_iter([
                     ("Cross-Origin-Embedder-Policy", "require-corp"),
                     ("Cross-Origin-Resource-Policy", "same-origin"),
                     ("Referrer-Policy", "no-referrer"),
                     ("Strict-Transport-Security", "max-age=15552000; includeSubDomains"),
                     ("X-Content-Type-Options", "nosniff"),
                     ("X-Frame-Options", "SAMEORIGIN"),
+
+                    ("Content-Length", "0"),
                 ]));
             }
             {
@@ -542,13 +544,15 @@ mod test {
                 let res = t.oneshot(req).await;
                 assert_eq!(res.status().code(), 404);
                 assert_eq!(res.text(), None);
-                assert_eq!(res.headers().collect::<HashSet<_>>(), HashSet::from_iter([
+                assert_eq!(res.headers().filter(|(h, _)| *h != "Date").collect::<HashSet<_>>(), HashSet::from_iter([
                     ("Cross-Origin-Embedder-Policy", "require-corp"),
                     ("Cross-Origin-Resource-Policy", "same-origin"),
                     ("Referrer-Policy", "no-referrer"),
                     ("Strict-Transport-Security", "max-age=15552000; includeSubDomains"),
                     ("X-Content-Type-Options", "nosniff"),
                     ("X-Frame-Options", "SAMEORIGIN"),
+
+                    ("Content-Length", "0"),
                 ]));
             }
             {
@@ -556,13 +560,15 @@ mod test {
                 let res = t.oneshot(req).await;
                 assert_eq!(res.status().code(), 404);
                 assert_eq!(res.text(), None);
-                assert_eq!(res.headers().collect::<HashSet<_>>(), HashSet::from_iter([
+                assert_eq!(res.headers().filter(|(h, _)| *h != "Date").collect::<HashSet<_>>(), HashSet::from_iter([
                     ("Cross-Origin-Embedder-Policy", "require-corp"),
                     ("Cross-Origin-Resource-Policy", "same-origin"),
                     ("Referrer-Policy", "no-referrer"),
                     ("Strict-Transport-Security", "max-age=15552000; includeSubDomains"),
                     ("X-Content-Type-Options", "nosniff"),
                     ("X-Frame-Options", "SAMEORIGIN"),
+
+                    ("Content-Length", "0"),
                 ]));
             }
         });
@@ -591,7 +597,7 @@ mod test {
                 let res = t.oneshot(req).await;
                 assert_eq!(res.status().code(), 200);
                 assert_eq!(res.text().unwrap(), "Hello, enamel!");
-                assert_eq!(res.headers().collect::<HashSet<_>>(), HashSet::from_iter([
+                assert_eq!(res.headers().filter(|(h, _)| *h != "Date").collect::<HashSet<_>>(), HashSet::from_iter([
                     /* defaults */
                     ("Cross-Origin-Embedder-Policy", "require-corp"),
                     ("Cross-Origin-Resource-Policy", "same-origin"),
@@ -626,7 +632,7 @@ mod test {
                 let res = t.oneshot(req).await;
                 assert_eq!(res.status().code(), 200);
                 assert_eq!(res.text().unwrap(), "Hello, enamel!");
-                assert_eq!(res.headers().collect::<HashSet<_>>(), HashSet::from_iter([
+                assert_eq!(res.headers().filter(|(h, _)| *h != "Date").collect::<HashSet<_>>(), HashSet::from_iter([
                     /* ("Cross-Origin-Embedder-Policy", "require-corp"), */
                     /* ("Cross-Origin-Resource-Policy", "same-origin"), */
                     ("Referrer-Policy", "no-referrer"),

--- a/ohkami/src/fang/builtin/helmet.rs
+++ b/ohkami/src/fang/builtin/helmet.rs
@@ -145,13 +145,16 @@ const _: () = {
 /// 
 /// ```
 /// use ohkami::prelude::*;
-/// use ohkami::fang::{Helmet, Sandbox::{allow_forms, allow_same_origin}};
+/// use ohkami::fang::helmet::{Helmet, CSP, Sandbox::{allow_forms, allow_same_origin}};
 /// 
 /// #[tokio::main]
 /// async fn main() {
 ///     Ohkami::new((
 ///         Helmet {
-///             sandbox: allow_forms | allow_same_origin,
+///             ContentSecurityPolicy: Some(CSP {
+///                 sandbox: allow_forms | allow_same_origin,
+///                 ..Default::default()
+///             }),
 ///             ..Default::default()
 ///         },
 ///         "/hello".GET(|| async {"Hello, helmet!"})
@@ -215,13 +218,16 @@ const _: () = {
 /// 
 /// ```
 /// use ohkami::prelude::*;
-/// use ohkami::fang::{Helmet, SouceList::{self_origin, data}};
+/// use ohkami::fang::helmet::{Helmet, CSP, SourceList::{self_origin, data}};
 /// 
 /// #[tokio::main]
 /// async fn main() {
 ///     Ohkami::new((
 ///         Helmet {
-///             script_src: self_origin | data,
+///             ContentSecurityPolicy: Some(CSP {
+///                 script_src: self_origin | data,
+///                 ..Default::default()
+///             }),
 ///             ..Default::default()
 ///         },
 ///         "/hello".GET(|| async {"Hello, helmet!"})
@@ -351,9 +357,8 @@ const _: () = {
             static SET_HEADERS: OnceLock<Box<dyn Fn(&mut Response) + Send + Sync>> = OnceLock::new();
 
             let set_headers = SET_HEADERS.get_or_init(|| {
-                /* clone only once */
+                /* clone **only once** */
                 let helmet = self.clone();
-
                 Box::new(move |res: &mut Response| {helmet.apply(res)})
             });
 

--- a/ohkami/src/fang/builtin/helmet.rs
+++ b/ohkami/src/fang/builtin/helmet.rs
@@ -1,30 +1,87 @@
-pub struct Helmet(Option<Box<HelmetFields>>);
+pub struct Helmet(Box<HelmetFields>);
 
+/// based on <https://hono.dev/docs/middleware/builtin/secure-headers>,
+/// with removing non-standard or deprecated headers
+#[derive(Clone)]
 struct HelmetFields {
-    delete_x_powered_by: bool,
-    content_security_policy: Option<ContentSecurityPolicy>,
+    pub ContentSecurityPolicy:           Option<CSP>,
+    pub ContentSecurityPolicyReportOnly: Option<CSP>,
+    pub CrossOriginEmbedderPolicy:       Option<&'static str>,
+    pub CrossOriginResourcePolicy:       Option<&'static str>,
+    pub ReferrerPolicy:                  Option<&'static str>,
+    pub StrictTransportSecurity:         Option<&'static str>,
+    pub XContentTypeOptions:             Option<&'static str>,
+    pub XFrameOptions:                   Option<&'static str>,
 }
 
-impl Default for Helmet {
-    fn default() -> Self {
-        Self(Some(Box::new(HelmetFields {
-            delete_x_powered_by: true,
-            content_security_policy: None,
-        })))
-    }
+/// based on <https://content-security-policy.com>
+#[derive(Clone)]
+pub struct CSP {
+    pub default_src:               Option<&'static str>,
+    pub script_src:                Option<&'static str>,
+    pub style_src:                 Option<&'static str>,
+    pub img_src:                   Option<&'static str>,
+    pub connect_src:               Option<&'static str>,
+    pub font_src:                  Option<&'static str>,
+    pub object_src:                Option<&'static str>,
+    pub media_src:                 Option<&'static str>,
+    pub frame_src:                 Option<&'static str>,
+    pub sandbox:                   Option<Sandbox>,
+    pub report_uri:                Option<&'static str>,
+    pub child_src:                 Option<&'static str>,
+    pub form_action:               Option<&'static str>,
+    pub frame_ancestors:           Option<&'static str>,
+    pub plugin_types:              Option<&'static str>,
+    pub base_uri:                  Option<&'static str>,
+    pub report_to:                 Option<&'static str>,
+    pub worker_src:                Option<&'static str>,
+    pub manifest_src:              Option<&'static str>,
+    pub prefetch_src:              Option<&'static str>,
+    pub navifate_to:               Option<&'static str>,
+    pub require_trusted_types_for: Option<&'static str>,
+    pub trusted_types:             Option<&'static str>,
+    pub upgrade_insecure_requests: Option<&'static str>,
+    pub block_all_mixed_content:   Option<&'static str>,
 }
+
+const _: () = {
+    use crate::{Request, Response, Fang, FangProc};
+    use std::sync::OnceLock;
+
+    impl<I: FangProc> Fang for Helmet {
+        type Proc = HelmetProc<I>;
+        fn chain(&self, inner: Inner) -> Self::Proc {
+            static SET_HEADERS: OnceLock<Box<dyn Fn(&mut Request)>>;
+
+            /* clone only once */
+            let set_headers = SET_HEADERS.get_or_init({
+
+                || {
+                    
+                }
+            });
+
+            HelmetProc { inner, set_headers }
+        }
+    }
+
+    struct HelmetProc<I> {
+        set_headers: Box<dyn Fn(&mut Request)>,
+        inner: I,
+    }
+
+    impl<I: FangProc> FangProc<I> for HelmetProc<I> {
+
+    }
+};
 
 impl Helmet {
-    pub fn delete_XPoweredBy(mut self, yes: bool) -> Self {
-        self.delete_XPoweredBy = yes;
-        self
-    }
     pub fn ContentSecurityPolicy(mut self, setter: impl FnOnce(field::ContentSecurityPolicy) -> field::ContentSecurityPolicy) -> Self {
-        self.ContentSecurityPolicy = setter(ContentSecurityPolicy(String::new()));
+        self.ContentSecurityPolicy = Some(setter(ContentSecurityPolicy(String::new())).0);
         self
     }
     pub fn ContentSecurityPolicyReportOnly(mut self, setter: impl FnOnce(field::ContentSecurityPolicy) -> field::ContentSecurityPolicy) -> Self {
-        self.ContentSecurityPolicyReportOnly = setter(ContentSecurityPolicyReportOnly(String::new()));
+        self.ContentSecurityPolicyReportOnly = Some(setter(ContentSecurityPolicyReportOnly(String::new())).0);
         self
     }
     pub fn CrossOriginEmbedderPolicy_require_corp(mut self) -> Self {
@@ -38,4 +95,6 @@ mod field {
     impl ContentSecurityPolicy {
 
     }
+
+
 }

--- a/ohkami/src/fang/builtin/helmet.rs
+++ b/ohkami/src/fang/builtin/helmet.rs
@@ -48,13 +48,13 @@ pub struct CSP {
 /// 
 /// ```
 /// use ohkami::prelude::*;
-/// use ohkami::fang::{Helmet, Sandbox};
+/// use ohkami::fang::{Helmet, Sandbox::{allow_forms, allow_same_origin}};
 /// 
 /// #[tokio::main]
 /// async fn main() {
 ///     Ohkami::new((
 ///         Helmet {
-///             sandbox: Sandbox::allow_forms | Sandbox::allow_same_origin,
+///             sandbox: allow_forms | allow_same_origin,
 ///             ..Default::default()
 ///         },
 ///         "/hello".GET(|| async {"Hello, helmet!"})
@@ -101,6 +101,17 @@ const _: () = {
             if self.0 & Self::allow_top_navigation.0 != 0           {result.push_str(" allow-top-navigation");}
             result
         }
+    }
+};
+
+pub struct SourceList {
+    directive: u16,
+    value: Option<Box<String>>,
+}
+const _: () = {
+    #[allow(non_upper_case_globals)]
+    impl SourceList {
+        
     }
 };
 

--- a/ohkami/src/fang/builtin/helmet.rs
+++ b/ohkami/src/fang/builtin/helmet.rs
@@ -388,19 +388,33 @@ pub mod src {
         (const $src:expr) => {SourceList { this: $src.build_const(), list: Vec::new() }};
         (hash $src:expr) => {SourceList { this: $src.build_hash(), list: Vec::new() }};
     }
+    /// `*`
     pub const any:            SourceList = this!(const Source::any);
+    /// `data:`
     pub const data:           SourceList = this!(const Source::data);
+    /// `https:`
     pub const https:          SourceList = this!(const Source::https);
+    /// `'none'`
     pub const none:           SourceList = this!(const Source::none);
+    /// `'self'`
     pub const self_origin:    SourceList = this!(const Source::self_origin);
+    /// `'strict-dynamic'`
     pub const strict_dynamic: SourceList = this!(const Source::strict_dynamic);
+    /// `'unsafe-inline'`
     pub const unsafe_inline:  SourceList = this!(const Source::unsafe_inline);
+    /// `'unsafe-eval'`
     pub const unsafe_eval:    SourceList = this!(const Source::unsafe_eval);
+    /// `'unsafe-hashes'`
     pub const unsafe_hashes:  SourceList = this!(const Source::unsafe_hashes);
+    /// like `domain.example.com`, `*.example.com`, `https://cdn.com`
     pub fn domain(domain: &'static str) -> SourceList {this!(const Source::domain(domain))}
+    /// `'sha256-{sha256}'`
     pub fn sha256(sha256: String) -> SourceList {this!(hash Source::sha256(sha256))}
+    /// `'sha384-{sha384}'`
     pub fn sha384(sha384: String) -> SourceList {this!(hash Source::sha384(sha384))}
+    /// `'sha512-{sha512}'`
     pub fn sha512(sha512: String) -> SourceList {this!(hash Source::sha512(sha512))}
+    /// `'nonce-{nonce}'`
     pub fn nonce(nonce:  String) -> SourceList {this!(hash Source::nonce(nonce))}
 
     impl std::ops::BitOr for SourceList {

--- a/ohkami/src/fang/builtin/helmet.rs
+++ b/ohkami/src/fang/builtin/helmet.rs
@@ -44,6 +44,66 @@ pub struct CSP {
     pub block_all_mixed_content:   Option<&'static str>,
 }
 
+/// ## Example
+/// 
+/// ```
+/// use ohkami::prelude::*;
+/// use ohkami::fang::{Helmet, Sandbox};
+/// 
+/// #[tokio::main]
+/// async fn main() {
+///     Ohkami::new((
+///         Helmet {
+///             sandbox: Sandbox::allow_forms | Sandbox::allow_same_origin,
+///             ..Default::default()
+///         },
+///         "/hello".GET(|| async {"Hello, helmet!"})
+///     )).howl("localhost:3000").await
+/// }
+/// ```
+#[derive(Clone)]
+pub struct Sandbox(u16);
+const _: () = {
+    #[allow(non_upper_case_globals)]
+    impl Sandbox {
+        pub const allow_forms                    = Self(0b0000000001u16),
+        pub const allow_same_origin              = Self(0b0000000010u16),
+        pub const allow_scripts                  = Self(0b0000000100u16),
+        pub const allow_popups                   = Self(0b0000001000u16),
+        pub const allow_modals                   = Self(0b0000010000u16),
+        pub const allow_orientation_lock         = Self(0b0000100000u16),
+        pub const allow_pointer_lock             = Self(0b0001000000u16),
+        pub const allow_presentation             = Self(0b0010000000u16),
+        pub const allow_popups_to_escape_sandbox = Self(0b0100000000u16),
+        pub const allow_top_navigation           = Self(0b1000000000u16),
+    }
+
+    impl std::ops::BitOr for Sandbox {
+        type Output = Self;
+
+        fn bitor(self, rhs: Self) -> Self::Output {
+            Self(self.0 | rhs.0)
+        }
+    }
+
+    impl Sandbox {
+        pub(self) fn build(&self) -> String {
+            let mut result = String::from("sandbox");
+            if self.0 & Self::allow_forms.0 != 0                    {result.push_str(" allow-forms");}
+            if self.0 & Self::allow_same_origin.0 != 0              {result.push_str(" allow-same-origin");}
+            if self.0 & Self::allow_scripts.0 != 0                  {result.push_str(" allow-scripts");}
+            if self.0 & Self::allow_popups.0 != 0                   {result.push_str(" allow-popups");}
+            if self.0 & Self::allow_modals.0 != 0                   {result.push_str(" allow-modals");}
+            if self.0 & Self::allow_orientation_lock.0 != 0         {result.push_str(" allow-orientation-lock");}
+            if self.0 & Self::allow_pointer_lock.0 != 0             {result.push_str(" allow-pointer-lock");}
+            if self.0 & Self::allow_presentation.0 != 0             {result.push_str(" allow-presentation");}
+            if self.0 & Self::allow_popups_to_escape_sandbox.0 != 0 {result.push_str(" allow-popups-to-escape-sandbox");}
+            if self.0 & Self::allow_top_navigation.0 != 0           {result.push_str(" allow-top-navigation");}
+            result
+        }
+    }
+};
+
 const _: () = {
     use crate::{Request, Response, Fang, FangProc};
     use std::sync::OnceLock;

--- a/ohkami/src/fang/builtin/helmet.rs
+++ b/ohkami/src/fang/builtin/helmet.rs
@@ -1,48 +1,145 @@
-pub struct Helmet(Box<HelmetFields>);
-
 /// based on <https://hono.dev/docs/middleware/builtin/secure-headers>,
 /// with removing non-standard or deprecated headers
 #[derive(Clone)]
-struct HelmetFields {
+#[allow(non_snake_case)]
+pub struct Helmet {
     pub ContentSecurityPolicy:           Option<CSP>,
     pub ContentSecurityPolicyReportOnly: Option<CSP>,
-    pub CrossOriginEmbedderPolicy:       Option<&'static str>,
-    pub CrossOriginResourcePolicy:       Option<&'static str>,
-    pub ReferrerPolicy:                  Option<&'static str>,
-    pub StrictTransportSecurity:         Option<&'static str>,
-    pub XContentTypeOptions:             Option<&'static str>,
-    pub XFrameOptions:                   Option<&'static str>,
+    pub CrossOriginEmbedderPolicy:       &'static str,
+    pub CrossOriginResourcePolicy:       &'static str,
+    pub ReferrerPolicy:                  &'static str,
+    pub StrictTransportSecurity:         &'static str,
+    pub XContentTypeOptions:             &'static str,
+    pub XFrameOptions:                   &'static str,
 }
+const _: () = {
+    impl Default for Helmet {
+        fn default() -> Self {
+            Helmet {
+                ContentSecurityPolicy:           None,
+                ContentSecurityPolicyReportOnly: None,
+                CrossOriginEmbedderPolicy:       "require-corp",
+                CrossOriginResourcePolicy:       "same-origin",
+                ReferrerPolicy:                  "no-referrer",
+                StrictTransportSecurity:         "max-age=15552000; includeSubDomains",
+                XContentTypeOptions:             "nosniff",
+                XFrameOptions:                   "SAMEORIGIN",
+            }
+        }
+    }
+
+    impl Helmet {
+        pub(self) fn apply(&self, res: &mut crate::Response) {
+            let mut h = res.headers.set();
+            if let Some(csp) = &self.ContentSecurityPolicy {
+                h = h.ContentSecurityPolicy(csp.build());
+            }
+            if let Some(csp) = &self.ContentSecurityPolicyReportOnly {
+                h = h.ContentSecurityPolicyReportOnly(csp.build());
+            }
+            if !self.CrossOriginEmbedderPolicy.is_empty() {
+                h = h.CrossOriginEmbedderPolicy(self.CrossOriginEmbedderPolicy);
+            }
+            if !self.CrossOriginResourcePolicy.is_empty() {
+                h = h.CrossOriginResourcePolicy(self.CrossOriginResourcePolicy);
+            }
+            if !self.ReferrerPolicy.is_empty() {
+                h = h.ReferrerPolicy(self.ReferrerPolicy);
+            }
+            if !self.StrictTransportSecurity.is_empty() {
+                h = h.StrictTransportSecurity(self.StrictTransportSecurity);
+            }
+            if !self.XContentTypeOptions.is_empty() {
+                h = h.XContentTypeOptions(self.XContentTypeOptions);
+            }
+            if !self.XFrameOptions.is_empty() {
+                h.XFrameOptions(self.XFrameOptions);
+            }
+        }
+    }
+};
 
 /// based on <https://content-security-policy.com>
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct CSP {
-    pub default_src:               Option<&'static str>,
-    pub script_src:                Option<&'static str>,
-    pub style_src:                 Option<&'static str>,
-    pub img_src:                   Option<&'static str>,
-    pub connect_src:               Option<&'static str>,
-    pub font_src:                  Option<&'static str>,
-    pub object_src:                Option<&'static str>,
-    pub media_src:                 Option<&'static str>,
-    pub frame_src:                 Option<&'static str>,
-    pub sandbox:                   Option<Sandbox>,
-    pub report_uri:                Option<&'static str>,
-    pub child_src:                 Option<&'static str>,
-    pub form_action:               Option<&'static str>,
-    pub frame_ancestors:           Option<&'static str>,
-    pub plugin_types:              Option<&'static str>,
-    pub base_uri:                  Option<&'static str>,
-    pub report_to:                 Option<&'static str>,
-    pub worker_src:                Option<&'static str>,
-    pub manifest_src:              Option<&'static str>,
-    pub prefetch_src:              Option<&'static str>,
-    pub navifate_to:               Option<&'static str>,
-    pub require_trusted_types_for: Option<&'static str>,
-    pub trusted_types:             Option<&'static str>,
-    pub upgrade_insecure_requests: Option<&'static str>,
-    pub block_all_mixed_content:   Option<&'static str>,
+    pub default_src:               SourceList,
+    pub script_src:                SourceList,
+    pub style_src:                 SourceList,
+    pub img_src:                   SourceList,
+    pub connect_src:               SourceList,
+    pub font_src:                  SourceList,
+    pub object_src:                SourceList,
+    pub media_src:                 SourceList,
+    pub frame_src:                 SourceList,
+    pub sandbox:                   Sandbox,
+    pub report_uri:                &'static str,
+    pub child_src:                 SourceList,
+    pub form_action:               &'static str,
+    pub frame_ancestors:           &'static str,
+    pub plugin_types:              &'static str,
+    pub base_uri:                  &'static str,
+    pub report_to:                 &'static str,
+    pub worker_src:                SourceList,
+    pub manifest_src:              SourceList,
+    pub prefetch_src:              SourceList,
+    pub navifate_to:               &'static str,
+    pub require_trusted_types_for: &'static str,
+    pub trusted_types:             &'static str,
+    pub upgrade_insecure_requests: &'static str,
+    pub block_all_mixed_content:   &'static str,
 }
+const _: () = {
+    impl CSP {
+        pub(self) fn build(&self) -> String {
+            let mut result = String::new();
+
+            macro_rules! append {
+                ($field:ident build as $policy:literal) => {
+                    if !(self.$field.is_empty()) {
+                        result.push_str(concat!($policy, " "));
+                        result.push_str(&*self.$field.build());
+                        result.push(';');
+                    }
+                };
+                ($field:ident as $policy:literal) => {
+                    if !(self.$field.is_empty()) {
+                        result.push_str(concat!($policy, " "));
+                        result.push_str(self.$field);
+                        result.push(';');
+                    }
+                };
+            }
+
+            append!(default_src               build as "default-src");
+            append!(script_src                build as "script-src");
+            append!(style_src                 build as "style-src");
+            append!(img_src                   build as "img-src");
+            append!(connect_src               build as "connect-src");
+            append!(font_src                  build as "font-src");
+            append!(object_src                build as "object-src");
+            append!(media_src                 build as "media-src");
+            append!(frame_src                 build as "frame-src");
+            append!(sandbox                   build as "sandbox");
+            append!(report_uri                      as "report-uri");
+            append!(child_src                 build as "child-src");
+            append!(form_action                     as "form-action");
+            append!(frame_ancestors                 as "frame-ancestors");
+            append!(plugin_types                    as "plugin-types");
+            append!(base_uri                        as "base-uri");
+            append!(report_to                       as "report-to");
+            append!(worker_src                build as "worker-src");
+            append!(manifest_src              build as "manifest-src");
+            append!(prefetch_src              build as "prefetch_src");
+            append!(navifate_to                     as "navifate-to");
+            append!(require_trusted_types_for       as "require-trusted-types-for");
+            append!(trusted_types                   as "trusted-types");
+            append!(upgrade_insecure_requests       as "upgrade-insecure-requests");
+            append!(block_all_mixed_content         as "block-all-mixed-content");
+
+            result
+        }
+    }
+};
 
 /// ## Example
 /// 
@@ -66,16 +163,16 @@ pub struct Sandbox(u16);
 const _: () = {
     #[allow(non_upper_case_globals)]
     impl Sandbox {
-        pub const allow_forms                    = Self(0b0000000001u16),
-        pub const allow_same_origin              = Self(0b0000000010u16),
-        pub const allow_scripts                  = Self(0b0000000100u16),
-        pub const allow_popups                   = Self(0b0000001000u16),
-        pub const allow_modals                   = Self(0b0000010000u16),
-        pub const allow_orientation_lock         = Self(0b0000100000u16),
-        pub const allow_pointer_lock             = Self(0b0001000000u16),
-        pub const allow_presentation             = Self(0b0010000000u16),
-        pub const allow_popups_to_escape_sandbox = Self(0b0100000000u16),
-        pub const allow_top_navigation           = Self(0b1000000000u16),
+        pub const allow_forms:                    Self = Self(0b0000000001u16);
+        pub const allow_same_origin:              Self = Self(0b0000000010u16);
+        pub const allow_scripts:                  Self = Self(0b0000000100u16);
+        pub const allow_popups:                   Self = Self(0b0000001000u16);
+        pub const allow_modals:                   Self = Self(0b0000010000u16);
+        pub const allow_orientation_lock:         Self = Self(0b0000100000u16);
+        pub const allow_pointer_lock:             Self = Self(0b0001000000u16);
+        pub const allow_presentation:             Self = Self(0b0010000000u16);
+        pub const allow_popups_to_escape_sandbox: Self = Self(0b0100000000u16);
+        pub const allow_top_navigation:           Self = Self(0b1000000000u16);
     }
 
     impl std::ops::BitOr for Sandbox {
@@ -86,9 +183,19 @@ const _: () = {
         }
     }
 
+    impl Default for Sandbox {
+        fn default() -> Self {
+            Self(0b0000000000u16)
+        }
+    }
+
     impl Sandbox {
+        pub(self) const fn is_empty(&self) -> bool {
+            self.0 == 0b0000000000u16
+        }
+
         pub(self) fn build(&self) -> String {
-            let mut result = String::from("sandbox");
+            let mut result = String::new();
             if self.0 & Self::allow_forms.0 != 0                    {result.push_str(" allow-forms");}
             if self.0 & Self::allow_same_origin.0 != 0              {result.push_str(" allow-same-origin");}
             if self.0 & Self::allow_scripts.0 != 0                  {result.push_str(" allow-scripts");}
@@ -104,14 +211,133 @@ const _: () = {
     }
 };
 
+/// ## Example
+/// 
+/// ```
+/// use ohkami::prelude::*;
+/// use ohkami::fang::{Helmet, SouceList::{self_origin, data}};
+/// 
+/// #[tokio::main]
+/// async fn main() {
+///     Ohkami::new((
+///         Helmet {
+///             script_src: self_origin | data,
+///             ..Default::default()
+///         },
+///         "/hello".GET(|| async {"Hello, helmet!"})
+///     )).howl("localhost:3000").await
+/// }
+/// ```
+#[derive(Clone, Default)]
 pub struct SourceList {
-    directive: u16,
-    value: Option<Box<String>>,
+    this: std::borrow::Cow<'static, str>,
+    list: Vec<std::borrow::Cow<'static, str>>,
 }
 const _: () = {
+    #[derive(Clone)]
+    #[allow(non_camel_case_types)]
+    pub enum Source {
+        any,
+        data,
+        https,
+        none,
+        self_origin,
+        strict_dynamic,
+        unsafe_inline,
+        unsafe_eval,
+        unsafe_hashes,
+        domain(&'static str),
+        sha256(String),
+        sha384(String),
+        sha512(String),
+        nonce(String),
+    }
+    impl Source {
+        pub(self) const fn build_const(&self) -> std::borrow::Cow<'static, str> {
+            match self {
+                Self::any            => std::borrow::Cow::Borrowed("*"),
+                Self::data           => std::borrow::Cow::Borrowed("data:"),
+                Self::https          => std::borrow::Cow::Borrowed("https:"),
+                Self::none           => std::borrow::Cow::Borrowed("'none'"),
+                Self::self_origin    => std::borrow::Cow::Borrowed("'self'"),
+                Self::strict_dynamic => std::borrow::Cow::Borrowed("'strict-dynamic'"),
+                Self::unsafe_inline  => std::borrow::Cow::Borrowed("'unsafe-inline'"),
+                Self::unsafe_eval    => std::borrow::Cow::Borrowed("'unsafe-eval'"),
+                Self::unsafe_hashes  => std::borrow::Cow::Borrowed("'unsafe-hashes'"),
+                Self::domain(s)      => std::borrow::Cow::Borrowed(*s),
+                Self::sha256(_) => unreachable!(),
+                Self::sha384(_) => unreachable!(),
+                Self::sha512(_) => unreachable!(),
+                Self::nonce(_)  => unreachable!(),
+            }
+        }
+        pub(self) fn build_hash(&self) -> std::borrow::Cow<'static, str> {
+            match self {
+                Self::any            => unreachable!(),
+                Self::data           => unreachable!(),
+                Self::https          => unreachable!(),
+                Self::none           => unreachable!(),
+                Self::self_origin    => unreachable!(),
+                Self::strict_dynamic => unreachable!(),
+                Self::unsafe_inline  => unreachable!(),
+                Self::unsafe_eval    => unreachable!(),
+                Self::unsafe_hashes  => unreachable!(),
+                Self::domain(_)      => unreachable!(),
+                Self::sha256(s) => std::borrow::Cow::Owned(format!("'sha256-{s}'")),
+                Self::sha384(s) => std::borrow::Cow::Owned(format!("'sha384-{s}'")),
+                Self::sha512(s) => std::borrow::Cow::Owned(format!("'sha512-{s}'")),
+                Self::nonce(s)  => std::borrow::Cow::Owned(format!("'nonce-{s}'")),
+            }
+        }
+    }
+
+    macro_rules! this {
+        (const $src:expr) => {SourceList { this: $src.build_const(), list: Vec::new() }};
+        (hash $src:expr) => {SourceList { this: $src.build_hash(), list: Vec::new() }};
+    }
     #[allow(non_upper_case_globals)]
     impl SourceList {
-        
+        pub const any:            Self = this!(const Source::any);
+        pub const data:           Self = this!(const Source::data);
+        pub const https:          Self = this!(const Source::https);
+        pub const none:           Self = this!(const Source::none);
+        pub const self_origin:    Self = this!(const Source::self_origin);
+        pub const strict_dynamic: Self = this!(const Source::strict_dynamic);
+        pub const unsafe_inline:  Self = this!(const Source::unsafe_inline);
+        pub const unsafe_eval:    Self = this!(const Source::unsafe_eval);
+        pub const unsafe_hashes:  Self = this!(const Source::unsafe_hashes);
+        pub fn domain(domain: &'static str) -> Self {this!(const Source::domain(domain))}
+        pub fn sha256(sha256: String) -> Self {this!(hash Source::sha256(sha256))}
+        pub fn sha384(sha384: String) -> Self {this!(hash Source::sha384(sha384))}
+        pub fn sha512(sha512: String) -> Self {this!(hash Source::sha512(sha512))}
+        pub fn nonce (nonce:  String) -> Self {this!(hash Source::nonce(nonce))}
+    }
+
+    impl std::ops::BitOr for SourceList {
+        type Output = Self;
+
+        fn bitor(mut self, rhs: Self) -> Self::Output {
+            self.list.push(rhs.this);
+            self.list.extend(rhs.list);
+            self
+        }
+    }
+
+    impl SourceList {
+        pub(self) fn is_empty(&self) -> bool {
+            self.this.is_empty()
+        }
+
+        pub(self) fn build(&self) -> String {
+            let mut result = String::from(&*self.this);
+            if !self.list.is_empty() {
+                for s in &self.list {
+                    result.push(' ');
+                    result.push_str(&*s);
+                }
+            }
+            result
+        }
     }
 };
 
@@ -119,53 +345,33 @@ const _: () = {
     use crate::{Request, Response, Fang, FangProc};
     use std::sync::OnceLock;
 
-    impl<I: FangProc> Fang for Helmet {
+    impl<I: FangProc> Fang<I> for Helmet {
         type Proc = HelmetProc<I>;
-        fn chain(&self, inner: Inner) -> Self::Proc {
-            static SET_HEADERS: OnceLock<Box<dyn Fn(&mut Request)>>;
+        fn chain(&self, inner: I) -> Self::Proc {
+            static SET_HEADERS: OnceLock<Box<dyn Fn(&mut Response) + Send + Sync>> = OnceLock::new();
 
-            /* clone only once */
-            let set_headers = SET_HEADERS.get_or_init({
+            let set_headers = SET_HEADERS.get_or_init(|| {
+                /* clone only once */
+                let helmet = self.clone();
 
-                || {
-                    
-                }
+                Box::new(move |res: &mut Response| {helmet.apply(res)})
             });
 
             HelmetProc { inner, set_headers }
         }
     }
 
-    struct HelmetProc<I> {
-        set_headers: Box<dyn Fn(&mut Request)>,
+    pub struct HelmetProc<I> {
+        set_headers: &'static (dyn Fn(&mut Response) + Send + Sync),
         inner: I,
     }
 
-    impl<I: FangProc> FangProc<I> for HelmetProc<I> {
-
+    impl<I: FangProc> FangProc for HelmetProc<I> {
+        #[inline]
+        async fn bite<'f>(&'f self, req: &'f mut Request) -> Response {
+            let mut res = self.inner.bite(req).await;
+            (self.set_headers)(&mut res);
+            res
+        }
     }
 };
-
-impl Helmet {
-    pub fn ContentSecurityPolicy(mut self, setter: impl FnOnce(field::ContentSecurityPolicy) -> field::ContentSecurityPolicy) -> Self {
-        self.ContentSecurityPolicy = Some(setter(ContentSecurityPolicy(String::new())).0);
-        self
-    }
-    pub fn ContentSecurityPolicyReportOnly(mut self, setter: impl FnOnce(field::ContentSecurityPolicy) -> field::ContentSecurityPolicy) -> Self {
-        self.ContentSecurityPolicyReportOnly = Some(setter(ContentSecurityPolicyReportOnly(String::new())).0);
-        self
-    }
-    pub fn CrossOriginEmbedderPolicy_require_corp(mut self) -> Self {
-        self.CrossOriginEmbedderPolicy_require_corp = true;
-        self
-    }
-}
-
-mod field {
-    struct ContentSecurityPolicy(String);
-    impl ContentSecurityPolicy {
-
-    }
-
-
-}

--- a/ohkami/src/fang/builtin/helmet.rs
+++ b/ohkami/src/fang/builtin/helmet.rs
@@ -1,0 +1,41 @@
+pub struct Helmet(Option<Box<HelmetFields>>);
+
+struct HelmetFields {
+    delete_x_powered_by: bool,
+    content_security_policy: Option<ContentSecurityPolicy>,
+}
+
+impl Default for Helmet {
+    fn default() -> Self {
+        Self(Some(Box::new(HelmetFields {
+            delete_x_powered_by: true,
+            content_security_policy: None,
+        })))
+    }
+}
+
+impl Helmet {
+    pub fn delete_XPoweredBy(mut self, yes: bool) -> Self {
+        self.delete_XPoweredBy = yes;
+        self
+    }
+    pub fn ContentSecurityPolicy(mut self, setter: impl FnOnce(field::ContentSecurityPolicy) -> field::ContentSecurityPolicy) -> Self {
+        self.ContentSecurityPolicy = setter(ContentSecurityPolicy(String::new()));
+        self
+    }
+    pub fn ContentSecurityPolicyReportOnly(mut self, setter: impl FnOnce(field::ContentSecurityPolicy) -> field::ContentSecurityPolicy) -> Self {
+        self.ContentSecurityPolicyReportOnly = setter(ContentSecurityPolicyReportOnly(String::new()));
+        self
+    }
+    pub fn CrossOriginEmbedderPolicy_require_corp(mut self) -> Self {
+        self.CrossOriginEmbedderPolicy_require_corp = true;
+        self
+    }
+}
+
+mod field {
+    struct ContentSecurityPolicy(String);
+    impl ContentSecurityPolicy {
+
+    }
+}

--- a/ohkami/src/fang/builtin/helmet.rs
+++ b/ohkami/src/fang/builtin/helmet.rs
@@ -1,16 +1,30 @@
 /// based on <https://hono.dev/docs/middleware/builtin/secure-headers>,
 /// with removing non-standard or deprecated headers
+/// 
+/// ## Example
+/// 
+/// ```no_run
+/// use ohkami::prelude::*;
+/// use ohkami::fang::Helmet;
+/// 
+/// #[tokio::main]
+/// async fn main() {
+///     Ohkami::new((Helmet::default(),
+///         "/hello".GET(|| async {"Hello, Helmet!"}),
+///     )).howl("localhost:4040").await
+/// }
+/// ```
 #[derive(Clone)]
 #[allow(non_snake_case)]
 pub struct Helmet {
-    pub ContentSecurityPolicy:           Option<CSP>,
-    pub ContentSecurityPolicyReportOnly: Option<CSP>,
-    pub CrossOriginEmbedderPolicy:       &'static str,
-    pub CrossOriginResourcePolicy:       &'static str,
-    pub ReferrerPolicy:                  &'static str,
-    pub StrictTransportSecurity:         &'static str,
-    pub XContentTypeOptions:             &'static str,
-    pub XFrameOptions:                   &'static str,
+    ContentSecurityPolicy:           Option<CSP>,
+    ContentSecurityPolicyReportOnly: Option<CSP>,
+    CrossOriginEmbedderPolicy:       &'static str,
+    CrossOriginResourcePolicy:       &'static str,
+    ReferrerPolicy:                  &'static str,
+    StrictTransportSecurity:         &'static str,
+    XContentTypeOptions:             &'static str,
+    XFrameOptions:                   &'static str,
 }
 const _: () = {
     impl Default for Helmet {
@@ -25,6 +39,42 @@ const _: () = {
                 XContentTypeOptions:             "nosniff",
                 XFrameOptions:                   "SAMEORIGIN",
             }
+        }
+    }
+
+    #[allow(non_snake_case)]
+    impl Helmet {
+        /// default: no setting
+        pub fn ContentSecurityPolicy(mut self, csp: CSP) -> Self {
+            self.ContentSecurityPolicy = Some(csp); self
+        }
+        /// default: no setting
+        pub fn ContentSecurityPolicyReportOnly(mut self, csp: CSP) -> Self {
+            self.ContentSecurityPolicyReportOnly = Some(csp); self
+        }
+        /// default: `"require-corp"`
+        pub fn CrossOriginEmbedderPolicy(mut self, CrossOriginEmbedderPolicy: &'static str) -> Self {
+            self.CrossOriginEmbedderPolicy = CrossOriginEmbedderPolicy; self
+        }
+        /// default: `"same-origin"`
+        pub fn CrossOriginResourcePolicy(mut self, CrossOriginResourcePolicy: &'static str) -> Self {
+            self.CrossOriginResourcePolicy = CrossOriginResourcePolicy; self
+        }
+        /// default: `"no-referrer"`
+        pub fn ReferrerPolicy(mut self, ReferrerPolicy: &'static str) -> Self {
+            self.ReferrerPolicy = ReferrerPolicy; self
+        }
+        /// default: `"max-age=15552000; includeSubDomains"`
+        pub fn StrictTransportSecurity(mut self, StrictTransportSecurity: &'static str) -> Self {
+            self.StrictTransportSecurity = StrictTransportSecurity; self
+        }
+        /// default: `"nosniff"`
+        pub fn XContentTypeOptions(mut self, XContentTypeOptions: &'static str) -> Self {
+            self.XContentTypeOptions = XContentTypeOptions; self
+        }
+        /// default: `"SAMEORIGIN"`
+        pub fn XFrameOptions(mut self, XFrameOptions: &'static str) -> Self {
+            self.XFrameOptions = XFrameOptions; self
         }
     }
 
@@ -60,28 +110,46 @@ const _: () = {
 };
 
 /// based on <https://content-security-policy.com>
+/// 
+/// ## Example
+/// 
+/// ```no_run
+/// use ohkami::prelude::*;
+/// use ohkami::fang::helmet::{Helmet, CSP, sandbox::{allow_forms, allow_same_origin}};
+/// 
+/// #[tokio::main]
+/// async fn main() {
+///     Ohkami::new((
+///         Helmet::default()
+///             .ContentSecurityPolicy(CSP {
+///                 sandbox: allow_forms | allow_same_origin,
+///                 ..Default::default()
+///             }),
+///     )).howl("localhost:4040").await
+/// }
+/// ```
 #[derive(Clone, Default)]
 pub struct CSP {
-    pub default_src:               SourceList,
-    pub script_src:                SourceList,
-    pub style_src:                 SourceList,
-    pub img_src:                   SourceList,
-    pub connect_src:               SourceList,
-    pub font_src:                  SourceList,
-    pub object_src:                SourceList,
-    pub media_src:                 SourceList,
-    pub frame_src:                 SourceList,
-    pub sandbox:                   Sandbox,
+    pub default_src:               source::SourceList,
+    pub script_src:                source::SourceList,
+    pub style_src:                 source::SourceList,
+    pub img_src:                   source::SourceList,
+    pub connect_src:               source::SourceList,
+    pub font_src:                  source::SourceList,
+    pub object_src:                source::SourceList,
+    pub media_src:                 source::SourceList,
+    pub frame_src:                 source::SourceList,
+    pub sandbox:                   sandbox::Sandbox,
     pub report_uri:                &'static str,
-    pub child_src:                 SourceList,
+    pub child_src:                 source::SourceList,
     pub form_action:               &'static str,
     pub frame_ancestors:           &'static str,
     pub plugin_types:              &'static str,
     pub base_uri:                  &'static str,
     pub report_to:                 &'static str,
-    pub worker_src:                SourceList,
-    pub manifest_src:              SourceList,
-    pub prefetch_src:              SourceList,
+    pub worker_src:                source::SourceList,
+    pub manifest_src:              source::SourceList,
+    pub prefetch_src:              source::SourceList,
     pub navifate_to:               &'static str,
     pub require_trusted_types_for: &'static str,
     pub trusted_types:             &'static str,
@@ -143,40 +211,36 @@ const _: () = {
 
 /// ## Example
 /// 
-/// ```
+/// ```no_run
 /// use ohkami::prelude::*;
-/// use ohkami::fang::helmet::{Helmet, CSP, Sandbox::{allow_forms, allow_same_origin}};
+/// use ohkami::fang::helmet::{Helmet, CSP, sandbox::{allow_forms, allow_same_origin}};
 /// 
 /// #[tokio::main]
 /// async fn main() {
 ///     Ohkami::new((
-///         Helmet {
-///             ContentSecurityPolicy: Some(CSP {
+///         Helmet::default()
+///             .ContentSecurityPolicy(CSP {
 ///                 sandbox: allow_forms | allow_same_origin,
 ///                 ..Default::default()
 ///             }),
-///             ..Default::default()
-///         },
-///         "/hello".GET(|| async {"Hello, helmet!"})
-///     )).howl("localhost:3000").await
+///     )).howl("localhost:4040").await
 /// }
 /// ```
-#[derive(Clone)]
-pub struct Sandbox(u16);
-const _: () = {
-    #[allow(non_upper_case_globals)]
-    impl Sandbox {
-        pub const allow_forms:                    Self = Self(0b0000000001u16);
-        pub const allow_same_origin:              Self = Self(0b0000000010u16);
-        pub const allow_scripts:                  Self = Self(0b0000000100u16);
-        pub const allow_popups:                   Self = Self(0b0000001000u16);
-        pub const allow_modals:                   Self = Self(0b0000010000u16);
-        pub const allow_orientation_lock:         Self = Self(0b0000100000u16);
-        pub const allow_pointer_lock:             Self = Self(0b0001000000u16);
-        pub const allow_presentation:             Self = Self(0b0010000000u16);
-        pub const allow_popups_to_escape_sandbox: Self = Self(0b0100000000u16);
-        pub const allow_top_navigation:           Self = Self(0b1000000000u16);
-    }
+#[allow(non_upper_case_globals)]
+pub mod sandbox {
+    #[derive(Clone)]
+    pub struct Sandbox(u16);
+
+    pub const allow_forms:                    Sandbox = Sandbox(0b0000000001u16);
+    pub const allow_same_origin:              Sandbox = Sandbox(0b0000000010u16);
+    pub const allow_scripts:                  Sandbox = Sandbox(0b0000000100u16);
+    pub const allow_popups:                   Sandbox = Sandbox(0b0000001000u16);
+    pub const allow_modals:                   Sandbox = Sandbox(0b0000010000u16);
+    pub const allow_orientation_lock:         Sandbox = Sandbox(0b0000100000u16);
+    pub const allow_pointer_lock:             Sandbox = Sandbox(0b0001000000u16);
+    pub const allow_presentation:             Sandbox = Sandbox(0b0010000000u16);
+    pub const allow_popups_to_escape_sandbox: Sandbox = Sandbox(0b0100000000u16);
+    pub const allow_top_navigation:           Sandbox = Sandbox(0b1000000000u16);
 
     impl std::ops::BitOr for Sandbox {
         type Output = Self;
@@ -193,53 +257,53 @@ const _: () = {
     }
 
     impl Sandbox {
-        pub(self) const fn is_empty(&self) -> bool {
+        pub(super) const fn is_empty(&self) -> bool {
             self.0 == 0b0000000000u16
         }
 
-        pub(self) fn build(&self) -> String {
+        pub(super) fn build(&self) -> String {
             let mut result = String::new();
-            if self.0 & Self::allow_forms.0 != 0                    {result.push_str(" allow-forms");}
-            if self.0 & Self::allow_same_origin.0 != 0              {result.push_str(" allow-same-origin");}
-            if self.0 & Self::allow_scripts.0 != 0                  {result.push_str(" allow-scripts");}
-            if self.0 & Self::allow_popups.0 != 0                   {result.push_str(" allow-popups");}
-            if self.0 & Self::allow_modals.0 != 0                   {result.push_str(" allow-modals");}
-            if self.0 & Self::allow_orientation_lock.0 != 0         {result.push_str(" allow-orientation-lock");}
-            if self.0 & Self::allow_pointer_lock.0 != 0             {result.push_str(" allow-pointer-lock");}
-            if self.0 & Self::allow_presentation.0 != 0             {result.push_str(" allow-presentation");}
-            if self.0 & Self::allow_popups_to_escape_sandbox.0 != 0 {result.push_str(" allow-popups-to-escape-sandbox");}
-            if self.0 & Self::allow_top_navigation.0 != 0           {result.push_str(" allow-top-navigation");}
+            if self.0 & allow_forms.0 != 0                    {result.push_str(" allow-forms");}
+            if self.0 & allow_same_origin.0 != 0              {result.push_str(" allow-same-origin");}
+            if self.0 & allow_scripts.0 != 0                  {result.push_str(" allow-scripts");}
+            if self.0 & allow_popups.0 != 0                   {result.push_str(" allow-popups");}
+            if self.0 & allow_modals.0 != 0                   {result.push_str(" allow-modals");}
+            if self.0 & allow_orientation_lock.0 != 0         {result.push_str(" allow-orientation-lock");}
+            if self.0 & allow_pointer_lock.0 != 0             {result.push_str(" allow-pointer-lock");}
+            if self.0 & allow_presentation.0 != 0             {result.push_str(" allow-presentation");}
+            if self.0 & allow_popups_to_escape_sandbox.0 != 0 {result.push_str(" allow-popups-to-escape-sandbox");}
+            if self.0 & allow_top_navigation.0 != 0           {result.push_str(" allow-top-navigation");}
             result
         }
     }
-};
+}
 
 /// ## Example
 /// 
-/// ```
+/// ```no_run
 /// use ohkami::prelude::*;
-/// use ohkami::fang::helmet::{Helmet, CSP, SourceList::{self_origin, data}};
+/// use ohkami::fang::helmet::{Helmet, CSP, source::{self_origin, data}};
 /// 
 /// #[tokio::main]
 /// async fn main() {
 ///     Ohkami::new((
-///         Helmet {
-///             ContentSecurityPolicy: Some(CSP {
+///         Helmet::default()
+///             .ContentSecurityPolicy(CSP {
 ///                 script_src: self_origin | data,
 ///                 ..Default::default()
 ///             }),
-///             ..Default::default()
-///         },
 ///         "/hello".GET(|| async {"Hello, helmet!"})
 ///     )).howl("localhost:3000").await
 /// }
 /// ```
-#[derive(Clone, Default)]
-pub struct SourceList {
-    this: std::borrow::Cow<'static, str>,
-    list: Vec<std::borrow::Cow<'static, str>>,
-}
-const _: () = {
+#[allow(non_upper_case_globals)]
+pub mod source {
+    #[derive(Clone, Default)]
+    pub struct SourceList {
+        this: std::borrow::Cow<'static, str>,
+        list: Vec<std::borrow::Cow<'static, str>>,
+    }
+
     #[derive(Clone)]
     #[allow(non_camel_case_types)]
     pub enum Source {
@@ -259,7 +323,7 @@ const _: () = {
         nonce(String),
     }
     impl Source {
-        pub(self) const fn build_const(&self) -> std::borrow::Cow<'static, str> {
+        const fn build_const(&self) -> std::borrow::Cow<'static, str> {
             match self {
                 Self::any            => std::borrow::Cow::Borrowed("*"),
                 Self::data           => std::borrow::Cow::Borrowed("data:"),
@@ -277,7 +341,7 @@ const _: () = {
                 Self::nonce(_)  => unreachable!(),
             }
         }
-        pub(self) fn build_hash(&self) -> std::borrow::Cow<'static, str> {
+        fn build_hash(&self) -> std::borrow::Cow<'static, str> {
             match self {
                 Self::any            => unreachable!(),
                 Self::data           => unreachable!(),
@@ -301,23 +365,20 @@ const _: () = {
         (const $src:expr) => {SourceList { this: $src.build_const(), list: Vec::new() }};
         (hash $src:expr) => {SourceList { this: $src.build_hash(), list: Vec::new() }};
     }
-    #[allow(non_upper_case_globals)]
-    impl SourceList {
-        pub const any:            Self = this!(const Source::any);
-        pub const data:           Self = this!(const Source::data);
-        pub const https:          Self = this!(const Source::https);
-        pub const none:           Self = this!(const Source::none);
-        pub const self_origin:    Self = this!(const Source::self_origin);
-        pub const strict_dynamic: Self = this!(const Source::strict_dynamic);
-        pub const unsafe_inline:  Self = this!(const Source::unsafe_inline);
-        pub const unsafe_eval:    Self = this!(const Source::unsafe_eval);
-        pub const unsafe_hashes:  Self = this!(const Source::unsafe_hashes);
-        pub fn domain(domain: &'static str) -> Self {this!(const Source::domain(domain))}
-        pub fn sha256(sha256: String) -> Self {this!(hash Source::sha256(sha256))}
-        pub fn sha384(sha384: String) -> Self {this!(hash Source::sha384(sha384))}
-        pub fn sha512(sha512: String) -> Self {this!(hash Source::sha512(sha512))}
-        pub fn nonce (nonce:  String) -> Self {this!(hash Source::nonce(nonce))}
-    }
+    pub const any:            SourceList = this!(const Source::any);
+    pub const data:           SourceList = this!(const Source::data);
+    pub const https:          SourceList = this!(const Source::https);
+    pub const none:           SourceList = this!(const Source::none);
+    pub const self_origin:    SourceList = this!(const Source::self_origin);
+    pub const strict_dynamic: SourceList = this!(const Source::strict_dynamic);
+    pub const unsafe_inline:  SourceList = this!(const Source::unsafe_inline);
+    pub const unsafe_eval:    SourceList = this!(const Source::unsafe_eval);
+    pub const unsafe_hashes:  SourceList = this!(const Source::unsafe_hashes);
+    pub fn domain(domain: &'static str) -> SourceList {this!(const Source::domain(domain))}
+    pub fn sha256(sha256: String) -> SourceList {this!(hash Source::sha256(sha256))}
+    pub fn sha384(sha384: String) -> SourceList {this!(hash Source::sha384(sha384))}
+    pub fn sha512(sha512: String) -> SourceList {this!(hash Source::sha512(sha512))}
+    pub fn nonce(nonce:  String) -> SourceList {this!(hash Source::nonce(nonce))}
 
     impl std::ops::BitOr for SourceList {
         type Output = Self;
@@ -330,11 +391,11 @@ const _: () = {
     }
 
     impl SourceList {
-        pub(self) fn is_empty(&self) -> bool {
+        pub(super) fn is_empty(&self) -> bool {
             self.this.is_empty()
         }
 
-        pub(self) fn build(&self) -> String {
+        pub(super) fn build(&self) -> String {
             let mut result = String::from(&*self.this);
             if !self.list.is_empty() {
                 for s in &self.list {
@@ -345,7 +406,7 @@ const _: () = {
             result
         }
     }
-};
+}
 
 const _: () = {
     use crate::{Request, Response, Fang, FangProc};

--- a/ohkami/src/ohkami/mod.rs
+++ b/ohkami/src/ohkami/mod.rs
@@ -446,9 +446,7 @@ impl Ohkami {
                 let (router, _) = self.into_router().finalize();
                 #[cfg(feature="DEBUG")] ::worker::console_debug!("Done `self.router.finalize`");
                 
-                let mut res = router.handle(&mut ohkami_req).await;
-                res.complete();
-                res
+                router.handle(&mut ohkami_req).await
             }
             Err(e) => {#[cfg(feature="DEBUG")] ::worker::console_debug!("`take_over` returned an error response: {e:?}");
                 e

--- a/ohkami/src/response/_test_headers.rs
+++ b/ohkami/src/response/_test_headers.rs
@@ -3,6 +3,11 @@
 use crate::header::{append, SameSitePolicy, SetCookie};
 use super::ResponseHeaders;
 
+macro_rules! headers_dump {
+    ($dump:literal) => {
+        format!($dump, NOW = ::ohkami_lib::imf_fixdate(crate::util::unix_timestamp()))
+    }
+}
 
 #[test] fn insert_and_write() {
     let mut h = ResponseHeaders::new();
@@ -10,7 +15,12 @@ use super::ResponseHeaders;
     {
         let mut buf = Vec::new();
         h._write_to(&mut buf);
-        assert_eq!(std::str::from_utf8(&buf).unwrap(), "Server: A\r\n\r\n");
+        assert_eq!(std::str::from_utf8(&buf).unwrap(), headers_dump!("\
+            Date: {NOW}\r\n\
+            Content-Length: 0\r\n\
+            Server: A\r\n\
+            \r\n\
+        "));
     }
 
     let mut h = ResponseHeaders::new();
@@ -20,12 +30,13 @@ use super::ResponseHeaders;
     {
         let mut buf = Vec::new();
         h._write_to(&mut buf);
-        assert_eq!(std::str::from_utf8(&buf).unwrap(), "\
+        assert_eq!(std::str::from_utf8(&buf).unwrap(), headers_dump!("\
+            Date: {NOW}\r\n\
+            Content-Length: 42\r\n\
             Server: B\r\n\
             Content-Type: text/html\r\n\
-            Content-Length: 42\r\n\
             \r\n\
-        ");
+        "));
     }
 }
 
@@ -37,10 +48,12 @@ use super::ResponseHeaders;
     {
         let mut buf = Vec::new();
         h._write_to(&mut buf);
-        assert_eq!(std::str::from_utf8(&buf).unwrap(), "\
+        assert_eq!(std::str::from_utf8(&buf).unwrap(), headers_dump!("\
+            Date: {NOW}\r\n\
+            Content-Length: 0\r\n\
             Server: X\r\n\
             \r\n\
-        ");
+        "));
     }
 
     h.set().Server(append("Y"));
@@ -48,10 +61,12 @@ use super::ResponseHeaders;
     {
         let mut buf = Vec::new();
         h._write_to(&mut buf);
-        assert_eq!(std::str::from_utf8(&buf).unwrap(), "\
+        assert_eq!(std::str::from_utf8(&buf).unwrap(), headers_dump!("\
+            Date: {NOW}\r\n\
+            Content-Length: 0\r\n\
             Server: X, Y\r\n\
             \r\n\
-        ");
+        "));
     }
 }
 
@@ -63,10 +78,12 @@ use super::ResponseHeaders;
     {
         let mut buf = Vec::new();
         h._write_to(&mut buf);
-        assert_eq!(std::str::from_utf8(&buf).unwrap(), "\
+        assert_eq!(std::str::from_utf8(&buf).unwrap(), headers_dump!("\
+            Date: {NOW}\r\n\
+            Content-Length: 0\r\n\
             Custom-Header: A\r\n\
             \r\n\
-        ");
+        "));
     }
 
     h.set().x("Custom-Header", append("B"));
@@ -74,10 +91,12 @@ use super::ResponseHeaders;
     {
         let mut buf = Vec::new();
         h._write_to(&mut buf);
-        assert_eq!(std::str::from_utf8(&buf).unwrap(), "\
+        assert_eq!(std::str::from_utf8(&buf).unwrap(), headers_dump!("\
+            Date: {NOW}\r\n\
+            Content-Length: 0\r\n\
             Custom-Header: A, B\r\n\
             \r\n\
-        ");
+        "));
     }
 }
 

--- a/ohkami/src/response/_test_headers.rs
+++ b/ohkami/src/response/_test_headers.rs
@@ -1,4 +1,5 @@
 #![cfg(test)]
+#![cfg(feature="__rt_native__")]
 
 use crate::header::{append, SameSitePolicy, SetCookie};
 use super::ResponseHeaders;

--- a/ohkami/src/response/headers.rs
+++ b/ohkami/src/response/headers.rs
@@ -212,6 +212,7 @@ macro_rules! Header {
     ContentSecurityPolicy:           b"Content-Security-Policy",
     ContentSecurityPolicyReportOnly: b"Content-Security-Policy-Report-Only",
     ContentType:                     b"Content-Type",
+    CrossOriginEmbedderPolicy:       b"Cross-Origin-Embedder-Policy",
     Date:                            b"Date",
     ETag:                            b"ETag",
     Expires:                         b"Expires",

--- a/ohkami/src/response/headers.rs
+++ b/ohkami/src/response/headers.rs
@@ -188,7 +188,7 @@ macro_rules! Header {
             }
         }
     };
-} Header! {45;
+} Header! {47;
     AcceptRanges:                    b"Accept-Ranges",
     AccessControlAllowCredentials:   b"Access-Control-Allow-Credentials",
     AccessControlAllowHeaders:       b"Access-Control-Allow-Headers",

--- a/ohkami/src/response/headers.rs
+++ b/ohkami/src/response/headers.rs
@@ -213,6 +213,7 @@ macro_rules! Header {
     ContentSecurityPolicyReportOnly: b"Content-Security-Policy-Report-Only",
     ContentType:                     b"Content-Type",
     CrossOriginEmbedderPolicy:       b"Cross-Origin-Embedder-Policy",
+    CrossOriginResourcePolicy:       b"Cross-Origin-Resource-Policy",
     Date:                            b"Date",
     ETag:                            b"ETag",
     Expires:                         b"Expires",

--- a/ohkami/src/response/headers.rs
+++ b/ohkami/src/response/headers.rs
@@ -418,12 +418,18 @@ impl Headers {
 impl Headers {
     #[inline]
     pub(crate) fn new() -> Self {
-        Self {
+        let mut this = Self {
             standard:  IndexMap::new(),
             custom:    None,
             setcookie: None,
             size:      "\r\n".len(),
-        }
+        };
+
+        this.set()
+            .Date(ohkami_lib::imf_fixdate(crate::util::unix_timestamp()))
+            .ContentLength("0");
+
+        this
     }
     #[cfg(feature="DEBUG")]
     #[doc(hidden)]

--- a/ohkami/src/ws/mod.rs
+++ b/ohkami/src/ws/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(feature="ws")]
+
 #[cfg(feature="__rt_native__")]
 mod native;
 #[cfg(feature="__rt_native__")]

--- a/ohkami/src/ws/native.rs
+++ b/ohkami/src/ws/native.rs
@@ -116,11 +116,13 @@ pub struct WebSocket<C: mews::connection::UnderlyingConnection = crate::__rt__::
 }
 impl crate::IntoResponse for WebSocket {
     fn into_response(self) -> crate::Response {
-        crate::Response::SwitchingProtocols().with_headers(|h|h
+        let mut res = crate::Response::SwitchingProtocols();
+        res.content = crate::response::Content::WebSocket(self.session);
+        res.with_headers(|h|h
             .Connection("Upgrade")
             .Upgrade("websocket")
             .SecWebSocketAccept(self.sign)
-        ).with_websocket(self.session)
+        )
     }
 
     #[cfg(feature="openapi")]

--- a/ohkami/src/ws/worker.rs
+++ b/ohkami/src/ws/worker.rs
@@ -262,9 +262,12 @@ pub mod split {
 pub struct WebSocket(Session);
 impl crate::IntoResponse for WebSocket {
     fn into_response(self) -> crate::Response {
-        crate::Response::SwitchingProtocols().with_websocket(self.0)
-        // let `worker` crate and Cloudflare Workers to do around
-        // headers and something other
+        let mut res = crate::Response::SwitchingProtocols();
+        res.content = crate::response::Content::Websocket(self.0);
+        res /*        
+            let `worker` crate and Cloudflare Workers to do around
+            headers and something other
+        */
     }
 
     #[cfg(feature="openapi")]

--- a/ohkami/src/ws/worker.rs
+++ b/ohkami/src/ws/worker.rs
@@ -263,7 +263,7 @@ pub struct WebSocket(Session);
 impl crate::IntoResponse for WebSocket {
     fn into_response(self) -> crate::Response {
         let mut res = crate::Response::SwitchingProtocols();
-        res.content = crate::response::Content::Websocket(self.0);
+        res.content = crate::response::Content::WebSocket(self.0);
         res /*        
             let `worker` crate and Cloudflare Workers to do around
             headers and something other


### PR DESCRIPTION
Add `fang::enamel::{Enamel, CSP, sandbox, src}` for security headers => close #264 

with refactoring around response headers and fix flaky test ( 1 sec diff ) => related to #331 