### PR TITLE
docs(README): temporarily remove `Web Frameworks Benchmark` link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 
 - *macro-less and type-safe* APIs for intuitive and declarative code
 - *various runtimes* are supported：`tokio`, `async-std`, `smol`, `nio`, `glommio` and `worker` (Cloudflare Workers), `lambda` (AWS Lambda)
-- *extremely fast*：[Web Frameworks Benchmark](https://web-frameworks-benchmark.netlify.app/result)
-- no-network testing, well-structured middlewares, Server-Sent Events, WebSocket, highly integrated OpenAPI document generation, ...
+- extremely fast, no-network testing, well-structured middlewares, Server-Sent Events, WebSocket, highly integrated OpenAPI document generation, ...
 
 <div align="right">
     <a href="https://github.com/ohkami-rs/ohkami/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/crates/l/ohkami.svg" /></a>


### PR DESCRIPTION
waiting for https://github.com/the-benchmarker/web-frameworks's issue 8229 to be resovled