### PR TITLE
fix(builtin fangs): use `SendSyncOnNative` instead of `Send + Sync` for rt_worker

### DIFF
--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -172,14 +172,21 @@ impl<Inner: FangProc> FangProc for CORSProc<Inner> {
 
 
 #[cfg(debug_assertions)]
-#[cfg(all(feature="__rt_native__", feature="DEBUG"))]
 #[cfg(test)]
 mod test {
-    use crate::prelude::*;
-    use crate::testing::*;
-    use super::CORS;
+    #[test] fn cors_fang_bound() {
+        use crate::fang::{Fang, BoxedFPC};
+        fn assert_fang<T: Fang<BoxedFPC>>() {}
 
+        assert_fang::<super::CORS>();
+    }
+
+    #[cfg(all(feature="__rt_native__", feature="DEBUG"))]
     #[test] fn options_request() {
+        use crate::prelude::*;
+        use crate::testing::*;
+        use super::CORS;
+    
         crate::__rt__::testing::block_on(async {
             let t = Ohkami::new(
                 "/hello".POST(|| async {"Hello!"})
@@ -221,7 +228,12 @@ mod test {
         });
     }
 
+    #[cfg(all(feature="__rt_native__", feature="DEBUG"))]
     #[test] fn cors_headers() {
+        use crate::prelude::*;
+        use crate::testing::*;
+        use super::CORS;
+    
         crate::__rt__::testing::block_on(async {
             let t = Ohkami::new((CORS::new("https://example.example"),
                 "/".GET(|| async {"Hello!"})

--- a/ohkami/src/fang/builtin/enamel.rs
+++ b/ohkami/src/fang/builtin/enamel.rs
@@ -5,7 +5,7 @@
 /// 
 /// ## What it does
 /// 
-/// By default, adds to response headers :
+/// By default, sets to response headers :
 /// 
 /// - `Cross-Origin-Embedder-Policy` to `require-corp`
 /// - `Cross-Origin-Resource-Policy` to `same-origin`
@@ -487,6 +487,14 @@ pub mod src {
     }
 }
 
+#[cfg(test)]
+#[test]
+fn enamel_fang_bound() {
+    use crate::fang::{Fang, BoxedFPC};
+    fn assert_fang<T: Fang<BoxedFPC>>() {}
+
+    assert_fang::<Enamel>();
+}
 
 #[cfg(test)]
 #[cfg(feature="__rt_native__")]

--- a/ohkami/src/fang/middleware/mod.rs
+++ b/ohkami/src/fang/middleware/mod.rs
@@ -1,5 +1,4 @@
 pub mod util;
-
 use super::{Fang, BoxedFPC};
 
 

--- a/ohkami/src/fang/mod.rs
+++ b/ohkami/src/fang/mod.rs
@@ -7,7 +7,7 @@ mod builtin;
 pub use builtin::*;
 
 mod bound;
-use bound::*;
+pub(crate) use bound::*;
 
 use crate::{Request, Response};
 use std::{pin::Pin, ops::Deref, future::Future};


### PR DESCRIPTION
By mistake, on `rt_worker`, some builtin fangs like `JWT` are not fang when the type param is not `Send + Sync`, which is quite common case, before this PR!

This PR:
- fixes `Send + Sync` to `SendSyncOnNative` in all related parts
- add `*_fang_bound` tests for builtin fangs