### PR TITLE
enhance: specialize `typed::header::Cookie` with `ohkami_lib::serde_cookie` + `Deserialize`

### DIFF
--- a/ohkami/src/format/builtin.rs
+++ b/ohkami/src/format/builtin.rs
@@ -23,7 +23,7 @@ fn reject(msg: impl std::fmt::Display) -> crate::Response {
 }
 
 #[cfg(feature="openapi")]
-mod bound {
+pub mod bound {
     use crate::openapi;
     use serde::{Serialize, Deserialize};
 
@@ -37,7 +37,7 @@ mod bound {
     impl<T> Outgoing for T where T: Serialize + openapi::Schema {}
 }
 #[cfg(not(feature="openapi"))]
-mod bound {
+pub mod bound {
     use serde::{Serialize, Deserialize};
 
     pub trait Schema: {}

--- a/ohkami/src/typed/header.rs
+++ b/ohkami/src/typed/header.rs
@@ -161,7 +161,7 @@ typed_header! {
 /// #[derive(Deserialize)]
 /// struct CookieSchema<'req> {
 ///     session_id: &'req str,
-///     metadata: Optin<&'req str>,
+///     metadata: Option<&'req str>,
 /// }
 /// 
 /// /// expecting request headers contains something like:

--- a/ohkami/src/typed/header.rs
+++ b/ohkami/src/typed/header.rs
@@ -199,7 +199,7 @@ impl<'req, Fields: crate::format::bound::Incoming<'req>> FromRequest<'req> for C
     #[cfg(feature="openapi")]
     fn openapi_inbound() -> crate::openapi::Inbound {
         let Some(schema) = Fields::schema().into().into_inline() else {
-            return crateopenapi::Inbound::None
+            return crate::openapi::Inbound::None
         };
         crate::openapi::Inbound::Params(
             schema.into_properties().into_iter().map(|(name, schema, required)|

--- a/ohkami/src/typed/header.rs
+++ b/ohkami/src/typed/header.rs
@@ -37,6 +37,16 @@ const _: () = {
 
 macro_rules! typed_header {
     ($( $Name:ident : $key:literal ),* $(,)?) => {$(
+        /// Extract the request header value as an type implementing
+        /// [`FromHeader<'_>`](crate::typed::header::FromHeader) trait
+        /// ( By default, `&str` and `String` implement it ) .
+        /// 
+        /// ## Note
+        /// 
+        /// ## Example
+        /// 
+        /// here extracting `Authorization` header value as `&str`.
+        /// 
         /// ```no_run
         /// use ohkami::prelude::*;
         /// use ohkami::typed::header;
@@ -102,7 +112,7 @@ typed_header! {
     ContentLength:               "Content-Length",
     ContentLocation:             "Content-Location",
     ContentType:                 "Content-Type",
-    Cookie:                      "Cookie",
+    /* Cookie:                      "Cookie", // specialize */
     Date:                        "Date",
     Expect:                      "Expect",
     Forwarded:                   "Forwarded",
@@ -134,4 +144,71 @@ typed_header! {
     Upgrade:                     "Upgrade",
     UpgradeInsecureRequests:     "Upgrade-Insecure-Requests",
     Via:                         "Via",
+}
+
+/// Extract `Cookie` header value and parse to a type implementing `Deserialize<'_>`.
+/// 
+/// ## Note
+/// 
+/// In `openapi` feature activated, the type is also required to impl `openapi::Schema`.
+/// 
+/// ## Example
+/// 
+/// ```no_run
+/// use ohkami::prelude::*;
+/// use ohkami::typed::header;
+/// 
+/// #[derive(Deserialize)]
+/// struct CookieSchema<'req> {
+///     session_id: &'req str,
+///     metadata: Optin<&'req str>,
+/// }
+/// 
+/// /// expecting request headers contains something like:
+/// /// 
+/// /// - `Cookie: session_id=ABCDEFG`
+/// /// - `Cookie: metadata="Hello, 世界!"; session_id=XYZ123`
+/// async fn private_handler(
+///     header::Cookie(c): header::Cookie<CookieSchema<'_>>,
+/// ) {
+///     println!("session_id: `{}`", c.session_id);
+///     println!("metadata: `{:?}`", c.metadata);
+/// }
+/// 
+/// #[tokio::main]
+/// async fn main() {
+///     Ohkami::new((
+///         "/private".GET(private_handler),
+///     )).howl("localhost:5050").await
+/// }
+/// ```
+pub struct Cookie<Fields>(pub Fields);
+
+impl<'req, Fields: crate::format::bound::Incoming<'req>> FromRequest<'req> for Cookie<Fields> {
+    type Error = crate::typed::status::Unauthorized<String>;
+
+    fn from_request(req: &'req Request) -> Option<Result<Self, Self::Error>> {
+        req.headers.Cookie().map(|raw| ohkami_lib::serde_cookie::from_str::<Fields>(raw)
+            .map(Cookie)
+            .map_err(|e| crate::typed::status::Unauthorized(format!(
+                "missing or invalid Cookie: {e}"
+            )))
+        )
+    }
+
+    #[cfg(feature="openapi")]
+    fn openapi_inbound() -> crate::openapi::Inbound {
+        let Some(schema) = Fields::schema().into().into_inline() else {
+            return crateopenapi::Inbound::None
+        };
+        crate::openapi::Inbound::Params(
+            schema.into_properties().into_iter().map(|(name, schema, required)|
+                if required {
+                    crate::openapi::Parameter::in_query(name, schema)
+                } else {
+                    crate::openapi::Parameter::maybe_in_query(name, schema)
+                }
+            ).collect()
+        )
+    }
 }

--- a/ohkami_lib/src/lib.rs
+++ b/ohkami_lib/src/lib.rs
@@ -15,6 +15,7 @@ mod percent_encoding;
 pub use percent_encoding::{percent_encode, percent_decode, percent_decode_utf8};
 
 pub mod serde_utf8;
+pub mod serde_cookie;
 pub mod serde_multipart;
 pub mod serde_urlencoded;
 
@@ -22,4 +23,3 @@ pub mod serde_urlencoded;
 pub mod stream;
 #[cfg(feature="stream")]
 pub use stream::{Stream, StreamExt};
-

--- a/ohkami_lib/src/serde_cookie.rs
+++ b/ohkami_lib/src/serde_cookie.rs
@@ -1,0 +1,37 @@
+mod de;
+
+#[cfg(test)]
+mod _test;
+
+#[inline(always)]
+pub fn from_str<'de, D: serde::Deserialize<'de>>(input: &'de str) -> Result<D, Error> {
+    let mut d = de::CookieDeserializer::new(input);
+    let t = D::deserialize(&mut d)?;
+    if d.remaining().is_empty() {
+        Ok(t)
+    } else {
+        Err((||serde::de::Error::custom(format!("Unexpected trailing charactors: {}", d.remaining().escape_ascii())))())
+    }
+}
+
+#[derive(Debug)]
+pub struct Error(String);
+const _: () = {
+    impl std::fmt::Display for Error {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str(&self.0)
+        }
+    }
+    impl std::error::Error for Error {}
+
+    impl serde::ser::Error for Error {
+        fn custom<T>(msg:T) -> Self where T:std::fmt::Display {
+            Self(msg.to_string())
+        }
+    }
+    impl serde::de::Error for Error {
+        fn custom<T>(msg:T) -> Self where T:std::fmt::Display {
+            Self(msg.to_string())
+        }
+    }
+};

--- a/ohkami_lib/src/serde_cookie/_test.rs
+++ b/ohkami_lib/src/serde_cookie/_test.rs
@@ -1,0 +1,100 @@
+#![cfg(test)]
+
+use crate::serde_cookie;
+use std::borrow::Cow;
+use ::serde::{Serialize, Deserialize};
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+struct Age(u8);
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+enum Gender {
+    #[serde(rename = "male")]
+    Male,
+    #[serde(rename = "female")]
+    Felmale,
+    #[serde(rename = "other")]
+    Other,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+struct UserInfo<'s> {
+    name:   Cow<'s, str>,
+    age:    Option<Age>,
+    gender: Option<Gender>,
+}
+
+#[test]
+fn simple_ascii_cookies() {
+    assert_eq!(
+        serde_cookie::from_str::<UserInfo>(
+            "name=ohkami; age=4"
+        ).unwrap(),
+        UserInfo {
+            name: Cow::Borrowed("ohkami"),
+            age: Some(Age(4)),
+            gender: None,
+        }
+    );
+
+    assert_eq!(
+        serde_cookie::from_str::<UserInfo>(
+            "age=4; name=ohkami; gender=other"
+        ).unwrap(),
+        UserInfo {
+            name: Cow::Borrowed("ohkami"),
+            age: Some(Age(4)),
+            gender: Some(Gender::Other),
+        }
+    );
+}
+
+#[test]
+fn simple_ascii_cookies_with_double_quoted_values() {
+    assert_eq!(
+        serde_cookie::from_str::<UserInfo>(
+            r#"name="ohkami"; age=4"#
+        ).unwrap(),
+        UserInfo {
+            name: Cow::Borrowed("ohkami"),
+            age: Some(Age(4)),
+            gender: None,
+        }
+    );
+
+    assert_eq!(
+        serde_cookie::from_str::<UserInfo>(
+            r#"age=4; name="ohkami"; gender="other""#
+        ).unwrap(),
+        UserInfo {
+            name: Cow::Borrowed("ohkami"),
+            age: Some(Age(4)),
+            gender: Some(Gender::Other),
+        }
+    );
+}
+
+#[test]
+fn nonascii_encoded_cookies() {
+    assert_eq!(
+        serde_cookie::from_str::<UserInfo>(
+            "name=%E7%8B%BC; age=4"
+        ).unwrap(),
+        UserInfo {
+            name: Cow::Borrowed("狼"),
+            age: Some(Age(4)),
+            gender: None,
+        }
+    );
+
+    assert_eq!(
+        serde_cookie::from_str::<UserInfo>(
+            "age=4; name=\"%E7%8B%BC\"; gender=other"
+        ).unwrap(),
+        UserInfo {
+            name: Cow::Borrowed("狼"),
+            age: Some(Age(4)),
+            gender: Some(Gender::Other),
+        }
+    );
+}

--- a/ohkami_lib/src/serde_cookie/de.rs
+++ b/ohkami_lib/src/serde_cookie/de.rs
@@ -1,0 +1,535 @@
+use serde::de::IntoDeserializer as _;
+use std::borrow::Cow;
+
+pub(crate) struct CookieDeserializer<'de> {
+    input: &'de [u8],
+    side:  ParsingSide,
+}
+#[derive(Debug, PartialEq, Clone, Copy)]
+enum ParsingSide {
+    Name,
+    Value,
+}
+
+impl<'de> CookieDeserializer<'de> {
+    pub(crate) const fn new(input: &'de str) -> Self {
+        Self { input: input.as_bytes(), side: ParsingSide::Name }
+    }
+    pub(crate) const fn remaining(&self) -> &'de [u8] {
+        &self.input
+    }
+}
+
+pub mod valid {
+    #[inline]
+    pub fn name(bytes: &[u8]) -> Result<&str, super::super::Error> {
+        for b in bytes {
+            match b {
+                | (128..) /* not ascii */
+                | 0..=31 | 127 /* ascii control */
+                | b' ' | b'(' | b')' | b'<' | b'>' | b'@' | b',' | b';' | b':' | b'\\' | b'"' | b'/' | b'[' | b']' | b'?' | b'=' | b'{' | b'}'
+                => return Err(serde::de::Error::custom("invalid Cookie name")),
+                _ => ()
+            }
+        }
+        // SAFETY: `bytes` here is obviously ASCII
+        Ok(unsafe {std::str::from_utf8_unchecked(bytes)})
+    }
+
+    #[inline]
+    pub fn value(mut bytes: &[u8]) -> Result<std::borrow::Cow<str>, super::super::Error> {
+        use std::borrow::Cow;
+
+        if bytes.len() >= 2 && bytes[0] == b'"' && bytes[bytes.len() - 1] == b'"' {
+            bytes = &bytes[1..(bytes.len() - 1)]
+        }
+        for b in bytes {
+            match b {
+                | (128..) /* not ascii */
+                | 0..=31 | 127 /* ascii control */
+                | b' ' | b',' | b';' | b'\\' | b'"'
+                => return Err(serde::de::Error::custom("invalid Cookie value")),
+                _ => ()
+            }
+        }
+        // SAFETY: `bytes` here os obviously ASCII
+        Ok(match crate::percent_decode(bytes) {
+            Cow::Borrowed(b) => Cow::Borrowed(unsafe {std::str::from_utf8_unchecked(b)}),
+            Cow::Owned(b) => Cow::Owned(unsafe {String::from_utf8_unchecked(b)})
+        })
+    }
+}
+
+impl<'de> CookieDeserializer<'de> {
+    #[inline(always)]
+    fn peek(&self) -> Result<&u8, super::Error> {
+        self.input.first().ok_or_else(|| serde::de::Error::custom("can't peek: unexpected end of input"))
+    }
+    #[inline(always)]
+    fn next(&mut self) -> Result<u8, super::Error> {
+        let next = self.peek()?.clone();
+        self.input = &self.input[1..];
+        Ok(next)
+    }
+    #[inline(always)]
+    unsafe fn take_n_unchecked(&mut self, n: usize) -> &'de [u8] {
+        use std::slice::from_raw_parts;
+
+        let len = self.input.len();
+        let ptr = self.input.as_ptr();
+
+        // SAFETY: Caller has to check that `0 <= mid <= self.len()`
+        let (take, remaining) = (from_raw_parts(ptr, n), from_raw_parts(ptr.add(n), len - n));
+        self.input = remaining;
+
+        take
+    }
+    #[inline(always)]
+    fn next_section(&mut self) -> Result<Cow<'de, str>, super::Error> {
+        let next_punc = self.input.iter().position(|b| matches!(b, b'=' | b';'));
+
+        match &self.side {
+            ParsingSide::Name => match next_punc {
+                /* e.g. `name` */
+                None => Err(serde::de::Error::custom("invalid name-value: unexpected end of input")),
+
+                /* e.g. `=ohkami` */
+                Some(0) => Err(serde::de::Error::custom("invalid name-value: empty name")),
+
+                /* e.g. `name=ohkami` is ok, `name; ohkami` is err */
+                Some(n) => (self.input[n] == b'=')
+                    .then_some(Cow::Borrowed(valid::name(unsafe {self.take_n_unchecked(n)})?))
+                    .ok_or_else(|| serde::de::Error::custom("invalid name-value: missing `=`"))
+            },
+
+            ParsingSide::Value => match next_punc {
+                /* final value; end of whole the parsing */
+                None => Ok(valid::value(unsafe {self.take_n_unchecked(self.input.len())})?),
+
+                /* n = 0 is ok (e.g. `name=; age=18` is valid; empty string) */
+                /* e.g. `name=ohkami&age=4` is ok, `name=ohkami=age=4` is err */
+                Some(n) => (self.input[n] == b';')
+                    .then_some(valid::value(unsafe {self.take_n_unchecked(n)})?)
+                    .ok_or_else(|| serde::de::Error::custom("invalid name-value: missing `; `"))
+            }
+        }
+    }
+}
+
+impl<'u, 'de> serde::Deserializer<'de> for &'u mut CookieDeserializer<'de> {
+    type Error = super::Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where V: serde::de::Visitor<'de> {
+        self.deserialize_map(visitor)
+    }
+
+    /// when the visitor visits value of unkown key
+    fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where V: serde::de::Visitor<'de> {
+        #[cfg(debug_assertions)] {
+            assert!(matches!(self.side, ParsingSide::Value));
+        }
+        let _ = self.next_section();
+
+        self.side = ParsingSide::Name;
+
+        visitor.visit_unit()
+    }
+
+    #[inline(always)]
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where V: serde::de::Visitor<'de> {
+        #[cfg(debug_assertions)] {
+            assert!(self.side == ParsingSide::Name);
+        }
+
+        visitor.visit_map(AmpersandSeparated::new(self))
+    }
+    #[inline(always)]
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where V: serde::de::Visitor<'de> {
+        self.deserialize_map(visitor)
+    }
+
+    #[inline]
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where V: serde::de::Visitor<'de> {
+        visitor.visit_enum(Enum::new(self))
+    }
+
+    #[inline(always)]
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where V: serde::de::Visitor<'de> {
+        /*
+            Here we don't put
+
+            ```
+            #[cfg(debug_assertions)] {
+                assert!(self.side == ParsingSide::Name);
+            }
+            ```
+            because `deserialize_identifier` can be called by value-place enums
+            like `enum Gender { Male, Female, Other }`.
+        */
+
+        self.deserialize_str(visitor)
+    }
+    #[inline(always)]
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where V: serde::de::Visitor<'de> {
+        match self.next_section()? {
+            Cow::Borrowed(str) => visitor.visit_borrowed_str(str),
+            Cow::Owned(string) => visitor.visit_string(string)
+                .map_err(|e: Self::Error| {
+                    #[cfg(debug_assertions)] {
+                        serde::de::Error::custom(format!(
+                            "{e}. [DEBUG] maybe you need to use `String` or `Cow<str>` \
+                            instead of `&str` to accept percent-decoded value"
+                        ))
+                    }
+                    #[cfg(not(debug_assertions))] {
+                        e
+                    }
+                })
+        }
+    }
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where V: serde::de::Visitor<'de> {
+        self.deserialize_str(visitor)
+    }
+    fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where V: serde::de::Visitor<'de> {
+        let section = self.next_section()?;
+        let mut chars = section.chars();
+        let (Some(ch), None) = (chars.next(), chars.next()) else {
+            return Err((|| serde::de::Error::custom(
+                format!("Expected a single charactor, but got `{section}`")
+            ))())
+        };
+        visitor.visit_char(ch)
+    }
+
+    #[inline]
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where V: serde::de::Visitor<'de> {
+        visitor.visit_newtype_struct(self)
+    }
+
+    #[inline]
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where V: serde::de::Visitor<'de> {
+        if self.input.iter().position(|b| b==&b'&').unwrap_or(self.input.len()) == 0 {
+            visitor.visit_none()
+        } else {
+            visitor.visit_some(self)
+        }
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where V: serde::de::Visitor<'de> {
+        if self.input.iter().position(|b| b==&b'&').unwrap_or(self.input.len()) == 0 {
+            visitor.visit_unit()
+        } else {
+            Err((|| serde::de::Error::custom(format!(
+                "Expected an empty value for an unit, but got `{}`",
+                match self.next_section() {
+                    Ok(section) => section.to_string(),
+                    Err(e) => e.to_string()
+                }
+            )))())
+        }
+    }
+    fn deserialize_unit_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where V: serde::de::Visitor<'de> {
+        self.deserialize_unit(visitor)
+    }
+
+    fn deserialize_seq<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where V: serde::de::Visitor<'de> {
+        Err(serde::de::Error::custom("Deserializing to sequence-like type is not supported"))
+    }
+    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where V: serde::de::Visitor<'de> {
+        self.deserialize_seq(visitor)
+    }
+    fn deserialize_tuple_struct<V>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where V: serde::de::Visitor<'de> {
+        self.deserialize_seq(visitor)
+    }
+
+    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where V: serde::de::Visitor<'de> {
+        #[cfg(debug_assertions)] {
+            assert!(self.side == ParsingSide::Value);
+        }
+
+        match self.next_section()? {
+            Cow::Borrowed(s) => visitor.visit_bytes(s.as_bytes()),
+            Cow::Owned(s) => visitor.visit_byte_buf(s.into_bytes()),
+        }
+    }
+    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where V: serde::de::Visitor<'de> {
+        #[cfg(debug_assertions)] {
+            assert!(self.side == ParsingSide::Value);
+        }
+
+        self.deserialize_bytes(visitor)
+    }
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where V: serde::de::Visitor<'de> {
+        #[cfg(debug_assertions)] {
+            assert!(self.side == ParsingSide::Value);
+        }
+
+        match &*self.next_section()? {
+            "true"  => visitor.visit_bool(true),
+            "false" => visitor.visit_bool(false),
+            other => Err(serde::de::Error::custom(format!(
+                "Expected `true` or `false`, but got `{other}`"
+            )))
+        }
+    }
+
+    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where V: serde::de::Visitor<'de> {
+        #[cfg(debug_assertions)] {
+            assert!(self.side == ParsingSide::Value);
+        }
+        let section = self.next_section()?;
+        visitor.visit_f32(
+            section.parse().map_err(|_| serde::de::Error::custom(
+                format!("Expected a number, but got `{section}`")
+            ))?
+        )
+    }
+    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where V: serde::de::Visitor<'de> {
+        #[cfg(debug_assertions)] {
+            assert!(self.side == ParsingSide::Value);
+        }
+        let section = self.next_section()?;
+        visitor.visit_f64(
+            section.parse().map_err(|_| serde::de::Error::custom(
+                format!("Expected a number, but got `{section}`")
+            ))?
+        )
+    }
+
+    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where V: serde::de::Visitor<'de> {
+        #[cfg(debug_assertions)] {
+            assert!(self.side == ParsingSide::Value);
+        }
+        let section = self.next_section()?;
+        visitor.visit_i8(
+            section.parse().map_err(|_| serde::de::Error::custom(
+                format!("Expected an integer, but got `{section}`")
+            ))?
+        )
+    }
+    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where V: serde::de::Visitor<'de> {
+        #[cfg(debug_assertions)] {
+            assert!(self.side == ParsingSide::Value);
+        }
+        let section = self.next_section()?;
+        visitor.visit_i16(
+            section.parse().map_err(|_| serde::de::Error::custom(
+                format!("Expected an integer, but got `{section}`")
+            ))?
+        )
+    }
+    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where V: serde::de::Visitor<'de> {
+        #[cfg(debug_assertions)] {
+            assert!(self.side == ParsingSide::Value);
+        }
+        let section = self.next_section()?;
+        visitor.visit_i32(
+            section.parse().map_err(|_| serde::de::Error::custom(
+                format!("Expected an integer, but got `{section}`")
+            ))?
+        )
+    }
+    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where V: serde::de::Visitor<'de> {
+        #[cfg(debug_assertions)] {
+            assert!(self.side == ParsingSide::Value);
+        }
+        let section = self.next_section()?;
+        visitor.visit_i64(
+            section.parse().map_err(|_| serde::de::Error::custom(
+                format!("Expected an integer, but got `{section}`")
+            ))?
+        )
+    }
+
+    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where V: serde::de::Visitor<'de> {
+        #[cfg(debug_assertions)] {
+            assert!(self.side == ParsingSide::Value);
+        }
+        let section = self.next_section()?;
+        visitor.visit_u8(
+            section.parse().map_err(|_| serde::de::Error::custom(
+                format!("Expected an integer, but got `{section}`")
+            ))?
+        )
+    }
+    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where V: serde::de::Visitor<'de> {
+        #[cfg(debug_assertions)] {
+            assert!(self.side == ParsingSide::Value);
+        }
+        let section = self.next_section()?;
+        visitor.visit_u16(
+            section.parse().map_err(|_| serde::de::Error::custom(
+                format!("Expected an integer, but got `{section}`")
+            ))?
+        )
+    }
+    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where V: serde::de::Visitor<'de> {
+        #[cfg(debug_assertions)] {
+            assert!(self.side == ParsingSide::Value);
+        }
+        let section = self.next_section()?;
+        visitor.visit_u32(
+            section.parse().map_err(|_| serde::de::Error::custom(
+                format!("Expected an integer, but got `{section}`")
+            ))?
+        )
+    }
+    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where V: serde::de::Visitor<'de> {
+        #[cfg(debug_assertions)] {
+            assert!(self.side == ParsingSide::Value);
+        }
+        let section = self.next_section()?;
+        visitor.visit_u64(
+            section.parse().map_err(|_| serde::de::Error::custom(
+                format!("Expected an integer, but got `{section}`")
+            ))?
+        )
+    }
+}
+
+
+struct AmpersandSeparated<'amp, 'de:'amp> {
+    de:    &'amp mut CookieDeserializer<'de>,
+    first: bool,
+}
+impl<'amp, 'de> AmpersandSeparated<'amp, 'de> {
+    fn new(de: &'amp mut CookieDeserializer<'de>) -> Self {
+        Self { de, first: true }
+    }
+}
+const _: () = {
+    impl<'amp, 'de> serde::de::MapAccess<'de> for AmpersandSeparated<'amp, 'de> {
+        type Error = super::Error;
+
+        #[inline]
+        fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+        where K: serde::de::DeserializeSeed<'de> {
+            if self.de.input.is_empty() {
+                return Ok(None)
+            }
+            if !self.first {
+                if self.de.next()? != b';' {
+                    return Err((|| serde::de::Error::custom("missing `;`"))())
+                }
+                if self.de.next()? != b' ' {
+                    return Err((|| serde::de::Error::custom("missing ` ` after `;`"))())
+                }
+            }
+            self.first = false;
+            self.de.side = ParsingSide::Name;
+            seed.deserialize(&mut *self.de).map(Some)
+        }
+        #[inline]
+        fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+        where V: serde::de::DeserializeSeed<'de> {
+            if self.de.next()? != b'=' {
+                return Err((|| serde::de::Error::custom("missing `=`"))())
+            }
+            self.de.side = ParsingSide::Value;
+            seed.deserialize(&mut *self.de)
+        }
+    }
+};
+
+struct Enum<'e, 'de:'e> {
+    de: &'e mut CookieDeserializer<'de>
+}
+impl<'e, 'de> Enum<'e, 'de> {
+    fn new(de: &'e mut CookieDeserializer<'de>) -> Self {
+        Self { de }
+    }
+}
+const _: () = {
+    impl<'e, 'de> serde::de::EnumAccess<'de> for Enum<'e, 'de> {
+        type Variant = Self;
+        type Error   = super::Error;
+
+        fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
+        where V: serde::de::DeserializeSeed<'de> {
+            Ok((
+                seed.deserialize(self.de.next_section().unwrap().into_deserializer())?,
+                self,
+            ))
+        }
+    }
+
+    impl<'e, 'de> serde::de::VariantAccess<'de> for Enum<'e, 'de> {
+        type Error = super::Error;
+
+        fn unit_variant(self) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        fn newtype_variant_seed<T>(self, _seed: T) -> Result<T::Value, Self::Error>
+        where T: serde::de::DeserializeSeed<'de> {
+            Err(serde::de::Error::custom("ohkami's builtin Cookie deserializer doesn't support enum with newtype variants !"))
+        }
+
+        fn struct_variant<V>(
+            self,
+            _fields: &'static [&'static str],
+            _visitor: V,
+        ) -> Result<V::Value, Self::Error>
+        where V: serde::de::Visitor<'de> {
+            Err(serde::de::Error::custom("ohkami's builtin Cookie deserializer doesn't support enum with struct variants !"))
+        }
+
+        fn tuple_variant<V>(self, _len: usize, _visitor: V) -> Result<V::Value, Self::Error>
+        where V: serde::de::Visitor<'de> {
+            Err(serde::de::Error::custom("ohkami's builtin Cookie deserializer doesn't support enum with tuple variants !"))
+        }
+    }
+};


### PR DESCRIPTION
Before it take just `T: FromHeader<'_>` value, requiring user to implement parsing flow from a raw `&str`, as other typed headers. But `Cookie` header value is composed by key-values in format like `name1=value1; name2=value2` and developer's interest is not in this entire string itself. This forced Ohkami users to write similar parsing process by their hands for evenry use of `typed::header::Cookie`s.

So this PR introduces `ohkami_lib::serde_cookie` and enhance `ohkami::typed::header::Cookie` to take `T: Deserialize<'_>`, allowing users to focus on the parsed struct, not on parsing flow.