### PR TITLE
fix(openapi): fix `typed::header::Cookie`'s `openapi_inbound`

### DIFF
--- a/ohkami/src/typed/header.rs
+++ b/ohkami/src/typed/header.rs
@@ -204,9 +204,9 @@ impl<'req, Fields: crate::format::bound::Incoming<'req>> FromRequest<'req> for C
         crate::openapi::Inbound::Params(
             schema.into_properties().into_iter().map(|(name, schema, required)|
                 if required {
-                    crate::openapi::Parameter::in_query(name, schema)
+                    crate::openapi::Parameter::in_cookie(name, schema)
                 } else {
-                    crate::openapi::Parameter::maybe_in_query(name, schema)
+                    crate::openapi::Parameter::maybe_in_cookie(name, schema)
                 }
             ).collect()
         )


### PR DESCRIPTION
Before `Parameter::{in_query, maybe_in_query}` was used by mistake! This PR fixes to `in_cookie`