### PR TITLE
Dx(worker): copy var binding doc comments to associated consts

### DIFF
--- a/ohkami/src/x_worker.rs
+++ b/ohkami/src/x_worker.rs
@@ -3,6 +3,8 @@
 pub use ::ohkami_macros::{worker, bindings, DurableObject};
 
 pub mod bindings {
+    /// `Var` binding can also be accessed via associated const
+    /// of the same name.
     pub type Var           = &'static str;
     pub type AI            = ::worker::Ai;
     pub type KV            = ::worker::kv::KvStore;

--- a/ohkami/src/x_worker.rs
+++ b/ohkami/src/x_worker.rs
@@ -10,6 +10,8 @@ pub mod bindings {
     pub type Service       = ::worker::Fetcher;
     pub type DurableObject = ::worker::ObjectNamespace;
     pub type D1            = ::worker::d1::D1Database;
+    /// `Queue` may cause a lot of *WARNING*s on `npm run dev`, but
+    /// it's not an actual problem and `Queue` binding does work.
     pub type Queue         = ::worker::Queue;
 }
 

--- a/ohkami_macros/src/lib.rs
+++ b/ohkami_macros/src/lib.rs
@@ -305,7 +305,7 @@ pub fn DurableObject(args: proc_macro::TokenStream, input: proc_macro::TokenStre
 ///   - Service
 ///   - Variables
 ///   - Durable Objects
-/// - `Queue` may cause a lot of *WARNING*s in `npm run dev`, but
+/// - `Queue` may cause a lot of *WARNING*s on `npm run dev`, but
 ///   it's not an actual problem and `Queue` binding does work.
 /// 
 /// <br>

--- a/ohkami_macros/src/lib.rs
+++ b/ohkami_macros/src/lib.rs
@@ -314,7 +314,7 @@ pub fn DurableObject(args: proc_macro::TokenStream, input: proc_macro::TokenStre
 /// 
 /// - You can switch between multiple `env`s by feature flags
 ///   like `#[cfg_attr(feature = "...", bindings(env_name))]`.
-/// - For `rust-analyzer` user : When you edit wrangler.toml around bindings,
+/// - For `rust-analyzer` user : When you edit wrangler.toml around bindings in **auto binding mode**,
 ///   you'll need to notify the change of `#[bindings]` if you're using auto binding mode.
 ///   For that, all you have to do is just **deleting `;` and immediate restoring it**.
 #[proc_macro_attribute]

--- a/ohkami_macros/src/worker.rs
+++ b/ohkami_macros/src/worker.rs
@@ -135,11 +135,14 @@ pub fn bindings(env_name: TokenStream, bindings_struct: TokenStream) -> Result<T
     let vis  = &bindings_struct.vis;
     let name = &bindings_struct.ident;
 
-    let field_names = match &bindings_struct.fields {
+    let named_fields = match &bindings_struct.fields {
         Fields::Unit => None,
         Fields::Named(n) => Some(n.named
             .iter()
-            .map(|field| field.ident.as_ref().unwrap())
+            .map(|field| (
+                field.ident.as_ref().unwrap(),
+                util::extract_doc_comment(&field.attrs)
+            ))
             .collect::<Vec<_>>()
         ),
         Fields::Unnamed(u) => return Err(Error::new(
@@ -148,10 +151,10 @@ pub fn bindings(env_name: TokenStream, bindings_struct: TokenStream) -> Result<T
         )),
     };
 
-    let declare_struct = match &field_names {
+    let declare_struct = match &named_fields {
         Some(n) => {
             let mut var_field_indexes = Vec::with_capacity(n.len());
-            for (i, field_name) in n.iter().enumerate() {
+            for (i, (field_name, _)) in n.iter().enumerate() {
                 let binding_type = bindings.iter()
                     .find_map(|(name, b)| (name == *field_name).then_some(b))
                     .ok_or_else(|| syn::Error::new(
@@ -203,13 +206,21 @@ pub fn bindings(env_name: TokenStream, bindings_struct: TokenStream) -> Result<T
                     _ => None
                 }
             )
-            .filter(|(name, _)| match &field_names {
-                None => true,
-                Some(n) => n.iter().any(|field_name| name == field_name)
+            .filter_map(|(name, value)| match &named_fields {
+                None => Some((name, value, None)),
+                Some(n) => n.iter().find_map(|(field_name, doc)|
+                    (name == *field_name).then_some((name, value, doc.as_ref()))
+                )
             })
-            .map(|(name, value)| {
+            .map(|(name, value, doc)| {
                 let value = LitStr::new(&value, Span::call_site());
+                let doc = doc.as_ref()
+                    .map(|d| {
+                        let d = LitStr::new(d, Span::call_site());
+                        quote! { #[doc = #d] }
+                    });
                 quote! {
+                    #doc
                     #vis const #name: &'static str = #value;
                 }
             });
@@ -224,9 +235,9 @@ pub fn bindings(env_name: TokenStream, bindings_struct: TokenStream) -> Result<T
 
     let impl_new = {
         let extract = bindings.iter()
-            .filter(|(name, _)| match &field_names {
+            .filter(|(name, _)| match &named_fields {
                 None => true,
-                Some(n) => n.iter().any(|field_name| name == *field_name)
+                Some(n) => n.iter().any(|(field_name, _)| name == *field_name)
             })
             .map(|(name, binding)| {
                 binding.tokens_extract_from_env(name)
@@ -262,7 +273,7 @@ pub fn bindings(env_name: TokenStream, bindings_struct: TokenStream) -> Result<T
     };
 
     let impl_send_sync = if
-        bindings.is_empty() || field_names.is_some_and(|n| n.is_empty())
+        bindings.is_empty() || named_fields.is_some_and(|n| n.is_empty())
     {
         None
     } else {

--- a/ohkami_macros/src/worker/binding.rs
+++ b/ohkami_macros/src/worker/binding.rs
@@ -32,10 +32,6 @@ impl Binding {
 
         let from_env = |getter: TokenStream| quote! {
             #name: env.#getter?
-                // {
-                //     ::worker::console_error!("{e}");
-                //     return ::std::option::Option::Some(::std::result::Result::Err(::ohkami::Response::InternalServerError()));
-                // }
         };
 
         match self {


### PR DESCRIPTION
Before, in manual binding mode of `#[bindings]`, doc comments for variable bindings like

```rust
#[bindings]
struct Bindings {
    /// this is a sample variable binding
    MY_VARIABLE: bindings::Var,
}
```

are not shown only for the fields, not in associated consts corresponded to them. This PR improves this DX by copying the doc comments if any to each associated consts.