### PR TITLE
fix(openapi): wrong operation generation

### DIFF
--- a/ohkami/src/ohkami/mod.rs
+++ b/ohkami/src/ohkami/mod.rs
@@ -529,7 +529,10 @@ impl Ohkami {
 
         crate::DEBUG!("[openapi_document_bytes] routes = {routes:#?}, router = {router:#?}");
 
-        let doc = router.gen_openapi_doc(routes.keys().map(|r| &**r), openapi);
+        let doc = router.gen_openapi_doc(
+            routes.iter().map(|(r, map)| (&**r, map.keys().copied())),
+            openapi
+        );
 
         let mut bytes = ::serde_json::to_vec_pretty(&doc).expect("failed to serialize OpenAPI document");
         bytes.push(b'\n');

--- a/ohkami_lib/src/map.rs
+++ b/ohkami_lib/src/map.rs
@@ -60,6 +60,9 @@ impl<K: PartialEq, V> TupleMap<K, V> {
     pub fn into_iter(self) -> impl Iterator<Item = (K, V)> {
         self.0.into_iter()
     }
+    pub fn keys(&self) -> impl Iterator<Item = &K> {
+        self.iter().map(|(k, _)| k)
+    }
 }
 
 impl<K: PartialEq, V: PartialEq> PartialEq for TupleMap<K, V> {

--- a/samples/petstore/openapi.json.sample
+++ b/samples/petstore/openapi.json.sample
@@ -86,6 +86,16 @@
         }
       }
     },
+    "/pets/admin": {
+      "get": {
+        "operationId": "show_pets_detail",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/pets/{petId}": {
       "get": {
         "operationId": "showPetById",
@@ -121,6 +131,14 @@
                 }
               }
             }
+          }
+        }
+      },
+      "put": {
+        "operationId": "edit_pet_profile",
+        "responses": {
+          "200": {
+            "description": "OK"
           }
         }
       }

--- a/samples/petstore/openapi.json.sample
+++ b/samples/petstore/openapi.json.sample
@@ -136,6 +136,16 @@
       },
       "put": {
         "operationId": "edit_pet_profile",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "petId",
+            "schema": {
+              "type": "integer"
+            },
+            "required": true
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK"

--- a/samples/petstore/src/main.rs
+++ b/samples/petstore/src/main.rs
@@ -51,7 +51,10 @@ async fn main() {
             .GET(list_pets)
             .POST(create_pet),
         "/pets/:petId"
-            .GET(show_pet_by_id),
+            .GET(show_pet_by_id)
+            .PUT(edit_pet_profile),
+        "/pets/admin"
+            .GET(show_pets_detail),
     ));
 
     o.generate(openapi::OpenAPI {
@@ -62,7 +65,7 @@ async fn main() {
         ]
     });
 
-    o.howl("localhost:5050").await
+    //o.howl("localhost:5050").await
 }
 
 #[openapi::operation({200: "All pets stored in this pet store"})]
@@ -137,6 +140,10 @@ async fn show_pet_by_id(
         })?;
     Ok(JSON(pet))
 }
+
+async fn edit_pet_profile() {}
+
+async fn show_pets_detail() {}
 
 
 #[derive(Serialize, Clone, openapi::Schema)]

--- a/samples/petstore/src/main.rs
+++ b/samples/petstore/src/main.rs
@@ -65,7 +65,7 @@ async fn main() {
         ]
     });
 
-    //o.howl("localhost:5050").await
+    o.howl("localhost:5050").await
 }
 
 #[openapi::operation({200: "All pets stored in this pet store"})]

--- a/samples/petstore/src/main.rs
+++ b/samples/petstore/src/main.rs
@@ -141,7 +141,7 @@ async fn show_pet_by_id(
     Ok(JSON(pet))
 }
 
-async fn edit_pet_profile() {}
+async fn edit_pet_profile(_id: u64) {}
 
 async fn show_pets_detail() {}
 

--- a/samples/realworld/Cargo.toml
+++ b/samples/realworld/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-ohkami             = { path = "../../ohkami", features = ["rt_tokio"] }
+ohkami             = { path = "../../ohkami", default-features = false, features = ["rt_tokio"] }
 tokio              = { version = "1", features = ["full"] }
 tracing            = "0.1"
 tracing-subscriber = "0.3"

--- a/samples/test.sh
+++ b/samples/test.sh
@@ -21,12 +21,12 @@ test $? -ne 0 && exit 152 || :
 
 cd $SAMPLES/petstore && \
     cargo build && \
-    diff openapi.json openapi.json.sample && \
     cd client && \
         npm install && \
         cd .. && \
     (timeout -sKILL 5 cargo run &) && \
     sleep 1 && \
+    diff openapi.json openapi.json.sample && \
     cd client && \
         npm run gen && \
         npm run main

--- a/samples/test.sh
+++ b/samples/test.sh
@@ -4,56 +4,57 @@ set -Ceu
 
 SAMPLES=$(pwd)
 
-#cd $SAMPLES/openapi-schema-enums && \
-#    cargo run && \
-#    diff openapi.json openapi.json.sample
-#test $? -ne 0 && exit 150 || :
-#
-#cd $SAMPLES/openapi-schema-from-into && \
-#    cargo run && \
-#    diff openapi.json openapi.json.sample
-#test $? -ne 0 && exit 151 || :
-#
-#cd $SAMPLES/openapi-tags && \
-#    cargo run && \
-#    diff openapi.json openapi.json.sample
-#test $? -ne 0 && exit 152 || :
-#
-#cd $SAMPLES/petstore && \
-#    cargo build && \
-#    cd client && \
-#        npm install && \
-#        cd .. && \
-#    (timeout -sKILL 5 cargo run &) && \
-#    sleep 1 && \
-#    cd client && \
-#        npm run gen && \
-#        npm run main
-## FIXME
-## this is a little flaky; sometimes cause connection refused
-#test $? -ne 0 && exit 153 || :
-#
-#cd $SAMPLES/readme-openapi && \
-#    cargo build && \
-#    (timeout -sKILL 1 cargo run &) && \
-#    sleep 1 && \
-#    diff openapi.json openapi.json.sample
-#test $? -ne 0 && exit 154 || :
-#
-#cd $SAMPLES/realworld && \
-#    docker compose up -d && \
-#    sleep 5 && \
-#    sqlx migrate run && \
-#    cargo test && \
-#    docker compose down
-#test $? -ne 0 && exit 155 || :
-#
-#cd $SAMPLES/streaming && \
-#    cargo build && \
-#    (timeout -sKILL 1 cargo run &) && \
-#    sleep 1 && \
-#    diff openapi.json openapi.json.sample
-#test $? -ne 0 && exit 156 || :
+cd $SAMPLES/openapi-schema-enums && \
+    cargo run && \
+    diff openapi.json openapi.json.sample
+test $? -ne 0 && exit 150 || :
+
+cd $SAMPLES/openapi-schema-from-into && \
+    cargo run && \
+    diff openapi.json openapi.json.sample
+test $? -ne 0 && exit 151 || :
+
+cd $SAMPLES/openapi-tags && \
+    cargo run && \
+    diff openapi.json openapi.json.sample
+test $? -ne 0 && exit 152 || :
+
+cd $SAMPLES/petstore && \
+    cargo build && \
+    diff openapi.json openapi.json.sample && \
+    cd client && \
+        npm install && \
+        cd .. && \
+    (timeout -sKILL 5 cargo run &) && \
+    sleep 1 && \
+    cd client && \
+        npm run gen && \
+        npm run main
+# FIXME
+# this is a little flaky; sometimes cause connection refused
+test $? -ne 0 && exit 153 || :
+
+cd $SAMPLES/readme-openapi && \
+    cargo build && \
+    (timeout -sKILL 1 cargo run &) && \
+    sleep 1 && \
+    diff openapi.json openapi.json.sample
+test $? -ne 0 && exit 154 || :
+
+cd $SAMPLES/realworld && \
+    docker compose up -d && \
+    sleep 5 && \
+    sqlx migrate run && \
+    cargo test && \
+    docker compose down
+test $? -ne 0 && exit 155 || :
+
+cd $SAMPLES/streaming && \
+    cargo build && \
+    (timeout -sKILL 1 cargo run &) && \
+    sleep 1 && \
+    diff openapi.json openapi.json.sample
+test $? -ne 0 && exit 156 || :
 
 cd $SAMPLES/worker-bindings && \
     cargo check


### PR DESCRIPTION
- closes https://github.com/ohkami-rs/ohkami/issues/357
- tested by `samples/petstore`'s diff test ( by `samples/test.sh` )

---

Before, for routes like

```rust
Ohkami::new((
    "/pets/:petId"
        .GET(show_pet_by_id)
        .PUT(edit_pet_profile),
    "/pets/admin"
        .GET(show_pets_detail),
))
```

, `gen_openapi_doc` generates `edit_pet_profile` **twice**, one is to `PUT /pets/:petId` correctly and other is **to `PUT /pets/admin` by bug**.

This is due to searching way in `gen_openapi_doc` that tries to find operations for each registered paths by **all methods**.
So, in this case, it *finds* an operation `edit_pet_profile` when searching `/pets/admin` with `PUT` method, matching to `/pets/:petId` .

This PR fixes this bug by using registered methods information stored in `router::base::Router`'s `routes` metadata and only searching actually registered methods for each paths.
This is, at the same time, to resolve:

- https://github.com/ohkami-rs/ohkami/issues/357