### PR TITLE
fix(openapi): correct `APIKey::{query, cookie}`'s `apikey_in:"header"`

### DIFF
--- a/ohkami_openapi/src/security.rs
+++ b/ohkami_openapi/src/security.rs
@@ -42,10 +42,10 @@ impl APIKey {
         Self { apikey_in:"header", name }
     }
     pub fn query(name: &'static str) -> Self {
-        Self { apikey_in:"header", name }
+        Self { apikey_in:"query", name }
     }
     pub fn cookie(name: &'static str) -> Self {
-        Self { apikey_in:"header", name }
+        Self { apikey_in:"cookie", name }
     }
 }
 


### PR DESCRIPTION
fix simply wrong `:"header"` into `:"query"` in `query` and `:"cookie` in `cookie`