### PR TITLE
enhance(worker): Support global bindings arg of `#[worker]`

### DIFF
--- a/ohkami_macros/src/worker.rs
+++ b/ohkami_macros/src/worker.rs
@@ -26,7 +26,7 @@ pub fn worker(args: TokenStream, ohkami_fn: TokenStream) -> Result<TokenStream, 
     let gen_ohkami = {
         let name = &ohkami_fn.sig.ident;
         let env = ohkami_fn.sig.inputs.first().map(|_| quote! {
-            <::ohkami::FromEnv>::from_env(&env)?
+            ::ohkami::FromEnv::from_env(&env).expect("`#[worker]` bindings arg has wrong `FromEnv` impl")
         });
         let awaiting = ohkami_fn.sig.asyncness.is_some().then_some(quote! {
             .await

--- a/ohkami_macros/src/worker/binding.rs
+++ b/ohkami_macros/src/worker/binding.rs
@@ -14,6 +14,19 @@ pub enum Binding {
 }
 
 impl Binding {
+    pub fn binding_type(&self) -> &'static str {
+        match self {
+            Self::Variable(_) => "String",
+            Self::AI => "Ai",
+            Self::D1 => "D1Database",
+            Self::KV => "$KV",
+            Self::R2 => "R2Bucket",
+            Self::Service => "Fetcher",
+            Self::Queue => "WorkerQueue",
+            Self::DurableObject => "DurableObjectNamespace",
+        }
+    }
+
     pub fn tokens_ty(&self) -> TokenStream {
         match self {
             Self::Variable(_)   => quote!(&'static str),

--- a/samples/test.sh
+++ b/samples/test.sh
@@ -66,6 +66,10 @@ cd $SAMPLES/worker-durable-websocket && \
     cargo check
 test $? -ne 0 && exit 158 || :
 
+cd $SAMPLES/worker-with-global-bindings && \
+    npm run openapi
+test $? -ne 0 && exit 159 || :
+
 cd $SAMPLES/worker-with-openapi && \
     cp wrangler.toml.sample wrangler.toml && \
     (test -f openapi.json || echo '{}' >> openapi.json) && \
@@ -80,4 +84,4 @@ cd $SAMPLES/worker-with-openapi && \
         diff openapi.json tmp.json \
         ; (test -f tmp.json && rm tmp.json) \
     || :)
-test $? -ne 0 && exit 159 || :
+test $? -ne 0 && exit 160 || :

--- a/samples/test.sh
+++ b/samples/test.sh
@@ -57,7 +57,9 @@ cd $SAMPLES/streaming && \
 test $? -ne 0 && exit 156 || :
 
 cd $SAMPLES/worker-bindings && \
-    cargo check
+    cargo check && \
+    wasm-pack build --target nodejs --dev --no-opt --no-pack --no-typescript && \
+    node dummy_env_test.js
 test $? -ne 0 && exit 157 || :
 
 cd $SAMPLES/worker-durable-websocket && \

--- a/samples/worker-bindings/Cargo.toml
+++ b/samples/worker-bindings/Cargo.toml
@@ -10,3 +10,4 @@ crate-type = ["cdylib", "rlib"]
 # set `default-features = false` to assure "DEBUG" feature be off even when DEBUGing `../ohkami`
 ohkami = { path = "../../ohkami", default-features = false, features = ["rt_worker"] }
 worker = { version = "0.5", features = ["queue", "d1"] }
+console_error_panic_hook = "0.1"

--- a/samples/worker-bindings/dummy_env_test.js
+++ b/samples/worker-bindings/dummy_env_test.js
@@ -1,0 +1,13 @@
+#! /usr/bin/env node
+
+import { join } from 'node:path';
+import { cwd, exit } from 'node:process';
+
+const wasmpack_js = await import(join(cwd(), `pkg`, `worker_with_openapi.js`));
+if (!wasmpack_js) {
+    exit("wasmpack_js is not found")
+}
+
+wasmpack_js.handle_dummy_env();
+
+console.log("ok");

--- a/samples/worker-bindings/src/lib.rs
+++ b/samples/worker-bindings/src/lib.rs
@@ -1,4 +1,5 @@
 use ohkami::bindings;
+use worker::wasm_bindgen;
 
 #[bindings]
 struct AutoBindings;
@@ -70,4 +71,39 @@ fn __test_bindings_new__(env: &worker::Env) -> Result<(), worker::Error> {
     let _: AutoBindings = AutoBindings::new(env)?;
     let _: ManualBindings = ManualBindings::new(env)?;
     Ok(())
+}
+
+#[wasm_bindgen::prelude::wasm_bindgen]
+pub fn handle_dummy_env() {
+    use worker::wasm_bindgen::{JsCast, closure::Closure};
+    use worker::js_sys::{Object, Reflect, Function};
+
+    console_error_panic_hook::set_once();
+
+    let dummy_db = {
+        let o = Object::new();
+        {
+            let constructor = Function::unchecked_from_js(Closure::<dyn Fn()>::new(|| {}).into_js_value());
+            {
+                let attributes = Object::new();
+                Reflect::set(&attributes, &"value".into(), &"D1Database".into()).unwrap();
+                Reflect::define_property(&constructor, &"name".into(), &attributes).unwrap();
+            }
+            Reflect::set(&o, &"constructor".into(), &constructor).unwrap();
+        }
+        o
+    };
+
+    let dummy_env = {
+        let o = Object::new();
+        {
+            Reflect::set(&o, &"DB".into(), &dummy_db).unwrap();
+            Reflect::set(&o, &"MY_KVSTORE".into(), &Object::new()).unwrap();
+        }
+        worker::Env::unchecked_from_js(o.unchecked_into())
+    };
+
+    let _: ohkami::bindings::D1 = dummy_env.d1("DB").unwrap();
+
+    let _: ohkami::bindings::KV = dummy_env.kv("MY_KVSTORE").unwrap();
 }

--- a/samples/worker-with-global-bindings/.gitignore
+++ b/samples/worker-with-global-bindings/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/samples/worker-with-global-bindings/Cargo.toml
+++ b/samples/worker-with-global-bindings/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name    = "worker-with-global-bindings"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+# set `default-features = false` to assure "DEBUG" feature be off even when DEBUGing `../ohkami`
+ohkami = { path = "../../ohkami", default-features = false, features = ["rt_worker"] }
+worker = { version = "0.5", features = ["d1"] }
+thiserror = "1.0"
+console_error_panic_hook = "0.1"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[profile.release]
+opt-level = "s"
+
+[features]
+openapi = ["ohkami/openapi"]
+
+# `--no-default-features` in release profile
+default = ["openapi"]

--- a/samples/worker-with-global-bindings/migrations/0001_schema.sql
+++ b/samples/worker-with-global-bindings/migrations/0001_schema.sql
@@ -1,0 +1,5 @@
+CREATE TABLE users (
+    id   INTEGER NOT NULL PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    age  INTEGER
+);

--- a/samples/worker-with-global-bindings/openapi.json
+++ b/samples/worker-with-global-bindings/openapi.json
@@ -1,0 +1,147 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "ohkami-with-global-bindings",
+    "version": "0.1.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:8787",
+      "description": "local dev"
+    },
+    {
+      "url": "https://worker-bindings-test.kanarus.workers.dev",
+      "description": "production"
+    }
+  ],
+  "paths": {
+    "/users": {
+      "get": {
+        "operationId": "list_users",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "age": {
+                        "type": "integer"
+                      },
+                      "id": {
+                        "type": "integer"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "name"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create_user",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "age": {
+                    "type": "integer"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "age": {
+                      "type": "integer"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/{id}": {
+      "get": {
+        "operationId": "show_user",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "integer"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "age": {
+                      "type": "integer"
+                    },
+                    "id": {
+                      "type": "integer"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/samples/worker-with-global-bindings/package.json
+++ b/samples/worker-with-global-bindings/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "ohkami-with-global-bindings",
+	"version": "0.1.0",
+	"private": true,
+	"scripts": {
+		"deploy": "export OHKAMI_WORKER_DEV='' && wrangler deploy",
+		"dev": "export OHKAMI_WORKER_DEV=1 && wrangler dev",
+		"openapi": "node ../../scripts/workers_openapi.js"
+	},
+	"devDependencies": {
+		"wrangler": "^3.50"
+	}
+}

--- a/samples/worker-with-global-bindings/src/lib.rs
+++ b/samples/worker-with-global-bindings/src/lib.rs
@@ -9,7 +9,7 @@ struct Bindings {
 
 #[ohkami::worker]
 async fn ohkami(Bindings { DB, MY_KV }: Bindings) -> Ohkami {
-    // just check to be able to retrieve
+    // just check to be able to retrieve even in openapi generation
     let _ = MY_KV;
 
     Ohkami::new((
@@ -131,7 +131,7 @@ mod routes {
 
     #[derive(Serialize)]
     #[cfg_attr(feature="openapi", derive(ohkami::openapi::Schema))]
-    struct User {
+    pub struct User {
         id: u32,
         name: String,
         age: Option<u8>,
@@ -139,7 +139,7 @@ mod routes {
 
     #[derive(Deserialize)]
     #[cfg_attr(feature="openapi", derive(ohkami::openapi::Schema))]
-    struct CreateUserRequest<'req> {
+    pub struct CreateUserRequest<'req> {
         name: &'req str,
         age: Option<u8>,
     }

--- a/samples/worker-with-global-bindings/src/lib.rs
+++ b/samples/worker-with-global-bindings/src/lib.rs
@@ -1,0 +1,188 @@
+use ohkami::prelude::*;
+use ohkami::fang::Context;
+
+#[ohkami::bindings]
+struct Bindings {
+    DB: ohkami::bindings::D1,
+    MY_KV: ohkami::bindings::KV,
+}
+
+#[ohkami::worker]
+async fn ohkami(Bindings { DB, MY_KV }: Bindings) -> Ohkami {
+    // just check to be able to retrieve
+    let _ = MY_KV;
+
+    Ohkami::new((
+        Context::new(D1UserRepository::new(DB)),
+        "/users".By(routes::users_ohkami::<D1UserRepository>())
+    ))
+}
+
+enum Error {
+    Worker(worker::Error),
+    Repository(String),
+    UserIdNotFound { id: u32 },
+}
+impl From<worker::Error> for Error {
+    fn from(e: worker::Error) -> Self {
+        Self::Worker(e)
+    }
+}
+impl IntoResponse for Error {
+    fn into_response(self) -> Response {
+        match self {
+            Self::Worker(e) => {
+                worker::console_error!("Worker's internal error: {e}");
+                Response::InternalServerError()
+            }
+            Self::Repository(e) => {
+                worker::console_error!("Error from repository: {e}");
+                Response::InternalServerError()
+            }
+            Self::UserIdNotFound { id } => {
+                worker::console_error!("Error: user not found by id: `{id}`");
+                Response::NotFound()
+            }
+        }
+    }
+
+    #[cfg(feature="openapi")]
+    fn openapi_responses() -> ohkami::openapi::Responses {
+        // there seems nothing needed to document
+        ohkami::openapi::Responses::new([])
+    }
+}
+
+#[derive(Clone)]
+struct D1UserRepository {
+    d1: std::rc::Rc<ohkami::bindings::D1>,
+}
+impl D1UserRepository {
+    fn new(d1: ohkami::bindings::D1) -> Self {
+        Self { d1: std::rc::Rc::new(d1) }
+    }
+}
+impl repository::UserRepository for D1UserRepository {
+    async fn get_all(&self) -> Result<Vec<repository::User>, Error> {
+        self.d1
+            .prepare("SELECT id, name, age FROM users")
+            .all().await?
+            .results()
+            .map_err(Into::into)
+    }
+
+    async fn get_by_id(&self, id: u32) -> Result<Option<repository::User>, Error> {
+        self.d1
+            .prepare("SELECT id, name, age FROM users WHERE id = ?")
+            .bind(&[id.into()])?
+            .first(None).await
+            .map_err(Into::into)
+    }
+
+    async fn create_returning_id(&self, params: repository::CreateUserParams<'_>) -> Result<u32, Error> {
+        let id = self.d1
+            .prepare("INSERT INTO users (name, age) VALUES (?, ?) RETURNING id")
+            .bind(&[params.name.into(), params.age.into()])?
+            .first(Some("id")).await?
+            .ok_or_else(|| Error::Repository(format!("`id` not found in `RETURNING id` qruery result")))?;
+        Ok(id)
+    }
+}
+
+mod repository {
+    #[derive(ohkami::serde::Deserialize)]
+    pub struct User {
+        pub id: u32,
+        pub name: String,
+        pub age: Option<u8>,
+    }
+
+    pub struct CreateUserParams<'r> {
+        pub name: &'r str,
+        pub age: Option<u8>,
+    }
+
+    pub trait UserRepository: 'static {
+        async fn get_all(&self) -> Result<Vec<User>, crate::Error>;
+
+        async fn get_by_id(&self, id: u32) -> Result<Option<User>, crate::Error>;
+
+        async fn create_returning_id(&self, params: CreateUserParams<'_>) -> Result<u32, crate::Error>;
+    }
+}
+
+mod routes {
+    use crate::repository::{self, UserRepository};
+    use ohkami::{Ohkami, Route};
+    use ohkami::format::JSON;
+    use ohkami::fang::Context;
+    use ohkami::typed::status;
+    use ohkami::serde::{Serialize, Deserialize};
+
+    pub fn users_ohkami<U: UserRepository>() -> Ohkami {
+        Ohkami::new((
+            "/"
+                .GET(list_users::<U>)
+                .POST(create_user::<U>),
+            "/:id"
+                .GET(show_user::<U>),
+        ))
+    }
+
+    #[derive(Serialize)]
+    #[cfg_attr(feature="openapi", derive(ohkami::openapi::Schema))]
+    struct User {
+        id: u32,
+        name: String,
+        age: Option<u8>,
+    }
+
+    #[derive(Deserialize)]
+    #[cfg_attr(feature="openapi", derive(ohkami::openapi::Schema))]
+    struct CreateUserRequest<'req> {
+        name: &'req str,
+        age: Option<u8>,
+    }
+
+    pub async fn list_users<U: UserRepository>(
+        Context(r): Context<'_, U>,
+    ) -> Result<JSON<Vec<User>>, crate::Error> {
+        let user_rows = r.get_all().await?;
+
+        Ok(JSON(user_rows.into_iter().map(|r| User {
+            id: r.id,
+            name: r.name,
+            age: r.age,
+        }).collect()))
+    }
+
+    pub async fn show_user<U: UserRepository>(
+        id: u32,
+        Context(r): Context<'_, U>,
+    ) -> Result<JSON<User>, crate::Error> {
+        let user_row = r.get_by_id(id).await?
+            .ok_or(crate::Error::UserIdNotFound { id })?;
+
+        Ok(JSON(User {
+            id: user_row.id,
+            name: user_row.name,
+            age: user_row.age,
+        }))
+    }
+
+    pub async fn create_user<U: UserRepository>(
+        JSON(req): JSON<CreateUserRequest<'_>>,
+        Context(r): Context<'_, U>,
+    ) -> Result<status::Created<JSON<User>>, crate::Error> {
+        let created_id = r.create_returning_id(repository::CreateUserParams {
+            name: &req.name,
+            age: req.age,
+        }).await?;
+
+        Ok(status::Created(JSON(User {
+            id: created_id,
+            name: req.name.to_string(),
+            age: req.age,
+        })))
+    }
+}

--- a/samples/worker-with-global-bindings/wrangler.toml
+++ b/samples/worker-with-global-bindings/wrangler.toml
@@ -1,0 +1,18 @@
+name = "worker-bindings-test"
+main = "build/worker/shim.mjs"
+compatibility_date = "2025-02-26"
+
+# `worker-build` and `wasm-pack` is required
+# (run `cargo install wasm-pack worker-build` to install)
+
+[build]
+command = "test $OHKAMI_WORKER_DEV && worker-build --dev || worker-build -- --no-default-features"
+
+[[d1_databases]]
+binding = "DB"
+database_name = "db"
+database_id = "xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+
+[[kv_namespaces]]
+binding = "MY_KV"
+id = "<BINDING_ID>"


### PR DESCRIPTION
close https://github.com/ohkami-rs/ohkami/issues/415

tested by

- `samples/worker-bindings` ( add `handle_dummy_env()` and `dummy_env_test.js`  )
- `samples/worker-with-global-bindings` ( new )

( via `samples/test.sh` )

---

Internally, this PR introduces `x_worker::FromEnv` trait for global bindings arg. Basically it just provides `fn from_env(&worker::Env) -> Result<Self>`.

However, the `worker::Env` **does not exist** during openapi generation phase. So `FromEnv` has hidden methods `bindings_meta` and `dummy_env` to work around it. The latter, `dummy_env`, literally creates _**dummy**_ `worker::Env` object in place, depending on metadata from the former `bindings_meta` generated by `#[bindings]`. Dirty hack...