### PR TITLE
enhance(openapi): provide default implementation of `openapi_responses` returning empty `Responses`

### DIFF
--- a/ohkami/src/response/into_response.rs
+++ b/ohkami/src/response/into_response.rs
@@ -42,7 +42,9 @@ pub trait IntoResponse {
     fn into_response(self) -> Response;
 
     #[cfg(feature="openapi")]
-    fn openapi_responses() -> openapi::Responses;
+    fn openapi_responses() -> openapi::Responses {
+        openapi::Responses::new([])
+    }
 }
 
 pub trait IntoBody {


### PR DESCRIPTION
close https://github.com/ohkami-rs/ohkami/issues/417