### PR TITLE
enhance(openapi): allow `#[operation]` to newly set status description

### DIFF
--- a/ohkami_openapi/src/response.rs
+++ b/ohkami_openapi/src/response.rs
@@ -83,6 +83,8 @@ impl Responses {
         let status = status.into();
         if let Some(response) = self.0.get_mut(&status) {
             response.description = new_description;
+        } else {
+            self.0.insert(status.into(), Response::when(new_description));
         }
     }
 }

--- a/samples/petstore/openapi.json.sample
+++ b/samples/petstore/openapi.json.sample
@@ -73,6 +73,9 @@
               }
             }
           },
+          "500": {
+            "description": "an internal error"
+          },
           "default": {
             "description": "Unexpected error",
             "content": {

--- a/samples/petstore/src/main.rs
+++ b/samples/petstore/src/main.rs
@@ -87,7 +87,11 @@ struct ListPetsMeta {
     limit: Option<usize>,
 }
 
-#[openapi::operation(createPet)]
+#[openapi::operation(createPet {
+    // 500 is not defined in `Error::openapi_responses`,
+    // but this *overrides* it to this description
+    500: "an internal error",
+})]
 async fn create_pet(
     JSON(req): JSON<CreatePetRequest<'_>>,
     Context(db): Context<'_, Arc<mock::DB>>,


### PR DESCRIPTION
related to: https://github.com/ohkami-rs/ohkami/issues/417

tested by:

- `samples/petstore`'s `createPet` operation ( via `samples/test.sh` )

---

Before `#[operation]`'s description overriding can only overwrite description of already-contained status in the operation's original `openapi::Response`. But:

- this is inconsistent with that `#[operation]`'s `summary` can newly insert `summary` field to the operation.
- will be better if it can newly set any possible statuses of the operation for more flexible documentation.

So this PR enables it.