### PR TITLE
enhance(util): improve internal log macros

### DIFF
--- a/ohkami/src/util.rs
+++ b/ohkami/src/util.rs
@@ -23,10 +23,7 @@ macro_rules! eprintln {
 macro_rules! WARNING {
     ( $( $t:tt )* ) => {{
         $crate::eprintln!(
-            "[ohkami][WARNING][{}:{}:{}] {}",
-            file!(),
-            line!(),
-            column!(),
+            "[ohkami:WARNS] {}",
             format_args!($($t)*)
         );
     }};
@@ -37,10 +34,7 @@ macro_rules! WARNING {
 macro_rules! ERROR {
     ( $($t:tt)* ) => {
         $crate::eprintln!(
-            "[ohkami][ERROR][{}:{}:{}] {}",
-            file!(),
-            line!(),
-            column!(),
+            "[ohkami:ERROR] {}",
             format_args!($($t)*)
         );
     };
@@ -52,10 +46,7 @@ macro_rules! DEBUG {
     ( $( $t:tt )* ) => {{
         #[cfg(feature="DEBUG")] {
             $crate::eprintln!(
-                "[ohkami][DEBUG][{}:{}:{}] {}",
-                file!(),
-                line!(),
-                column!(),
+                "[ohkami:DEBUG] {}",
                 format_args!($($t)*)
             );
         }

--- a/ohkami/src/util.rs
+++ b/ohkami/src/util.rs
@@ -46,7 +46,10 @@ macro_rules! DEBUG {
     ( $( $t:tt )* ) => {{
         #[cfg(feature="DEBUG")] {
             $crate::eprintln!(
-                "[ohkami:DEBUG] {}",
+                "[ohkami:DEBUG] {}:{}:{} {}",
+                file!(),
+                line!(),
+                column!(),
                 format_args!($($t)*)
             );
         }


### PR DESCRIPTION
- avoid printing `file`, `line`, `column` except for `DEBUG!` . they are Ohkami's internal implementations' information and useless for users
- unify header ( `[ohkami:_____]` )'s width for ease of log viewing:
  - `[ohkami:WARNS]`
  - `[ohkami:ERROR]`
  - `[ohkami:DEBUG]`