### PR TITLE
enhance(fangs): set `SendSyncOnNative + 'static` as super trait of `Fang` `Fangs`

### DIFF
--- a/ohkami/src/fang/middleware/mod.rs
+++ b/ohkami/src/fang/middleware/mod.rs
@@ -1,9 +1,9 @@
 pub mod util;
-use super::{Fang, BoxedFPC};
+use super::{Fang, BoxedFPC, SendSyncOnNative};
 
 
 #[allow(private_interfaces)]
-pub trait Fangs {
+pub trait Fangs: SendSyncOnNative + 'static {
     // returning box for object-safety
     fn build(&self, inner: BoxedFPC) -> BoxedFPC;
 

--- a/ohkami/src/fang/mod.rs
+++ b/ohkami/src/fang/mod.rs
@@ -54,7 +54,7 @@ use crate::openapi;
 /// };
 /// 
 /// ```
-pub trait Fang<Inner: FangProc> {
+pub trait Fang<Inner: FangProc>: SendSyncOnNative + 'static {
     type Proc: FangProc;
     fn chain(&self, inner: Inner) -> Self::Proc;
 

--- a/ohkami/src/ohkami/mod.rs
+++ b/ohkami/src/ohkami/mod.rs
@@ -879,11 +879,26 @@ mod sync {
 
 #[cfg(all(debug_assertions, feature="__rt_native__"))]
 #[cfg(test)]
-#[test] fn can_howl_on_any_native_async_runtime() {
-    __rt__::testing::block_on(async {
-        crate::util::timeout_in(
-            std::time::Duration::from_secs(3),
-            Ohkami::new(()).howl(("localhost", __rt__::testing::PORT))
-        ).await
-    });
+mod test {
+    use super::*;
+
+    #[test] fn can_howl_on_any_native_async_runtime() {
+        __rt__::testing::block_on(async {
+            crate::util::timeout_in(
+                std::time::Duration::from_secs(3),
+                Ohkami::new(()).howl(("localhost", __rt__::testing::PORT))
+            ).await
+        });
+    }
+
+    #[test] fn ohkami_is_send_sync_static_on_native() {
+        fn is_send_sync_static<T: Send + Sync + 'static>(_: T) {}
+
+        let o = Ohkami::new((
+            crate::fang::Context::new(String::from("resource")),
+            "/".GET(async || {"Hello, world!"})
+        ));
+
+        is_send_sync_static(o);
+    }
 }


### PR DESCRIPTION
tested by: test `ohkami_is_send_sync_static_on_native` in `ohkami/ohkami/mod.rs`

---

This PR adds `SendSyncOnNative` super traits to `Fangs` `Fangs`, which have been *implicitly* required in other APIs ( like `fang::Context` ) for now.

Additionally, this, especially the latter's `Send`, makes `Ohkami` instance itself `Send` on native environment.