### PR TITLE
enhance(ohkami): Support single-thread async runtime on multiple threads

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -11,6 +11,7 @@ members  = [
     "static_files",
     "json_response",
     "derive_from_request",
+    "multiple-single-threads",
 ]
 
 [workspace.dependencies]

--- a/examples/hello/Cargo.toml
+++ b/examples/hello/Cargo.toml
@@ -11,3 +11,4 @@ tracing-subscriber = { workspace = true }
 
 [features]
 nightly = ["ohkami/nightly"]
+DEBUG   = ["ohkami/DEBUG"]

--- a/examples/multiple-single-threads/Cargo.toml
+++ b/examples/multiple-single-threads/Cargo.toml
@@ -5,5 +5,6 @@ edition = "2024"
 authors = ["kanarus <kanarus786@gmail.com>"]
 
 [dependencies]
-ohkami  = { workspace = true }
-tokio   = { workspace = true }
+ohkami   = { workspace = true }
+tokio    = { workspace = true }
+num_cpus = "1.16"

--- a/examples/multiple-single-threads/Cargo.toml
+++ b/examples/multiple-single-threads/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name    = "multiple-single-threads"
+version = "0.1.0"
+edition = "2024"
+authors = ["kanarus <kanarus786@gmail.com>"]
+
+[dependencies]
+ohkami  = { workspace = true }
+tokio   = { workspace = true }

--- a/examples/multiple-single-threads/Cargo.toml
+++ b/examples/multiple-single-threads/Cargo.toml
@@ -8,3 +8,6 @@ authors = ["kanarus <kanarus786@gmail.com>"]
 ohkami   = { workspace = true }
 tokio    = { workspace = true }
 num_cpus = "1.16"
+
+[features]
+DEBUG = ["ohkami/DEBUG"]

--- a/examples/multiple-single-threads/src/main.rs
+++ b/examples/multiple-single-threads/src/main.rs
@@ -1,0 +1,30 @@
+use ohkami::prelude::*;
+
+fn main() {
+    async fn serve(o: Ohkami) -> std::io::Result<()> {
+        let socket = tokio::net::TcpSocket::new_v4()?;
+
+        socket.bind("0.0.0.0:8000".parse().unwrap())?;
+
+        let listener = socket.listen(1024)?;
+
+        o.howl(listener).await;
+
+        Ok(())
+    }
+
+    fn runtime() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+    }
+
+    runtime().block_on(serve(ohkami())).expect("serving error")
+}
+
+fn ohkami() -> Ohkami {
+    Ohkami::new((
+        "/".GET(async || {"Hello, world!"}),
+    ))
+}

--- a/ohkami/src/ohkami/mod.rs
+++ b/ohkami/src/ohkami/mod.rs
@@ -818,82 +818,91 @@ mod sync {
         }
     };
 
-    pub struct CtrlC;
+    pub struct CtrlC { index: usize }
     const _: () = {
-        use std::sync::atomic::{AtomicBool, Ordering};
-        use std::future::Future;
+        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         use std::task::{Context, Poll, Waker};
         use std::pin::Pin;
 
-        #[cfg(any(feature="rt_tokio", feature="rt_async-std", feature="rt_smol", feature="rt_nio"))]
-        use std::{sync::atomic::AtomicPtr, ptr::null_mut};
-        #[cfg(any(feature="rt_glommio"))]
-        use std::sync::Mutex;
-    
-        #[cfg(any(feature="rt_tokio", feature="rt_async-std", feature="rt_smol", feature="rt_nio"))]
-        static WAKER: AtomicPtr<Waker> = AtomicPtr::new(null_mut());
-        #[cfg(any(feature="rt_glommio"))]
-        static WAKER: Mutex<Vec<(usize, Waker)>> = Mutex::new(Vec::new());
-
-        static CATCH: AtomicBool = AtomicBool::new(false);
+        static INTERRUPTED: AtomicBool = AtomicBool::new(false);
+        static WAKERS: std::sync::Mutex<Vec<Waker>> = std::sync::Mutex::new(Vec::new());
 
         impl CtrlC {
             pub fn new() -> Self {
-                #[cfg(any(feature="rt_tokio", feature="rt_async-std", feature="rt_smol", feature="rt_nio"))]
-                ::ctrlc::set_handler(|| {
-                    CATCH.store(true, Ordering::SeqCst);
-                    let waker = WAKER.swap(null_mut(), Ordering::SeqCst);
-                    if !waker.is_null() {
-                        unsafe {Box::from_raw(waker)}.wake();
-                    }
-                }).expect("Something went wrong with Ctrl-C");
+                /*
+                    When finally get Ctrl-C signal, let's set `INTERRUPTED` to true and
+                    wake all wakers for Ohkamis on one or more threads.
 
-                #[cfg(any(feature="rt_glommio"))]
-                ::ctrlc::try_set_handler(|| {
-                    CATCH.store(true, Ordering::SeqCst);
-                    let lock = &mut *WAKER.lock().unwrap();
-                    crate::DEBUG!("Finally {} executors on {} CPU(s)", lock.len(), num_cpus::get());
-                    for (_, w) in std::mem::take(lock) {
+                    This is intended to work correctly in both :
+
+                    1. A single Ohkami is running on multi-thread async runtime.
+                    2. Spawning some threads and single-thread Ohkami is running on
+                       each thread with single-thread async runtime.
+                       - glommio is designed to do so
+                       - even in other runtimes, sometimes this way of entrypoint
+                         with `SO_REUSEADDR` may work in better performance than ordinary
+                         one with multi-thread runtime.
+
+                    For case 1., we only have to hold the single `AtomicPtr<Waker>`
+                    corresponded to the Ohkami in `static WAKER`, and here retrieve/wake it :
+
+                    ```
+                    ::ctrlc::set_handler(|| {
+                        INTERRUPTED.store(true, Ordering::SeqCst);
+                        let waker = WAKER.swap(null_mut(), Ordering::SeqCst);
+                        if !waker.is_null() {
+                            unsafe {Box::from_raw(waker)}.wake();
+                        }
+                    }).expect("Something went wrong with Ctrl-C");
+
+                    ```
+
+                    But taking case 2. into consideration, we must terminate other threads
+                    together with the main thread in this handler. So we have to hold
+                    all `Waker`s in `WAKERS` and wake each them.
+                */
+                ::ctrlc::set_handler(|| {
+                    INTERRUPTED.store(true, Ordering::SeqCst);
+
+                    let mut wakers = WAKERS.lock().unwrap();
+                    crate::DEBUG!("CtrlC handler: Waiting for {} Ohkami(s)", wakers.len());
+                    for w in std::mem::take(&mut *wakers) {
                         w.wake();
                     }
                 }).ok();
 
-                Self
+                let index = {
+                    static WAKER_INDEX: AtomicUsize = AtomicUsize::new(0);
+                    WAKER_INDEX.fetch_add(1, Ordering::Relaxed)
+                };
+
+                /* ensure that `WAKERS` has the same numbers of `Waker`s as `CtrlC` instances */
+                WAKERS.lock().unwrap().push(Waker::noop().clone());
+
+                Self { index }
             }
 
             pub fn until_interrupt<T>(&self, task: impl Future<Output = T>) -> impl Future<Output = Option<T>> {
-                return UntilInterrupt(task);
+                return UntilInterrupt { index: self.index, task };
 
-                struct UntilInterrupt<F: Future>(F);
+                struct UntilInterrupt<F: Future> {
+                    index: usize,
+                    task:  F,
+                }
                 impl<F: Future> Future for UntilInterrupt<F> {
                     type Output = Option<F::Output>;
 
                     #[inline]
                     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-                        match unsafe {Pin::new_unchecked(&mut self.get_unchecked_mut().0)}.poll(cx) {
+                        let UntilInterrupt { index, task } = unsafe {self.get_unchecked_mut()};
+
+                        match unsafe {Pin::new_unchecked(task)}.poll(cx) {
                             Poll::Ready(t) => Poll::Ready(Some(t)),
-                            Poll::Pending  => if CATCH.load(Ordering::SeqCst) {
+                            Poll::Pending  => if INTERRUPTED.load(Ordering::SeqCst) {
                                 crate::DEBUG!("[CtrlC::catch] Ready");
                                 Poll::Ready(None)
                             } else {
-                                #[cfg(any(feature="rt_tokio", feature="rt_async-std", feature="rt_smol", feature="rt_nio"))] {
-                                    let prev_waker = WAKER.swap(
-                                        Box::into_raw(Box::new(cx.waker().clone())),
-                                        Ordering::SeqCst
-                                    );
-                                    if !prev_waker.is_null() {
-                                        unsafe {prev_waker.drop_in_place()}
-                                    }
-                                }
-                                #[cfg(any(feature="rt_glommio"))] {
-                                    let current_id = glommio::executor().id();
-                                    let current_waker = cx.waker().clone();
-                                    let mut lock = WAKER.lock().unwrap();
-                                    match lock.iter_mut().find(|(id, _)| (*id == current_id)) {
-                                        Some(prev) => *prev = (current_id, current_waker),
-                                        None       => lock.push((current_id, current_waker)),
-                                    }
-                                }
+                                WAKERS.lock().unwrap()[*index] = cx.waker().clone();
                                 Poll::Pending
                             }
                         }


### PR DESCRIPTION
tested by:

- `examples/multiple-single-threads` ( behavior; interrupt by hand )
- `benches_rt/tokio/bin/param.rs` ( perf; compare `wrk` result with that of `v0.24` branch )

we should add an regression test in future at least for the behavior

---

In some cases, spawning multiple thread each of which runs single-thread async runtime with `SO_REUSEADDR` is more performant than just a multi-thread runtime ( especially when interacting with DB / example: https://github.com/TechEmpower/FrameworkBenchmarks/blob/38c565ebaa900b4db51c0425d11a6619a5615a79/frameworks/Rust/axum/src/server.rs#L109-L130 ) .

Howeveer, before Ohkami ( on other than `rt_glommio` ) has been assumed that only single `Ohkami` instance is running in an application, causing panics when running multiple `Ohkami` instances.

This PR fixes `CtrlC` implementation to support such usages with no degradation in performance.
At the same time, it also improves the performance on `rt_glommio`.