### PR TITLE
chore: test `.Dir()`

### DIFF
--- a/examples/static_files/public/.env.sample
+++ b/examples/static_files/public/.env.sample
@@ -1,0 +1,1 @@
+WHATS_THIS='A sample .env file'

--- a/examples/static_files/public/index.html
+++ b/examples/static_files/public/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
     <h1>ohkami</h1>
-    <p>This page is served by ohkami web framework.</p>
+    <p>This page is served by Ohkami web framework.</p>
+    <script src="/index.js"></script>
 </body>
 </html>

--- a/examples/static_files/public/index.js
+++ b/examples/static_files/public/index.js
@@ -1,0 +1,1 @@
+window.alert('Hello, Ohkami!');

--- a/examples/static_files/src/main.rs
+++ b/examples/static_files/src/main.rs
@@ -1,8 +1,71 @@
 use ohkami::prelude::*;
 
+struct Options {
+    omit_dot_html: bool,
+    serve_dotfiles: bool,
+}
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            omit_dot_html: false,
+            serve_dotfiles: false,
+        }
+    }
+}
+
+fn ohkami(Options { omit_dot_html, serve_dotfiles }: Options) -> Ohkami {
+    Ohkami::new((
+        "/".Dir("./public")
+            .omit_extensions(if omit_dot_html {&["html"]} else {&[]})
+            .serve_dotfiles(serve_dotfiles),
+    ))
+}
+
 #[tokio::main]
 async fn main() {
-    Ohkami::new((
-        "/".Dir("./public"),//.omit_extensions(["html"]),
-    )).howl("localhost:3000").await
+    ohkami(Default::default()).howl("0.0.0.0:3000").await
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use ohkami::testing::*;
+
+    #[tokio::test]
+    async fn test_default() {
+        let t = ohkami(Default::default()).test();
+
+        // dotfiles are not served
+        {
+            let req = TestRequest::GET("/.env.sample");
+            let res = t.oneshot(req).await;
+            assert_eq!(res.status().code(), 404);
+        }
+
+        // .js is served as text/javascript
+        {
+            let req = TestRequest::GET("/index.js");
+            let res = t.oneshot(req).await;
+            assert_eq!(res.status().code(), 200);
+            assert_eq!(res.content("text/javascript"), Some(include_str!("../public/index.js").as_bytes()));
+        }
+
+        // .html is served as text/html with extension
+        {
+            let req = TestRequest::GET("/index.html");
+            let res = t.oneshot(req).await;
+            assert_eq!(res.status().code(), 200);
+            assert_eq!(res.content("text/html"), Some(include_str!("../public/index.html").as_bytes()));
+
+            let req = TestRequest::GET("/about.html");
+            let res = t.oneshot(req).await;
+            assert_eq!(res.status().code(), 200);
+            assert_eq!(res.content("text/html"), Some(include_str!("../public/about.html").as_bytes()));
+
+            let req = TestRequest::GET("/blog/index.html");
+            let res = t.oneshot(req).await;
+            assert_eq!(res.status().code(), 200);
+            assert_eq!(res.content("text/html"), Some(include_str!("../public/blog/index.html").as_bytes()));
+        }
+    }
 }

--- a/examples/test.sh
+++ b/examples/test.sh
@@ -4,6 +4,9 @@ set -Cue
 
 EXAMPLES=$(pwd)
 
+cd $EXAMPLES/static_files && \
+    cargo test
+
 cd $EXAMPLES/jwt && \
     cp .env.sample .env
 cd $EXAMPLES/jwt && \

--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -96,19 +96,19 @@ __rt_native__ = ["__rt__", "dep:mime_guess", "dep:ctrlc"]
 
 ##### DEBUG #####
 DEBUG = ["tokio?/rt-multi-thread", "tokio?/macros"]
-default = [
-    "nightly",
-    "openapi",
-    "sse",
-    "ws",
-    "rt_tokio",
-    #"rt_async-std",
-    #"rt_smol",
-    #"rt_nio",
-    #"rt_glommio",
-    #"rt_worker",
-    "DEBUG",
-]
+#default = [
+#    "nightly",
+#    "openapi",
+#    "sse",
+#    "ws",
+#    "rt_tokio",
+#    #"rt_async-std",
+#    #"rt_smol",
+#    #"rt_nio",
+#    #"rt_glommio",
+#    #"rt_worker",
+#    "DEBUG",
+#]
 
 
 [dev-dependencies]

--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -96,19 +96,19 @@ __rt_native__ = ["__rt__", "dep:mime_guess", "dep:ctrlc"]
 
 ##### DEBUG #####
 DEBUG = ["tokio?/rt-multi-thread", "tokio?/macros"]
-#default = [
-#    "nightly",
-#    "openapi",
-#    "sse",
-#    "ws",
-#    "rt_tokio",
-#    #"rt_async-std",
-#    #"rt_smol",
-#    #"rt_nio",
-#    #"rt_glommio",
-#    #"rt_worker",
-#    "DEBUG",
-#]
+default = [
+    "nightly",
+    "openapi",
+    "sse",
+    "ws",
+    "rt_tokio",
+    #"rt_async-std",
+    #"rt_smol",
+    #"rt_nio",
+    #"rt_glommio",
+    #"rt_worker",
+    "DEBUG",
+]
 
 
 [dev-dependencies]

--- a/ohkami/src/ohkami/dir.rs
+++ b/ohkami/src/ohkami/dir.rs
@@ -38,12 +38,12 @@ impl Dir {
             while let Some(entry) = entries.pop() {
                 if entry.is_file() {
                     files.push((
-                        entry.clone(),
+                        entry.iter().skip(dir_path.iter().count()).collect(),
                         std::fs::File::open(entry)?
                     ));
 
                 } else if entry.is_dir() {
-                    entries.append(&mut fetch_entries(entry)?)
+                    entries.extend(fetch_entries(entry)?);
 
                 } else {
                     continue

--- a/ohkami/src/ohkami/routing.rs
+++ b/ohkami/src/ohkami/routing.rs
@@ -177,6 +177,7 @@ const _: () = {
                 let file_path = file_path
                     .iter()
                     .map(|s| s.to_str().expect(&format!("invalid path to serve: `{}`", s.to_string_lossy())))
+                    .filter(|s| !matches!(*s, "" | "/"))
                     .collect::<Vec<_>>()
                     .join("/");
 

--- a/ohkami/src/router/segments.rs
+++ b/ohkami/src/router/segments.rs
@@ -83,29 +83,12 @@ pub(crate) enum RouteSegment {
 impl RouteSegment {
     pub(crate) fn new(segment: Cow<'static, str>) -> Result<Self, String> {
         fn validate_segment_name(mut name: impl DoubleEndedIterator<Item = char>) -> Result<(), String> {
-            let is_invalid_head_or_tail_char = |c: char| !/* NOT */ matches!(c,
-                '0'..='9' | 'a'..='z' | 'A'..='Z'
-            );
-            let is_invalid_char = |c: char| !/* NOT */ matches!(c,
-                '.' | '-' | '_' | '0'..='9' | 'a'..='z' | 'A'..='Z'
-            );
-
-            let head = name.next().ok_or(format!("found an empty segment name"))?;
-            if is_invalid_head_or_tail_char(head) {
-                return Err(format!("path segment can't start with '{head}'"))
-            }
-
-            if let Some(tail) = name.next_back() {
-                if is_invalid_head_or_tail_char(tail) {
-                    return Err(format!("path segment can't end with '{tail}'"))
-                }
-            }
-
-            if name.any(is_invalid_char) {
-                return Err(format!("path segment can only contain '.' | '-' | '_' | '0'..='9' | 'a'..='z' | 'A'..='Z'"))
-            }
-
-            Ok(())
+            name.all(|c| matches!(
+                c,
+                'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '.' | '_' | '~'
+            )).then_some(()).ok_or_else(|| format!(
+                "path can only contain: [a-zA-Z0-9-\\._~]"
+            ))
         }
 
         let mut segment_chars = segment.starts_with('/')

--- a/ohkami/src/testing/mod.rs
+++ b/ohkami/src/testing/mod.rs
@@ -214,4 +214,9 @@ impl TestResponse {
             Some(serde_json::from_slice(body))
         } else {None}
     }
+    pub fn content(&self, content_type: &'static str) -> Option<&[u8]> {
+        if self.0.headers.ContentType()? == content_type {
+            self.0.content.as_bytes()
+        } else {None}
+    }
 }

--- a/ohkami/src/testing/mod.rs
+++ b/ohkami/src/testing/mod.rs
@@ -215,7 +215,7 @@ impl TestResponse {
         } else {None}
     }
     pub fn content(&self, content_type: &'static str) -> Option<&[u8]> {
-        if self.0.headers.ContentType()? == content_type {
+        if self.0.headers.ContentType()?.starts_with(content_type) {
             self.0.content.as_bytes()
         } else {None}
     }


### PR DESCRIPTION
This PR adds test for `.Dir()` by `examples/static_files` ( via `examples/test.sh` ) , with adding `TestResponse::content()` and fixing `RouteSegment::new`'s validation