### PR TITLE
enhance(testing): expect `TestResponse::json`'s `serde_json::Result` to be `Ok`

### DIFF
--- a/examples/jwt/src/main.rs
+++ b/examples/jwt/src/main.rs
@@ -93,8 +93,7 @@ mod test {
         let req = TestRequest::GET("/auth");
         let res = t.oneshot(req).await;
         let AuthResponse { token } = res.json()
-            .expect("`/auth` response doesn't contain a token")
-            .expect("`/auth` response is not `AuthResponse`");
+            .expect("`/auth` response doesn't contain a token");
 
         let req = TestRequest::GET("/private")
             .header("Authorization", format!("Bearer {token}"));

--- a/ohkami/src/fang/builtin/jwt.rs
+++ b/ohkami/src/fang/builtin/jwt.rs
@@ -652,7 +652,7 @@ impl<Payload: for<'de> Deserialize<'de>> JWT<Payload> {
                 .header("Authorization", format!("Bearer {jwt_1}"));
             let res = t.oneshot(req).await;
             assert_eq!(res.status(), Status::OK);
-            assert_eq!(res.json::<Profile>().unwrap().unwrap(), Profile {
+            assert_eq!(res.json::<Profile>().unwrap(), Profile {
                 id:           1,
                 first_name:   String::from("ohkami"),
                 familly_name: String::from("framework"),
@@ -690,7 +690,7 @@ impl<Payload: for<'de> Deserialize<'de>> JWT<Payload> {
                 .header("Authorization", format!("Bearer {jwt_2}"));
             let res = t.oneshot(req).await;
             assert_eq!(res.status(), Status::OK);
-            assert_eq!(res.json::<Profile>().unwrap().unwrap(), Profile {
+            assert_eq!(res.json::<Profile>().unwrap(), Profile {
                 id:           2,
                 first_name:   String::from("Leonhard"),
                 familly_name: String::from("Euler"),
@@ -718,7 +718,7 @@ impl<Payload: for<'de> Deserialize<'de>> JWT<Payload> {
                 .header("Authorization", format!("Bearer {jwt_1}"));
             let res = t.oneshot(req).await;
             assert_eq!(res.status(), Status::OK);
-            assert_eq!(res.json::<Profile>().unwrap().unwrap(), Profile {
+            assert_eq!(res.json::<Profile>().unwrap(), Profile {
                 id:           1,
                 first_name:   String::from("ohkami"),
                 familly_name: String::from("framework"),

--- a/ohkami/src/testing/mod.rs
+++ b/ohkami/src/testing/mod.rs
@@ -221,14 +221,12 @@ impl TestResponse {
                 bytes.escape_ascii()
             )))
     }
-    pub fn json<'d, T: serde::Deserialize<'d>>(&'d self) -> Option<Result<T, serde_json::Error>> {
+    pub fn json<'d, T: serde::Deserialize<'d>>(&'d self) -> Option<T> {
         self.content("application/json")
-            .map(|bytes| serde_json::from_slice(bytes)
-                // .expect(&f!(
-                //     "Failed to deserialize json payload as {}: {}",
-                //     std::any::type_name::<T>(),
-                //     bytes.escape_ascii()
-                // ))
-            )
+            .map(|bytes| serde_json::from_slice(bytes).expect(&f!(
+                "Failed to deserialize json payload as {}: {}",
+                std::any::type_name::<T>(),
+                bytes.escape_ascii()
+            )))
     }
 }

--- a/samples/realworld/src/_test.rs
+++ b/samples/realworld/src/_test.rs
@@ -101,7 +101,7 @@ pub async fn senario() {
 
     let UserResponse {
         user: User { email, jwt, name, bio, image }
-    } = res.json().unwrap().unwrap();
+    } = res.json().unwrap();
 
     assert_eq!(email, "jake@jake.jake");
     assert_eq!(name,  "Jacob");
@@ -119,7 +119,7 @@ pub async fn senario() {
 
     let UserResponse {
         user: User { email, jwt, name, bio, image }
-    } = res.json().unwrap().unwrap();
+    } = res.json().unwrap();
 
     assert_eq!(email, "jake@jake.jake");
     assert_eq!(name, "Jacob");
@@ -145,7 +145,7 @@ pub async fn senario() {
 
     let UserResponse {
         user: User { email, jwt, name, bio, image }
-    } = res.json().unwrap().unwrap();
+    } = res.json().unwrap();
 
     assert_eq!(email, "jake@jake.jake");
     assert_eq!(name,  "Jacob");
@@ -160,7 +160,7 @@ pub async fn senario() {
     let res = t.oneshot(req).await;
 
     assert_eq!(res.status(), Status::OK);
-    assert_eq!(res.json::<ListOfTagsResponse>().unwrap().unwrap(), ListOfTagsResponse {
+    assert_eq!(res.json::<ListOfTagsResponse>().unwrap(), ListOfTagsResponse {
         tags: Vec::new()
     });
 
@@ -181,7 +181,7 @@ pub async fn senario() {
 
     assert_eq!(res.status(), Status::Created);
 
-    let SingleArticleResponse { article } = res.json().unwrap().unwrap();
+    let SingleArticleResponse { article } = res.json().unwrap();
 
     assert_eq!(article.title,           "How to train your dragon");
     assert_eq!(article.slug,            "How-to-train-your-dragon");
@@ -204,7 +204,7 @@ pub async fn senario() {
     let res = t.oneshot(req).await;
 
     assert_eq!(res.status(), Status::OK);
-    assert_eq!(res.json::<ListOfTagsResponse>().unwrap().unwrap(), ListOfTagsResponse {
+    assert_eq!(res.json::<ListOfTagsResponse>().unwrap(), ListOfTagsResponse {
         tags: vec![Tag::new("reactjs"), Tag::new("angularjs"), Tag::new("dragons")]
     });
 


### PR DESCRIPTION
instead of returning the `Result`, useless in testing situation, call `.expect("...")` to panic immediately