### PR TITLE
dx: make `WARNING!` print `[ohkami:WARNING]`, not `[ohkami:WARNS]`

### DIFF
--- a/ohkami/src/util.rs
+++ b/ohkami/src/util.rs
@@ -34,7 +34,7 @@ macro_rules! INFO {
 macro_rules! WARNING {
     ( $( $t:tt )* ) => {{
         $crate::eprintln!(
-            "[ohkami:WARNS] {}",
+            "[ohkami:WARNING] {}",
             format_args!($($t)*)
         );
     }};


### PR DESCRIPTION
`WANRS` is for unify the length of logs as `[ohkami:ERROR]` and `[ohkami:DEBUG]`, but that's meaningless ingenuity. Just `[ohkami:WARNING]` will be better at readability for developers and processablity for common analysis tools.