### PR TITLE
fix(session): revise default timeout config

### DIFF
--- a/ohkami/src/config.rs
+++ b/ohkami/src/config.rs
@@ -46,7 +46,7 @@ impl Config {
                 .ok()
                 .map(|v| v.parse().ok())
                 .flatten()
-                .unwrap_or(42)
+                .unwrap_or(30) // 30 seconds
             ),
 
             #[cfg(feature="__rt_native__")]
@@ -55,7 +55,7 @@ impl Config {
                 .ok()
                 .map(|v| v.parse().ok())
                 .flatten()
-                .unwrap_or(42)
+                .unwrap_or(1 * 60 * 60) // 1 hour
             ),
         }
     }

--- a/ohkami/src/session/mod.rs
+++ b/ohkami/src/session/mod.rs
@@ -78,7 +78,7 @@ impl<C: Connection> Session<C> {
                 None => {
                     crate::DEBUG!("\
                         Reached Keep-Alive timeout. In Ohkami, Keep-Alive timeout \
-                        is set to 42 seconds by default and is configurable \
+                        is set to 30 seconds by default and is configurable \
                         by `OHKAMI_KEEPALIVE_TIMEOUT` environment variable.\
                     ");
                     break Upgrade::None;


### PR DESCRIPTION
- fix default websocket timeout ( was malformed to `42` at some time in past... ) to `1 * 60 * 60`
- fix default keep-alive timeout from `42` to `30` for better behavior in more cases