### PR TITLE
rename(headers): follow Rust's naming convention

### DIFF
--- a/examples/hello/src/main.rs
+++ b/examples/hello/src/main.rs
@@ -68,8 +68,7 @@ mod fangs {
     pub struct SetServer;
     impl FangAction for SetServer {
         fn back<'a>(&'a self, res: &'a mut Response) -> impl std::future::Future<Output = ()> + Send {
-            res.headers.set()
-                .Server("ohkami");
+            res.headers.set().server("ohkami");
 
             tracing::info!("\
                 Called `SetServer`\n\

--- a/examples/html_layout/src/main.rs
+++ b/examples/html_layout/src/main.rs
@@ -31,7 +31,7 @@ impl Layout {
 
         impl FangAction for Fang {
             async fn back(&self, res: &mut Response) {
-                if res.headers.ContentType().is_some_and(|x| x.starts_with("text/html")) {
+                if res.headers.content_type().is_some_and(|x| x.starts_with("text/html")) {
                     let content = res.drop_content().into_bytes().unwrap();
                     let content = std::str::from_utf8(&*content).unwrap();
                     res.set_html(uibeam::shoot(UI! {

--- a/ohkami/src/fang/builtin/basicauth.rs
+++ b/ohkami/src/fang/builtin/basicauth.rs
@@ -69,14 +69,14 @@ where
 const _: () = {
     fn unauthorized() -> Response {
         Response::Unauthorized().with_headers(|h|h
-            .WWWAuthenticate("Basic realm=\"Secure Area\"")
+            .www_authenticate("Basic realm=\"Secure Area\"")
         )
     }
 
     #[inline]
     fn basic_credential_of(req: &Request) -> Result<String, Response> {
         (|| crate::util::base64_decode_utf8(
-            req.headers.Authorization()?.strip_prefix("Basic ")?
+            req.headers.authorization()?.strip_prefix("Basic ")?
         ).ok())().ok_or_else(unauthorized)
     }
 

--- a/ohkami/src/fang/builtin/enamel.rs
+++ b/ohkami/src/fang/builtin/enamel.rs
@@ -32,7 +32,7 @@
 ///     )).howl("localhost:4040").await
 /// }
 /// ```
-pub struct Enamel(
+pub struct Enamel(// clone in `Fang::chain`
     std::sync::Arc<EnamelFields>
 );
 #[allow(non_snake_case)]
@@ -124,30 +124,29 @@ const _: () = {
 
     impl Enamel {
         fn apply(&self, res: &mut crate::Response) {
-            let mut h = res.headers.set();
             if let Some(csp) = &self.0.content_security_policy {
-                h = h.ContentSecurityPolicy(csp.build());
+                res.headers.set().content_security_policy(csp.build());
             }
             if let Some(csp) = &self.0.content_security_policy_report_only {
-                h = h.ContentSecurityPolicyReportOnly(csp.build());
+                res.headers.set().content_security_policy_report_only(csp.build());
             }
             if !self.0.cross_origin_embedder_policy.is_empty() {
-                h = h.CrossOriginEmbedderPolicy(self.0.cross_origin_embedder_policy);
+                res.headers.set().cross_origin_embedder_policy(self.0.cross_origin_embedder_policy);
             }
             if !self.0.corss_origin_resource_policy.is_empty() {
-                h = h.CrossOriginResourcePolicy(self.0.corss_origin_resource_policy);
+                res.headers.set().cross_origin_resource_policy(self.0.corss_origin_resource_policy);
             }
             if !self.0.referrer_policy.is_empty() {
-                h = h.ReferrerPolicy(self.0.referrer_policy);
+                res.headers.set().referrer_policy(self.0.referrer_policy);
             }
             if !self.0.strict_transport_security.is_empty() {
-                h = h.StrictTransportSecurity(self.0.strict_transport_security);
+                res.headers.set().strict_transport_security(self.0.strict_transport_security);
             }
             if !self.0.x_content_type_options.is_empty() {
-                h = h.XContentTypeOptions(self.0.x_content_type_options);
+                res.headers.set().x_content_type_options(self.0.x_content_type_options);
             }
             if !self.0.x_frame_options.is_empty() {
-                h.XFrameOptions(self.0.x_frame_options);
+                res.headers.set().x_frame_options(self.0.x_frame_options);
             }
         }
     }

--- a/ohkami/src/fang/builtin/jwt.rs
+++ b/ohkami/src/fang/builtin/jwt.rs
@@ -171,7 +171,7 @@ impl<Payload> Jwt<Payload> {
 
     /// Customize get-token process in JWT verifying.
     /// 
-    /// *default*: `req.headers.Authorization()?.strip_prefix("Bearer ")`
+    /// *default*: `req.headers.authorization()?.strip_prefix("Bearer ")`
     pub fn get_token_by(
         mut self,
         get_token: fn(&Request)->Option<&str>,
@@ -198,7 +198,7 @@ impl<Payload> Jwt<Payload> {
     fn new(alg: VerifyingAlgorithm, secret: impl Into<Cow<'static, str>>) -> Self {
         #[inline(always)]
         fn get_token(req: &Request) -> Option<&str> {
-            req.headers.Authorization()?.strip_prefix("Bearer ")
+            req.headers.authorization()?.strip_prefix("Bearer ")
         }
 
         Self {

--- a/ohkami/src/fang/handler/mod.rs
+++ b/ohkami/src/fang/handler/mod.rs
@@ -84,25 +84,27 @@ impl Handler {
         }
     }
 
-    pub(crate) fn default_options_with(mut available_methods: Vec<&'static str>) -> Self {
+    pub(crate) fn default_options_with(available_methods: Vec<&'static str>) -> Self {
         let available_methods: &'static [&'static str] = {
-            if available_methods.contains(&"GET") {
-                available_methods.push("HEAD")
+            let mut methods = available_methods;
+            if methods.contains(&"GET") {
+                methods.push("HEAD")
             }
-            available_methods.push("OPTIONS");
-            available_methods
+            methods.push("OPTIONS");
+            methods
         }.leak();
 
         let available_methods_str: &'static str =
             available_methods.join(", ").leak();
 
+        /* see `fang::Cors` for more detail about what to do here */
         Handler::new(move |req| {
             Box::pin(async move {
                 #[cfg(debug_assertions)] {
                     assert_eq!(req.method, crate::Method::OPTIONS);
                 }
 
-                match req.headers.AccessControlRequestMethod() {
+                match req.headers.access_control_request_method() {
                     Some(method) => {
                         /*
                             Ohkami, by default, does nothing more than setting
@@ -116,7 +118,7 @@ impl Handler {
                         } else {
                             crate::Response::BadRequest()
                         }).with_headers(|h| h
-                            .AccessControlAllowMethods(available_methods_str)
+                            .access_control_allow_methods(available_methods_str)
                         )
                     }
                     None => {
@@ -127,7 +129,7 @@ impl Handler {
                             ```
                             crate::Response::NoContent()
                                 .with_headers(|h| h
-                                    .Allow(available_methods_str)
+                                    .allow(available_methods_str)
                                 )
                             ```
                         */

--- a/ohkami/src/header/append.rs
+++ b/ohkami/src/header/append.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 
 pub struct Append(pub(crate) Cow<'static, str>);
 
-/// Passed to `{Request/Response}.headers.set().Name( 〜 )` and
+/// Passed to `{Request/Response}.headers.set().{name}( 〜 )` and
 /// append `value` to the header.
 /// 
 /// Here appended values are combined by `,`.
@@ -18,8 +18,7 @@ pub struct Append(pub(crate) Cow<'static, str>);
 /// struct AppendServer(&'static str);
 /// impl FangAction for AppendServer {
 ///     async fn back<'b>(&'b self, res: &'b mut Response) {
-///         res.headers.set()
-///             .Server(append(self.0));
+///         res.headers.set().server(append(self.0));
 ///     }
 /// }
 /// 

--- a/ohkami/src/request/_test_headers.rs
+++ b/ohkami/src/request/_test_headers.rs
@@ -11,14 +11,14 @@ use crate::header::append;
     let mut h = RequestHeaders::new();
 
     h.append(RequestHeader::Origin, CowSlice::from("A".as_bytes()));
-    assert_eq!(h.Origin(), Some("A"));
+    assert_eq!(h.origin(), Some("A"));
     h.append(RequestHeader::Origin, CowSlice::from("B".as_bytes()));
-    assert_eq!(h.Origin(), Some("A, B"));
+    assert_eq!(h.origin(), Some("A, B"));
 
-    h.set().Accept(append("X"));
-    assert_eq!(h.Accept(), Some("X"));
-    h.set().Accept(append("Y"));
-    assert_eq!(h.Accept(), Some("X, Y"));
+    h.set().accept(append("X"));
+    assert_eq!(h.accept(), Some("X"));
+    h.set().accept(append("Y"));
+    assert_eq!(h.accept(), Some("X, Y"));
 }
 
 #[test] fn append_custom_header() {

--- a/ohkami/src/request/from_request.rs
+++ b/ohkami/src/request/from_request.rs
@@ -232,7 +232,7 @@ impl<'req, B: FromBody<'req>> FromRequest<'req> for B {
             Response::BadRequest().with_text(msg.to_string())
         }
 
-        if req.headers.ContentType()?.starts_with(B::MIME_TYPE) {
+        if req.headers.content_type()?.starts_with(B::MIME_TYPE) {
             Some(B::from_body(req.payload()?).map_err(reject))
         } else {
             None

--- a/ohkami/src/request/headers.rs
+++ b/ohkami/src/request/headers.rs
@@ -120,7 +120,7 @@ pub trait CustomHeadersAction<'set> {
 };
 
 macro_rules! Header {
-    ($N:literal; $( $konst:ident: $name_bytes:literal | $lower_case:literal $(| $other_pattern:literal)* , )*) => {
+    ($N:literal; $( $method:ident($konst:ident): $name_bytes:literal | $lower_case:literal $(| $other_pattern:literal)* , )*) => {
         pub(crate) const N_CLIENT_HEADERS: usize = $N;
         const _: [Header; N_CLIENT_HEADERS] = [$(Header::$konst),*];
 
@@ -159,15 +159,16 @@ macro_rules! Header {
         impl<'set> SetHeaders<'set> {
             $(
                 #[inline(always)]
-                pub fn $konst(self, action: impl HeaderAction<'set>) -> Self {
+                pub fn $method(self, action: impl HeaderAction<'set>) -> Self {
                     action.perform(self, Header::$konst)
+                }
+
+                #[deprecated = "Use snake_case method instead"]
+                pub fn $konst(self, action: impl HeaderAction<'set>) -> Self {
+                    self.$method(action)
                 }
             )*
 
-            #[deprecated = "use `.x` instead"]
-            pub fn custom(self, name: &'static str, action: impl CustomHeadersAction<'set>) -> Self {
-                self.x(name, action)
-            }
             pub fn x(self, name: &'static str, action: impl CustomHeadersAction<'set>) -> Self {
                 if self.0.custom.is_none() {
                     self.0.custom = Some(Box::new(TupleMap::new()));
@@ -184,15 +185,16 @@ macro_rules! Header {
                 /// Multiple values are conbined into a comma-separated string, that can be iterated just by `.split(", ")`,\
                 /// except for `Cookie` that by semicolon (see `Cookies` helper method).
                 #[inline(always)]
-                pub fn $konst(&self) -> Option<&str> {
+                pub fn $method(&self) -> Option<&str> {
                     self.get_standard(Header::$konst)
+                }
+
+                #[deprecated = "Use snake_case method instead"]
+                pub fn $konst(&self) -> Option<&str> {
+                    self.$method()
                 }
             )*
 
-            #[deprecated = "use `.get` instead"]
-            pub fn custom(&self, name: &str) -> Option<&str> {
-                self.get(name)
-            }
             pub fn get(&self, name: &str) -> Option<&str> {
                 let value = self.custom.as_ref()?
                     .get(&Slice::from_bytes(name.as_bytes()))
@@ -217,52 +219,52 @@ macro_rules! Header {
         }
     };
 } Header! {46;
-    Accept:                      b"Accept" | b"accept",
-    AcceptEncoding:              b"Accept-Encoding" | b"accept-encoding",
-    AcceptLanguage:              b"Accept-Language" | b"accept-language",
-    AccessControlRequestHeaders: b"Access-Control-Request-Headers" | b"access-control-request-headers",
-    AccessControlRequestMethod:  b"Access-Control-Request-Method" | b"access-control-request-method",
-    Authorization:               b"Authorization" | b"authorization",
-    CacheControl:                b"Cache-Control" | b"cache-control",
-    Connection:                  b"Connection" | b"connection",
-    ContentDisposition:          b"Content-Disposition" | b"content-disposition",
-    ContentEncoding:             b"Content-Encoding" | b"content-encoding",
-    ContentLanguage:             b"Content-Language" | b"content-language",
-    ContentLength:               b"Content-Length" | b"content-length",
-    ContentLocation:             b"Content-Location" | b"content-location",
-    ContentType:                 b"Content-Type" | b"content-type",
-    Cookie:                      b"Cookie" | b"cookie",
-    Date:                        b"Date" | b"date",
-    Expect:                      b"Expect" | b"expect",
-    Forwarded:                   b"Forwarded" | b"forwarded",
-    From:                        b"From" | b"from",
-    Host:                        b"Host" | b"host",
-    IfMatch:                     b"If-Match" | b"if-match",
-    IfModifiedSince:             b"If-Modified-Since" | b"if-modified-since",
-    IfNoneMatch:                 b"If-None-Match" | b"if-none-match",
-    IfRange:                     b"If-Range" | b"if-range",
-    IfUnmodifiedSince:           b"If-Unmodified-Since" | b"if-unmodified-since",
-    Link:                        b"Link" | b"link",
-    MaxForwards:                 b"Max-Forwards" | b"max-forwards",
-    Origin:                      b"Origin" | b"origin",
-    ProxyAuthorization:          b"Proxy-Authorization" | b"proxy-authorization",
-    Range:                       b"Range" | b"range",
-    Referer:                     b"Referer" | b"referer",
-    SecFetchDest:                b"Sec-Fetch-Dest" | b"sec-fetch-dest",
-    SecFetchMode:                b"Sec-Fetch-Mode" | b"sec-fetch-mode",
-    SecFetchSite:                b"Sec-Fetch-Site" | b"sec-fetch-site",
-    SecFetchUser:                b"Sec-Fetch-User" | b"sec-fetch-user",
-    SecWebSocketExtensions:      b"Sec-WebSocket-Extensions" | b"sec-websocket-extensions",
-    SecWebSocketKey:             b"Sec-WebSocket-Key" | b"sec-websocket-key",
-    SecWebSocketProtocol:        b"Sec-WebSocket-Protocol" | b"sec-websocket-protocol",
-    SecWebSocketVersion:         b"Sec-WebSocket-Version" | b"sec-websocket-version",
-    TE:                          b"TE" | b"te",
-    Trailer:                     b"Trailer" | b"trailer",
-    TransferEncoding:            b"Transfer-Encoding" | b"transfer-encoding",
-    UserAgent:                   b"User-Agent" | b"user-agent",
-    Upgrade:                     b"Upgrade" | b"upgrade",
-    UpgradeInsecureRequests:     b"Upgrade-Insecure-Requests" | b"upgrade-insecure-requests",
-    Via:                         b"Via" | b"via",
+    accept(Accept): b"Accept" | b"accept",
+    accept_encoding(AcceptEncoding): b"Accept-Encoding" | b"accept-encoding",
+    accept_language(AcceptLanguage): b"Accept-Language" | b"accept-language",
+    access_control_request_headers(AccessControlRequestHeaders): b"Access-Control-Request-Headers" | b"access-control-request-headers",
+    access_control_request_method(AccessControlRequestMethod): b"Access-Control-Request-Method" | b"access-control-request-method",
+    authorization(Authorization): b"Authorization" | b"authorization",
+    cache_control(CacheControl): b"Cache-Control" | b"cache-control",
+    connection(Connection): b"Connection" | b"connection",
+    content_disposition(ContentDisposition): b"Content-Disposition" | b"content-disposition",
+    content_encoding(ContentEncoding): b"Content-Encoding" | b"content-encoding",
+    content_laguage(ContentLanguage): b"Content-Language" | b"content-language",
+    content_length(ContentLength): b"Content-Length" | b"content-length",
+    content_location(ContentLocation): b"Content-Location" | b"content-location",
+    content_type(ContentType): b"Content-Type" | b"content-type",
+    cookie(Cookie): b"Cookie" | b"cookie",
+    date(Date): b"Date" | b"date",
+    expect(Expect): b"Expect" | b"expect",
+    forwarded(Forwarded): b"Forwarded" | b"forwarded",
+    from(From): b"From" | b"from",
+    host(Host): b"Host" | b"host",
+    if_match(IfMatch): b"If-Match" | b"if-match",
+    if_modified_since(IfModifiedSince): b"If-Modified-Since" | b"if-modified-since",
+    if_none_match(IfNoneMatch): b"If-None-Match" | b"if-none-match",
+    if_range(IfRange): b"If-Range" | b"if-range",
+    if_unmodified_since(IfUnmodifiedSince): b"If-Unmodified-Since" | b"if-unmodified-since",
+    link(Link): b"Link" | b"link",
+    max_forwards(MaxForwards): b"Max-Forwards" | b"max-forwards",
+    origin(Origin): b"Origin" | b"origin",
+    proxy_authorization(ProxyAuthorization): b"Proxy-Authorization" | b"proxy-authorization",
+    range(Range): b"Range" | b"range",
+    referer(Referer): b"Referer" | b"referer",
+    sec_fetch_dest(SecFetchDest): b"Sec-Fetch-Dest" | b"sec-fetch-dest",
+    sec_fetch_mode(SecFetchMode): b"Sec-Fetch-Mode" | b"sec-fetch-mode",
+    sec_fetch_site(SecFetchSite): b"Sec-Fetch-Site" | b"sec-fetch-site",
+    sec_fetch_user(SecFetchUser): b"Sec-Fetch-User" | b"sec-fetch-user",
+    sec_websocket_extensions(SecWebSocketExtensions): b"Sec-WebSocket-Extensions" | b"sec-websocket-extensions",
+    sec_websocket_key(SecWebSocketKey): b"Sec-WebSocket-Key" | b"sec-websocket-key",
+    sec_websocket_protocol(SecWebSocketProtocol): b"Sec-WebSocket-Protocol" | b"sec-websocket-protocol",
+    sec_websocket_version(SecWebSocketVersion): b"Sec-WebSocket-Version" | b"sec-websocket-version",
+    te(TE): b"TE" | b"te",
+    trailer(Trailer): b"Trailer" | b"trailer",
+    transfer_encoding(TransferEncoding): b"Transfer-Encoding" | b"transfer-encoding",
+    user_agent(UserAgent): b"User-Agent" | b"user-agent",
+    upgrade(Upgrade): b"Upgrade" | b"upgrade",
+    upgrade_insecure_requests(UpgradeInsecureRequests): b"Upgrade-Insecure-Requests" | b"upgrade-insecure-requests",
+    via(Via): b"Via" | b"via",
 }
 
 #[allow(non_snake_case)]
@@ -272,7 +274,7 @@ impl Headers {
     /// 
     /// internally uses [`ohkami::util::iter_cookies`](crate::util::iter_cookies).
     pub fn Cookies(&self) -> impl Iterator<Item = (&str, &str)> {
-        self.Cookie().map(crate::util::iter_cookies).into_iter().flatten()
+        self.cookie().map(crate::util::iter_cookies).into_iter().flatten()
     }
 
     pub(crate) fn iter(&self) -> impl Iterator<Item = (&str, &str)> {
@@ -288,7 +290,7 @@ impl Headers {
                     std::str::from_utf8(unsafe {v.as_bytes()}).expect("Header value is not UTF-8"),
                 )))
             )
-            .chain(self.Cookie().map(|c| ("Cookie", c)))
+            .chain(self.cookie().map(|c| ("Cookie", c)))
     }
 }
 

--- a/ohkami/src/request/mod.rs
+++ b/ohkami/src/request/mod.rs
@@ -135,8 +135,8 @@ pub struct Request {
 
     /// Headers of this request
     /// 
-    /// - `.{Name}()`, `.get("{Name}")` to get value
-    /// - `.set().{Name}({action})`, `.set().x("{Name}", {action})` to mutate values
+    /// - `.{name}()`, `.get("{name}")` to get value
+    /// - `.set().{name}({action})`, `.set().x("{name}", {action})` to mutate values
     /// 
     /// `{action}`:
     /// - just `{value}` to insert
@@ -502,7 +502,7 @@ impl Request {
 
         self.headers = req.headers;
         if !req.cookies.is_empty() {
-            self.headers.set().Cookie(req.cookies.join("; "));
+            self.headers.set().cookie(req.cookies.join("; "));
         }
 
         if let Some(body) = req.body {

--- a/ohkami/src/response/_test.rs
+++ b/ohkami/src/response/_test.rs
@@ -8,7 +8,7 @@ macro_rules! assert_response_bytes_eq {
             $res.complete();
 
             /* avoid flakiness of 1 sec difference */
-            let now = $res.headers.Date()
+            let now = $res.headers.date()
                 .expect("No `Date` header in res")
                 .to_string(/* `$res` moves by `.send` */);
 
@@ -41,7 +41,7 @@ fn test_response_into_bytes() {
     ");
 
     let mut res = Response::NoContent();
-    res.headers.set().Server("ohkami");
+    res.headers.set().server("ohkami");
     assert_response_bytes_eq!(res, "\
         HTTP/1.1 204 No Content\r\n\
         Date: {NOW}\r\n\
@@ -59,7 +59,7 @@ fn test_response_into_bytes() {
 
     let mut res = Response::NotFound();
     res.headers.set()
-        .Server("ohkami")
+        .server("ohkami")
         .x("Hoge-Header", "Something-Custom");
     assert_response_bytes_eq!(res, "\
         HTTP/1.1 404 Not Found\r\n\
@@ -72,10 +72,10 @@ fn test_response_into_bytes() {
 
     let mut res = Response::NotFound();
     res.headers.set()
-        .Server("ohkami")
+        .server("ohkami")
         .x("Hoge-Header", "Something-Custom")
-        .SetCookie("id", "42", |d|d.Path("/").SameSiteLax())
-        .SetCookie("name", "John", |d|d.Path("/where").SameSiteStrict());
+        .set_cookie("id", "42", |d|d.path("/").same_site_lax())
+        .set_cookie("name", "John", |d|d.path("/where").same_site_strict());
     assert_response_bytes_eq!(res, "\
         HTTP/1.1 404 Not Found\r\n\
         Date: {NOW}\r\n\
@@ -89,10 +89,10 @@ fn test_response_into_bytes() {
 
     let mut res = Response::NotFound().with_text("sample text");
     res.headers.set()
-        .Server("ohkami")
+        .server("ohkami")
         .x("Hoge-Header", "Something-Custom")
-        .SetCookie("id", "42", |d|d.Path("/").SameSiteLax())
-        .SetCookie("name", "John", |d|d.Path("/where").SameSiteStrict());
+        .set_cookie("id", "42", |d|d.path("/").same_site_lax())
+        .set_cookie("name", "John", |d|d.path("/where").same_site_strict());
     assert_response_bytes_eq!(res, "\
         HTTP/1.1 404 Not Found\r\n\
         Date: {NOW}\r\n\
@@ -143,9 +143,9 @@ fn test_stream_response() {
             repeat_by(3, |i| format!("This is message#{i} !"))
         )
         .with_headers(|h| h
-            .Server("ohkami")
+            .server("ohkami")
             .x("is-stream", "true")
-            .SetCookie("name", "John", |d|d.Path("/where").SameSiteStrict())
+            .set_cookie("name", "John", |d|d.path("/where").same_site_strict())
         );
     assert_response_bytes_eq!(res, "\
         HTTP/1.1 200 OK\r\n\
@@ -178,8 +178,8 @@ fn test_stream_response() {
             repeat_by(3, |i| format!("This is message#{i}\nです"))
         )
         .with_headers(|h| h
-            .Server("ohkami")
-            .SetCookie("name", "John", |d|d.Path("/where").SameSiteStrict())
+            .server("ohkami")
+            .set_cookie("name", "John", |d|d.path("/where").same_site_strict())
             .x("is-stream", "true")
         );
     assert_response_bytes_eq!(res, "\

--- a/ohkami/src/response/_test_headers.rs
+++ b/ohkami/src/response/_test_headers.rs
@@ -12,7 +12,7 @@ macro_rules! headers_dump {
 
 #[test] fn insert_and_write() {
     let mut h = ResponseHeaders::new();
-    h.set().Server("A");
+    h.set().server("A");
     {
         let mut buf = Vec::new();
         h._write_to(&mut buf);
@@ -25,9 +25,9 @@ macro_rules! headers_dump {
     }
 
     let mut h = ResponseHeaders::new();
-    h.set().Server("A").ContentType("application/json");
-    h.set().Server("B").ContentLength("100");
-    h.set().ContentType("text/html").ContentLength("42");
+    h.set().server("A").content_type("application/json");
+    h.set().server("B").content_length("100");
+    h.set().content_type("text/html").content_length("42");
     {
         let mut buf = Vec::new();
         h._write_to(&mut buf);
@@ -44,8 +44,8 @@ macro_rules! headers_dump {
 #[test] fn append_header() {
     let mut h = ResponseHeaders::new();
 
-    h.set().Server(append("X"));
-    assert_eq!(h.Server(), Some("X"));
+    h.set().server(append("X"));
+    assert_eq!(h.server(), Some("X"));
     {
         let mut buf = Vec::new();
         h._write_to(&mut buf);
@@ -57,8 +57,8 @@ macro_rules! headers_dump {
         "));
     }
 
-    h.set().Server(append("Y"));
-    assert_eq!(h.Server(), Some("X, Y"));
+    h.set().server(append("Y"));
+    assert_eq!(h.server(), Some("X, Y"));
     {
         let mut buf = Vec::new();
         h._write_to(&mut buf);
@@ -103,44 +103,44 @@ macro_rules! headers_dump {
 
 #[test] fn parse_setcookie_headers() {
     let mut h = ResponseHeaders::new();
-    h.set().SetCookie("id", "42", |d|d.Path("/").SameSiteLax().Secure());
-    assert_eq!(h.SetCookie().collect::<Vec<_>>(), [
+    h.set().set_cookie("id", "42", |d|d.path("/").same_site_lax().secure(true));
+    assert_eq!(h.set_cookie().collect::<Vec<_>>(), [
         SetCookie {
-            Cookie:   ("id", "42".into()),
-            Expires:  None,
-            MaxAge:   None,
-            Domain:   None,
-            Path:     Some("/".into()),
-            Secure:   Some(true),
-            HttpOnly: None,
-            SameSite: Some(SameSitePolicy::Lax),
+            cookie:   ("id", "42".into()),
+            expires:  None,
+            max_age:   None,
+            domain:   None,
+            path:     Some("/".into()),
+            secure:   Some(true),
+            http_only: None,
+            same_site: Some(SameSitePolicy::Lax),
         }
     ]);
 
     let mut h = ResponseHeaders::new();
     h.set()
-        .SetCookie("id", "10", |d|d.Path("/").SameSiteLax().Secure())
-        .SetCookie("id", "42", |d|d.MaxAge(1280).HttpOnly().Path("/where").SameSiteLax().Secure());
-    assert_eq!(h.SetCookie().collect::<Vec<_>>(), [
+        .set_cookie("id", "10", |d|d.path("/").same_site_lax().secure(true))
+        .set_cookie("id", "42", |d|d.max_age(1280).http_only().path("/where").same_site_lax().secure(true));
+    assert_eq!(h.set_cookie().collect::<Vec<_>>(), [
         SetCookie {
-            Cookie:   ("id", "10".into()),
-            Expires:  None,
-            MaxAge:   None,
-            Domain:   None,
-            Path:     Some("/".into()),
-            Secure:   Some(true),
-            HttpOnly: None,
-            SameSite: Some(SameSitePolicy::Lax),
+            cookie:   ("id", "10".into()),
+            expires:  None,
+            max_age:   None,
+            domain:   None,
+            path:     Some("/".into()),
+            secure:   Some(true),
+            http_only: None,
+            same_site: Some(SameSitePolicy::Lax),
         },
         SetCookie {
-            Cookie:   ("id", "42".into()),
-            Expires:  None,
-            MaxAge:   Some(1280),
-            Domain:   None,
-            Path:     Some("/where".into()),
-            Secure:   Some(true),
-            HttpOnly: Some(true),
-            SameSite: Some(SameSitePolicy::Lax),
+            cookie:   ("id", "42".into()),
+            expires:  None,
+            max_age:   Some(1280),
+            domain:   None,
+            path:     Some("/where".into()),
+            secure:   Some(true),
+            http_only: Some(true),
+            same_site: Some(SameSitePolicy::Lax),
         },
     ]);
 }

--- a/ohkami/src/response/headers.rs
+++ b/ohkami/src/response/headers.rs
@@ -13,8 +13,10 @@ pub struct Headers {
 
 pub struct SetHeaders<'set>(
     &'set mut Headers
-); impl Headers {
-    #[inline] pub fn set(&mut self) -> SetHeaders<'_> {
+);
+impl Headers {
+    #[inline]
+    pub fn set(&mut self) -> SetHeaders<'_> {
         SetHeaders(self)
     }
 }
@@ -107,7 +109,7 @@ pub trait CustomHeadersAction<'action> {
 };
 
 macro_rules! Header {
-    ($N:literal; $( $konst:ident: $name_bytes:literal, )*) => {
+    ($N:literal; $( $method:ident($konst:ident): $name_bytes:literal, )*) => {
         pub(crate) const N_SERVER_HEADERS: usize = $N;
         const _: [Header; N_SERVER_HEADERS] = [$(Header::$konst),*];
 
@@ -153,8 +155,13 @@ macro_rules! Header {
         impl<'set> SetHeaders<'set> {
             $(
                 #[inline]
-                pub fn $konst(self, action: impl HeaderAction<'set>) -> Self {
+                pub fn $method(self, action: impl HeaderAction<'set>) -> Self {
                     action.perform(self, Header::$konst)
+                }
+
+                #[deprecated = "Use snake_case method instead"]
+                pub fn $konst(self, action: impl HeaderAction<'set>) -> Self {
+                    self.$method(action)
                 }
             )*
 
@@ -172,8 +179,13 @@ macro_rules! Header {
         impl Headers {
             $(
                 #[inline]
-                pub fn $konst(&self) -> Option<&str> {
+                pub fn $method(&self) -> Option<&str> {
                     self.get_standard(Header::$konst)
+                }
+
+                #[deprecated = "Use snake_case method instead"]
+                pub fn $konst(&self) -> Option<&str> {
+                    self.$method()
                 }
             )*
 
@@ -189,60 +201,60 @@ macro_rules! Header {
         }
     };
 } Header! {48;
-    AcceptRanges:                    b"Accept-Ranges",
-    AccessControlAllowCredentials:   b"Access-Control-Allow-Credentials",
-    AccessControlAllowHeaders:       b"Access-Control-Allow-Headers",
-    AccessControlAllowMethods:       b"Access-Control-Allow-Methods",
-    AccessControlAllowOrigin:        b"Access-Control-Allow-Origin",
-    AccessControlExposeHeaders:      b"Access-Control-Expose-Headers",
-    AccessControlMaxAge:             b"Access-Control-Max-Age",
-    Age:                             b"Age",
-    Allow:                           b"Allow",
-    AltSvc:                          b"Alt-Svc",
-    CacheControl:                    b"Cache-Control",
-    CacheStatus:                     b"Cache-Status",
-    CDNCacheControl:                 b"CDN-Cache-Control",
-    Connection:                      b"Connection",
-    ContentDisposition:              b"Content-Disposition",
-    ContentEncoding:                 b"Content-Encoding",
-    ContentLanguage:                 b"Content-Language",
-    ContentLength:                   b"Content-Length",
-    ContentLocation:                 b"Content-Location",
-    ContentRange:                    b"Content-Range",
-    ContentSecurityPolicy:           b"Content-Security-Policy",
-    ContentSecurityPolicyReportOnly: b"Content-Security-Policy-Report-Only",
-    ContentType:                     b"Content-Type",
-    CrossOriginEmbedderPolicy:       b"Cross-Origin-Embedder-Policy",
-    CrossOriginResourcePolicy:       b"Cross-Origin-Resource-Policy",
-    Date:                            b"Date",
-    ETag:                            b"ETag",
-    Expires:                         b"Expires",
-    Link:                            b"Link",
-    Location:                        b"Location",
-    LastModified:                    b"Last-Modified",
-    ProxyAuthenticate:               b"Proxy-Authenticate",
-    ReferrerPolicy:                  b"Referrer-Policy",
-    Refresh:                         b"Refresh",
-    RetryAfter:                      b"Retry-After",
-    SecWebSocketAccept:              b"Sec-WebSocket-Accept",
-    SecWebSocketProtocol:            b"Sec-WebSocket-Protocol",
-    SecWebSocketVersion:             b"Sec-WebSocket-Version",
-    Server:                          b"Server",
-    StrictTransportSecurity:         b"Strict-Transport-Security",
-    Trailer:                         b"Trailer",
-    TransferEncoding:                b"Transfer-Encoding",
-    Upgrade:                         b"Upgrade",
-    Vary:                            b"Vary",
-    Via:                             b"Via",
-    XContentTypeOptions:             b"X-Content-Type-Options",
-    XFrameOptions:                   b"X-Frame-Options",
-    WWWAuthenticate:                 b"WWW-Authenticate",
+    accept_ranges(AcceptRanges): b"Accept-Ranges",
+    access_control_allow_credentials(AccessControlAllowCredentials): b"Access-Control-Allow-Credentials",
+    access_control_allow_headers(AccessControlAllowHeaders): b"Access-Control-Allow-Headers",
+    access_control_allow_methods(AccessControlAllowMethods): b"Access-Control-Allow-Methods",
+    access_control_allow_origin(AccessControlAllowOrigin): b"Access-Control-Allow-Origin",
+    access_control_expose_headers(AccessControlExposeHeaders): b"Access-Control-Expose-Headers",
+    access_control_max_age(AccessControlMaxAge): b"Access-Control-Max-Age",
+    age(Age): b"Age",
+    allow(Allow): b"Allow",
+    alt_svc(AltSvc): b"Alt-Svc",
+    cache_control(CacheControl): b"Cache-Control",
+    cache_status(CacheStatus): b"Cache-Status",
+    cdn_cache_control(CDNCacheControl): b"CDN-Cache-Control",
+    connection(Connection): b"Connection",
+    content_dispotision(ContentDisposition): b"Content-Disposition",
+    content_encoding(ContentEncoding): b"Content-Encoding",
+    content_language(ContentLanguage): b"Content-Language",
+    content_length(ContentLength): b"Content-Length",
+    content_location(ContentLocation): b"Content-Location",
+    content_range(ContentRange): b"Content-Range",
+    content_security_policy(ContentSecurityPolicy): b"Content-Security-Policy",
+    content_security_policy_report_only(ContentSecurityPolicyReportOnly): b"Content-Security-Policy-Report-Only",
+    content_type(ContentType): b"Content-Type",
+    cross_origin_embedder_policy(CrossOriginEmbedderPolicy): b"Cross-Origin-Embedder-Policy",
+    cross_origin_resource_policy(CrossOriginResourcePolicy): b"Cross-Origin-Resource-Policy",
+    date(Date): b"Date",
+    etag(ETag): b"ETag",
+    expires(Expires): b"Expires",
+    link(Link): b"Link",
+    location(Location): b"Location",
+    last_modified(LastModified): b"Last-Modified",
+    proxy_authenticate(ProxyAuthenticate): b"Proxy-Authenticate",
+    referrer_policy(ReferrerPolicy): b"Referrer-Policy",
+    refresh(Refresh): b"Refresh",
+    retry_after(RetryAfter): b"Retry-After",
+    sec_websocket_accept(SecWebSocketAccept): b"Sec-WebSocket-Accept",
+    sec_websocket_protocol(SecWebSocketProtocol): b"Sec-WebSocket-Protocol",
+    sec_websocket_version(SecWebSocketVersion): b"Sec-WebSocket-Version",
+    server(Server): b"Server",
+    strict_transport_security(StrictTransportSecurity): b"Strict-Transport-Security",
+    trailer(Trailer): b"Trailer",
+    transfer_encoding(TransferEncoding): b"Transfer-Encoding",
+    upgrade(Upgrade): b"Upgrade",
+    vary(Vary): b"Vary",
+    via(Via): b"Via",
+    x_content_type_options(XContentTypeOptions): b"X-Content-Type-Options",
+    x_frame_options(XFrameOptions): b"X-Frame-Options",
+    www_authenticate(WWWAuthenticate): b"WWW-Authenticate",
 }
 
 const _: () = {
     #[allow(non_snake_case)]
     impl Headers {
-        pub fn SetCookie(&self) -> impl Iterator<Item = SetCookie<'_>> {
+        pub fn set_cookie(&self) -> impl Iterator<Item = SetCookie<'_>> {
             self.setcookie.as_ref().map(|setcookies|
                 setcookies.iter().filter_map(|raw| match SetCookie::from_raw(raw) {
                     Ok(valid) => Some(valid),
@@ -273,13 +285,13 @@ const _: () = {
         /// 
         /// fn mutate_header(res: &mut Response) {
         ///     res.headers.set()
-        ///         .Server("ohkami")
-        ///         .SetCookie("id", "42", |d|d.Path("/").SameSiteStrict())
-        ///         .SetCookie("name", "John", |d|d.Path("/where").SameSiteLax());
+        ///         .server("ohkami")
+        ///         .set_cookie("id", "42", |d|d.path("/").same_site_strict())
+        ///         .set_cookie("name", "John", |d|d.path("/where").same_site_lax());
         /// }
         /// ```
         #[inline]
-        pub fn SetCookie(self,
+        pub fn set_cookie(self,
             name:  &'static str,
             value: impl Into<Cow<'static, str>>,
             directives: impl FnOnce(SetCookieBuilder)->SetCookieBuilder
@@ -427,8 +439,8 @@ impl Headers {
         };
 
         this.set()
-            .Date(ohkami_lib::imf_fixdate(crate::util::unix_timestamp()))
-            .ContentLength("0");
+            .date(ohkami_lib::imf_fixdate(crate::util::unix_timestamp()))
+            .content_length("0");
 
         this
     }

--- a/ohkami/src/session/mod.rs
+++ b/ohkami/src/session/mod.rs
@@ -86,7 +86,7 @@ impl<C: Connection> Session<C> {
                 Some(result) => {
                     match result {
                         Ok(Some(())) => {
-                            let close = matches!(req.headers.Connection(), Some("close" | "Close"));
+                            let close = matches!(req.headers.connection(), Some("close" | "Close"));
 
                             let res = match catch_unwind(AssertUnwindSafe({
                                 let req = req.as_mut();

--- a/ohkami/src/testing/mod.rs
+++ b/ohkami/src/testing/mod.rs
@@ -197,12 +197,12 @@ impl TestResponse {
     }
 
     pub fn content(&self, content_type: &'static str) -> Option<&[u8]> {
-        let _= self.0.headers.ContentType()?.starts_with(content_type)
+        let _= self.0.headers.content_type()?.starts_with(content_type)
             .then_some(())?;
         let bytes = self.0.content.as_bytes()?;
         assert_eq!(
             bytes.len(),
-            self.0.headers.ContentLength()?.parse::<usize>().unwrap(),
+            self.0.headers.content_length()?.parse::<usize>().unwrap(),
             "Content-Length does not match the actual content length"
         );
         Some(bytes)

--- a/ohkami/src/typed/header.rs
+++ b/ohkami/src/typed/header.rs
@@ -36,7 +36,7 @@ const _: () = {
 };
 
 macro_rules! typed_header {
-    ($( $Name:ident : $key:literal ),* $(,)?) => {$(
+    ($( $method:ident($Name:ident) : $key:literal ),* $(,)?) => {$(
         /// Extract the request header value as an type implementing
         /// [`FromHeader<'_>`](crate::typed::header::FromHeader) trait
         /// ( By default, `&str` and `String` implement it ) .
@@ -74,7 +74,7 @@ macro_rules! typed_header {
             type Error = <Value as FromHeader<'req>>::Error;
 
             fn from_request(req: &'req Request) -> Option<Result<Self, Self::Error>> {
-                let raw = req.headers.$Name()?;
+                let raw = req.headers.$method()?;
                 Some(Value::from_header(raw).map(Self))
             }
 
@@ -98,52 +98,52 @@ macro_rules! typed_header {
     )*};
 }
 typed_header! {
-    Accept:                      "Accept",
-    AcceptEncoding:              "Accept-Encoding",
-    AcceptLanguage:              "Accept-Language",
-    AccessControlRequestHeaders: "Access-Control-Request-Headers",
-    AccessControlRequestMethod:  "Access-Control-Request-Method",
-    Authorization:               "Authorization",
-    CacheControl:                "Cache-Control",
-    Connection:                  "Connection",
-    ContentDisposition:          "Content-Disposition",
-    ContentEncoding:             "Content-Encoding",
-    ContentLanguage:             "Content-Language",
-    ContentLength:               "Content-Length",
-    ContentLocation:             "Content-Location",
-    ContentType:                 "Content-Type",
-    /* Cookie:                      "Cookie", // specialize */
-    Date:                        "Date",
-    Expect:                      "Expect",
-    Forwarded:                   "Forwarded",
-    From:                        "From",
-    Host:                        "Host",
-    IfMatch:                     "If-Match",
-    IfModifiedSince:             "If-Modified-Since",
-    IfNoneMatch:                 "If-None-Match",
-    IfRange:                     "If-Range",
-    IfUnmodifiedSince:           "If-Unmodified-Since",
-    Link:                        "Link",
-    MaxForwards:                 "Max-Forwards",
-    Origin:                      "Origin",
-    ProxyAuthorization:          "Proxy-Authorization",
-    Range:                       "Range",
-    Referer:                     "Referer",
-    SecFetchDest:                "Sec-Fetch-Dest",
-    SecFetchMode:                "Sec-Fetch-Mode",
-    SecFetchSite:                "Sec-Fetch-Site",
-    SecFetchUser:                "Sec-Fetch-User",
-    SecWebSocketExtensions:      "Sec-WebSocket-Extensions",
-    SecWebSocketKey:             "Sec-WebSocket-Key",
-    SecWebSocketProtocol:        "Sec-WebSocket-Protocol",
-    SecWebSocketVersion:         "Sec-WebSocket-Version",
-    TE:                          "TE",
-    Trailer:                     "Trailer",
-    TransferEncoding:            "Transfer-Encoding",
-    UserAgent:                   "User-Agent",
-    Upgrade:                     "Upgrade",
-    UpgradeInsecureRequests:     "Upgrade-Insecure-Requests",
-    Via:                         "Via",
+    accept(Accept): "Accept",
+    accept_encoding(AcceptEncoding): "Accept-Encoding",
+    accept_language(AcceptLanguage): "Accept-Language",
+    access_control_request_headers(AccessControlRequestHeaders): "Access-Control-Request-Headers",
+    access_control_request_method(AccessControlRequestMethod): "Access-Control-Request-Method",
+    authorization(Authorization): "Authorization",
+    cache_control(CacheControl): "Cache-Control",
+    connection(Connection): "Connection",
+    content_disposition(ContentDisposition): "Content-Disposition",
+    content_encoding(ContentEncoding): "Content-Encoding",
+    content_laguage(ContentLanguage): "Content-Language",
+    content_length(ContentLength): "Content-Length",
+    content_location(ContentLocation): "Content-Location",
+    content_type(ContentType): "Content-Type",
+    /* cookie(Cookie): "Cookie", : specialize later... */
+    date(Date): "Date",
+    expect(Expect): "Expect",
+    forwarded(Forwarded): "Forwarded",
+    from(From): "From",
+    host(Host): "Host",
+    if_match(IfMatch): "If-Match",
+    if_modified_since(IfModifiedSince): "If-Modified-Since",
+    if_none_match(IfNoneMatch): "If-None-Match",
+    if_range(IfRange): "If-Range",
+    if_unmodified_since(IfUnmodifiedSince): "If-Unmodified-Since",
+    link(Link): "Link",
+    max_forwards(MaxForwards): "Max-Forwards",
+    origin(Origin): "Origin",
+    proxy_authorization(ProxyAuthorization): "Proxy-Authorization",
+    range(Range): "Range",
+    referer(Referer): "Referer",
+    sec_fetch_dest(SecFetchDest): "Sec-Fetch-Dest",
+    sec_fetch_mode(SecFetchMode): "Sec-Fetch-Mode",
+    sec_fetch_site(SecFetchSite): "Sec-Fetch-Site",
+    sec_fetch_user(SecFetchUser): "Sec-Fetch-User",
+    sec_websocket_extensions(SecWebSocketExtensions): "Sec-WebSocket-Extensions",
+    sec_websocket_key(SecWebSocketKey): "Sec-WebSocket-Key",
+    sec_websocket_protocol(SecWebSocketProtocol): "Sec-WebSocket-Protocol",
+    sec_websocket_version(SecWebSocketVersion): "Sec-WebSocket-Version",
+    te(TE): "TE",
+    trailer(Trailer): "Trailer",
+    transfer_encoding(TransferEncoding): "Transfer-Encoding",
+    user_agent(UserAgent): "User-Agent",
+    upgrade(Upgrade): "Upgrade",
+    upgrade_insecure_requests(UpgradeInsecureRequests): "Upgrade-Insecure-Requests",
+    via(Via): "Via",
 }
 
 /// Extract `Cookie` header value and parse to a type implementing `Deserialize<'_>`.
@@ -188,7 +188,8 @@ impl<'req, Fields: crate::format::bound::Incoming<'req>> FromRequest<'req> for C
     type Error = crate::typed::status::Unauthorized<String>;
 
     fn from_request(req: &'req Request) -> Option<Result<Self, Self::Error>> {
-        req.headers.Cookie().map(|raw| ohkami_lib::serde_cookie::from_str::<Fields>(raw)
+        req.headers.cookie()
+            .map(|raw| ohkami_lib::serde_cookie::from_str::<Fields>(raw)
             .map(Cookie)
             .map_err(|e| crate::typed::status::Unauthorized(format!(
                 "missing or invalid Cookie: {e}"

--- a/ohkami/src/typed/status.rs
+++ b/ohkami/src/typed/status.rs
@@ -57,8 +57,8 @@ macro_rules! generate_statuses_as_types_containing_value {
 
                     let mut headers = self.headers;
                     headers.set()
-                        .ContentType(B::CONTENT_TYPE)
-                        .ContentLength(ohkami_lib::num::itoa(body.len()));
+                        .content_type(B::CONTENT_TYPE)
+                        .content_length(ohkami_lib::num::itoa(body.len()));
                     
                     Response {
                         status: Status::$status,
@@ -185,7 +185,7 @@ macro_rules! generate_redirects {
             impl $status {
                 pub fn $contructor(location: impl Into<::std::borrow::Cow<'static, str>>) -> Self {
                     let mut headers = ResponseHeaders::new();
-                    headers.set().Location(location.into());
+                    headers.set().location(location.into());
                     Self { headers }
                 }
 
@@ -241,15 +241,15 @@ mod test {
         assert_eq!(
             Created("Hello, world!")
                 .with_headers(|h| h
-                    .Server("ohkami")
-                    .Vary("origin")
+                    .server("ohkami")
+                    .vary("origin")
                 )
                 .into_response(),
             Response::Created()
                 .with_text("Hello, world!")
                 .with_headers(|h| h
-                    .Server("ohkami")
-                    .Vary("origin")
+                    .server("ohkami")
+                    .vary("origin")
                 )
         );
     }
@@ -261,20 +261,20 @@ mod test {
                 .into_response(),
             Response::Found()
                 .with_headers(|h| h
-                    .Location("https://example.com")
+                    .location("https://example.com")
                 )
         );
 
         assert_eq!(
             Found::at("https://example.com")
                 .with_headers(|h| h
-                    .Server("ohkami")
+                    .server("ohkami")
                 )
                 .into_response(),
             Response::Found()
                 .with_headers(|h| h
-                    .Location("https://example.com")
-                    .Server("ohkami")
+                    .location("https://example.com")
+                    .server("ohkami")
                 )
         );
     }

--- a/ohkami/src/ws/mod.rs
+++ b/ohkami/src/ws/mod.rs
@@ -43,17 +43,17 @@ impl<'req> crate::FromRequest<'req> for WebSocketContext<'req> {
 
     #[inline]
     fn from_request(req: &'req crate::Request) -> Option<Result<Self, Self::Error>> {
-        if !matches!(req.headers.Connection()?, "Upgrade" | "upgrade") {
+        if !matches!(req.headers.connection()?, "Upgrade" | "upgrade") {
             return Some(Err((|| crate::Response::BadRequest().with_text("upgrade request must have `Connection: Upgrade`"))()))
         }
-        if !(req.headers.Upgrade()?.eq_ignore_ascii_case("websocket")) {
+        if !(req.headers.upgrade()?.eq_ignore_ascii_case("websocket")) {
             return Some(Err((|| crate::Response::BadRequest().with_text("upgrade request must have `Upgrade: websocket`"))()))
         }
-        if !(req.headers.SecWebSocketVersion()? == "13") {
+        if !(req.headers.sec_websocket_version()? == "13") {
             return Some(Err((|| crate::Response::BadRequest().with_text("upgrade request must have `Sec-WebSocket-Version: 13`"))()))
         }
 
-        req.headers.SecWebSocketKey().map(|sec_websocket_key|
+        req.headers.sec_websocket_key().map(|sec_websocket_key|
             Ok(Self { sec_websocket_key })
         )
     }

--- a/ohkami/src/ws/native.rs
+++ b/ohkami/src/ws/native.rs
@@ -119,9 +119,9 @@ impl crate::IntoResponse for WebSocket {
         let mut res = crate::Response::SwitchingProtocols();
         res.content = crate::response::Content::WebSocket(self.session);
         res.with_headers(|h|h
-            .Connection("Upgrade")
-            .Upgrade("websocket")
-            .SecWebSocketAccept(self.sign)
+            .connection("Upgrade")
+            .upgrade("websocket")
+            .sec_websocket_accept(self.sign)
         )
     }
 

--- a/samples/realworld/src/fangs.rs
+++ b/samples/realworld/src/fangs.rs
@@ -19,7 +19,7 @@ impl Auth {
 }
 impl FangAction for Auth {
     async fn fore<'a>(&'a self, req: &'a mut Request) -> Result<(), Response> {
-        if req.headers.Authorization().is_none() && self.optional {
+        if req.headers.authorization().is_none() && self.optional {
             return Ok(());
         }
 

--- a/samples/realworld/src/handlers.rs
+++ b/samples/realworld/src/handlers.rs
@@ -15,11 +15,11 @@ pub fn realworld_ohkami(
         "/api".By(Ohkami::new((
             Logger,
             Context::new(pool),
-            "/users"   .By(users::users_ohkami()),
-            "/user"    .By(user::user_ohkami()),
+            "/users".By(users::users_ohkami()),
+            "/user".By(user::user_ohkami()),
             "/profiles".By(profiles::profiles_ohkami()),
             "/articles".By(articles::articles_ohkami()),
-            "/tags"    .By(tags::tags_ohkami()),
+            "/tags".By(tags::tags_ohkami()),
         ))
     ))
 }

--- a/samples/worker-with-openapi/src/fang.rs
+++ b/samples/worker-with-openapi/src/fang.rs
@@ -24,7 +24,7 @@ struct TokenSchema<'req> {
 impl FangAction for TokenAuth {
     async fn fore<'a>(&'a self, req: &'a mut Request) -> Result<(), Response> {
         let authorization_bearer = req.headers
-            .Authorization().ok_or_else(Response::BadRequest)?
+            .authorization().ok_or_else(Response::BadRequest)?
             .strip_prefix("Bearer ").ok_or_else(Response::BadRequest)?;
 
         let TokenSchema { user_id, token } =


### PR DESCRIPTION
This PR partially resolves #376 around headers as #485 did around fang/format: rename all `.PascalCase()` header method names into `.snake_case()`.

Considering users' rewriting cost, this remains `.PascalCase` methods with `#[deprecated = "Use snake_case method instead"]`. They will be removed in v0.25.