### PR TITLE
rename(openapi): follow Rust's naming convention

### DIFF
--- a/ohkami/src/fang/builtin/basicauth.rs
+++ b/ohkami/src/fang/builtin/basicauth.rs
@@ -99,7 +99,7 @@ const _: () = {
         #[cfg(feature="openapi")]
         fn openapi_map_operation(&self, operation: openapi::Operation) -> openapi::Operation {
             use openapi::security::SecurityScheme;
-            operation.security(SecurityScheme::Basic("basicAuth"), &[])
+            operation.security(SecurityScheme::basic("basicAuth"), &[])
         }
     }
 
@@ -124,7 +124,7 @@ const _: () = {
         #[cfg(feature="openapi")]
         fn openapi_map_operation(&self, operation: openapi::Operation) -> openapi::Operation {
             use openapi::security::SecurityScheme;
-            operation.security(SecurityScheme::Basic("basicAuth"), &[])
+            operation.security(SecurityScheme::basic("basicAuth"), &[])
         }
     }
 };

--- a/ohkami/src/fang/builtin/jwt.rs
+++ b/ohkami/src/fang/builtin/jwt.rs
@@ -209,7 +209,7 @@ impl<Payload> Jwt<Payload> {
             secret: secret.into(),
 
             #[cfg(feature="openapi")]
-            openapi_security: crate::openapi::security::SecurityScheme::Bearer(
+            openapi_security: crate::openapi::security::SecurityScheme::bearer(
                 "jwtAuth",
                 Some("JWT")
             )

--- a/ohkami/src/fang/handler/into_handler.rs
+++ b/ohkami/src/fang/handler/into_handler.rs
@@ -58,7 +58,7 @@ fn with_default_operation_id<F>(op: openapi::Operation) -> openapi::Operation {
     if type_ident == "{{closure}}" {
         op
     } else {
-        op.operationId(type_ident)
+        op.operation_id(type_ident)
     }
 }
 

--- a/ohkami/src/router/final.rs
+++ b/ohkami/src/router/final.rs
@@ -122,7 +122,7 @@ impl Router {
                 for param_name in &openapi_path_param_names {
                     operation.assign_path_param_name(param_name.to_string());
                 }
-                for security_scheme in operation.iter_securitySchemes() {
+                for security_scheme in operation.iter_security_schemes() {
                     doc.register_securityScheme_component(security_scheme);
                 }
                 for schema_component in operation.refize_schemas() {

--- a/ohkami_macros/src/openapi.rs
+++ b/ohkami_macros/src/openapi.rs
@@ -577,7 +577,7 @@ pub(super) fn operation(meta: TokenStream, handler: TokenStream) -> syn::Result<
                 },
                 DescriptionTarget::RequestBody => {
                     quote! {
-                        op = op.requestBody_description(#value);
+                        op = op.requestbody_description(#value);
                     }
                 },
                 DescriptionTarget::DefaultResponse => {

--- a/ohkami_macros/src/openapi.rs
+++ b/ohkami_macros/src/openapi.rs
@@ -303,7 +303,7 @@ pub(super) fn derive_schema(input: TokenStream) -> syn::Result<TokenStream> {
                 }
 
                 Ok(quote! {
-                    ::ohkami::openapi::array(::ohkami::openapi::oneOf(
+                    ::ohkami::openapi::array(::ohkami::openapi::one_of(
                         (#(#type_schemas,)*)
                     ))
                 })
@@ -436,7 +436,7 @@ pub(super) fn derive_schema(input: TokenStream) -> syn::Result<TokenStream> {
             }
 
             Ok(quote! {
-                ::ohkami::openapi::oneOf(
+                ::ohkami::openapi::one_of(
                     ( #(#variant_schemas,)* )
                 )
             })
@@ -447,7 +447,7 @@ pub(super) fn derive_schema(input: TokenStream) -> syn::Result<TokenStream> {
 pub(super) fn operation(meta: TokenStream, handler: TokenStream) -> syn::Result<TokenStream> {
     #[allow(non_snake_case)]
     struct OperationMeta {
-        operationId:  Option<String>,
+        operation_id:  Option<String>,
         descriptions: Vec<DescriptionOverride>,
     }
 
@@ -514,7 +514,7 @@ pub(super) fn operation(meta: TokenStream, handler: TokenStream) -> syn::Result<
     impl syn::parse::Parse for OperationMeta {
         fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
             #[allow(non_snake_case)]
-            let operationId = input.peek(Ident)
+            let operation_id = input.peek(Ident)
                 .then(|| input.parse::<Ident>().map(|i| i.to_string()))
                 .transpose()?;
 
@@ -529,7 +529,7 @@ pub(super) fn operation(meta: TokenStream, handler: TokenStream) -> syn::Result<
                 .unwrap_or_default();
 
 
-            Ok(Self { operationId, descriptions })
+            Ok(Self { operation_id, descriptions })
         }
     }
 
@@ -554,12 +554,12 @@ pub(super) fn operation(meta: TokenStream, handler: TokenStream) -> syn::Result<
     let modify_op = {
         let mut modify_op = TokenStream::new();
 
-        let operation_id = match meta.operationId {
+        let operation_id = match meta.operation_id {
             Some(operation_id) => LitStr::new(&operation_id, Span::call_site()),
             None => LitStr::new(&handler.sig.ident.to_string(), handler.sig.ident.span())
         };
         modify_op.extend(quote! {
-            op = op.operationId(#operation_id);
+            op = op.operation_id(#operation_id);
         });
 
         if let Some(description) = extract_doc_comment(&handler.attrs) {

--- a/ohkami_openapi/src/document.rs
+++ b/ohkami_openapi/src/document.rs
@@ -75,13 +75,14 @@ impl Server {
 #[derive(Serialize, Clone)]
 pub struct Components {
     #[serde(skip_serializing_if = "Map::is_empty")]
-    schemas:         Map<&'static str, RawSchema>,
+    schemas: Map<&'static str, RawSchema>,
     #[serde(skip_serializing_if = "Map::is_empty")]
-    securitySchemes: Map<&'static str, SecurityScheme>,
+    #[serde(rename = "securitySchemes")]
+    security_schemes: Map<&'static str, SecurityScheme>,
 }
 impl Components {
     fn is_empty(&self) -> bool {
-        self.schemas.is_empty() && self.securitySchemes.is_empty()
+        self.schemas.is_empty() && self.security_schemes.is_empty()
     }
 }
 
@@ -96,7 +97,7 @@ impl Document {
             info:       Info { title, version, description:None },
             servers:    servers.into(),
             paths:      Paths::new(),
-            components: Components { schemas:Map::new(), securitySchemes:Map::new() }
+            components: Components { schemas:Map::new(), security_schemes:Map::new() }
         }
     }
 
@@ -122,10 +123,10 @@ impl Document {
     }
     #[doc(hidden)]
     pub fn register_securityScheme_component(&mut self, securityScheme: SecurityScheme) {
-        match self.components.securitySchemes.get(&securityScheme.__name__) {
+        match self.components.security_schemes.get(&securityScheme.__name__) {
             Some(it) if *it == securityScheme => return,
-            Some(_) => panic!("[OpenAPI] `components.securitySchemes`: contradict registrations of multiple `{}`s", securityScheme.__name__),
-            None => self.components.securitySchemes.insert(securityScheme.__name__, securityScheme),
+            Some(_) => panic!("[OpenAPI] `components.security_schemes`: contradict registrations of multiple `{}`s", securityScheme.__name__),
+            None => self.components.security_schemes.insert(securityScheme.__name__, securityScheme),
         }
     }
 }

--- a/ohkami_openapi/src/lib.rs
+++ b/ohkami_openapi/src/lib.rs
@@ -50,14 +50,14 @@ pub fn array(items: impl Into<schema::SchemaRef>) -> schema::Schema<schema::Type
 pub fn object() -> schema::Schema<schema::Type::object> {
     schema::Schema::object()
 }
-pub fn anyOf(schemas: impl schema::SchemaList) -> schema::Schema<schema::Type::any> {
-    schema::Schema::anyOf(schemas)
+pub fn any_of(schemas: impl schema::SchemaList) -> schema::Schema<schema::Type::any> {
+    schema::Schema::any_of(schemas)
 }
-pub fn allOf(schemas: impl schema::SchemaList) -> schema::Schema<schema::Type::any> {
-    schema::Schema::allOf(schemas)
+pub fn all_of(schemas: impl schema::SchemaList) -> schema::Schema<schema::Type::any> {
+    schema::Schema::all_of(schemas)
 }
-pub fn oneOf(schemas: impl schema::SchemaList) -> schema::Schema<schema::Type::any> {
-    schema::Schema::oneOf(schemas)
+pub fn one_of(schemas: impl schema::SchemaList) -> schema::Schema<schema::Type::any> {
+    schema::Schema::one_of(schemas)
 }
 
 pub trait Schema {

--- a/ohkami_openapi/src/paths.rs
+++ b/ohkami_openapi/src/paths.rs
@@ -27,7 +27,7 @@ pub struct Operation {
     description:  Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "externalDocs")]
-    external_cocs: Option<ExternalDoc>,
+    external_docs: Option<ExternalDoc>,
     #[serde(skip_serializing_if = "is_false")]
     deprecated: bool,
 
@@ -126,7 +126,7 @@ impl Operation {
             tags:         Vec::new(),
             summary:      None,
             description:  None,
-            external_cocs: None,
+            external_docs: None,
             deprecated:   false,
             parameters:   Vec::new(),
             requestbody:  None,
@@ -165,8 +165,8 @@ impl Operation {
         self.description = Some(description);
         self
     }
-    pub fn external_cocs(mut self, external_cocs: ExternalDoc) -> Self {
-        self.external_cocs = Some(external_cocs);
+    pub fn external_docs(mut self, external_docs: ExternalDoc) -> Self {
+        self.external_docs = Some(external_docs);
         self
     }
     pub fn deprecated(mut self) -> Self {

--- a/ohkami_openapi/src/paths.rs
+++ b/ohkami_openapi/src/paths.rs
@@ -16,7 +16,8 @@ pub struct Operations(
 #[derive(Serialize, Clone)]
 pub struct Operation {
     #[serde(skip_serializing_if = "Option::is_none")]
-    operationId: Option<&'static str>,
+    #[serde(rename = "operationId")]
+    operation_id: Option<&'static str>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     tags: Vec<&'static str>,
 
@@ -119,7 +120,7 @@ impl Operation {
     pub fn with(responses: Responses) -> Self {
         Self {
             responses,
-            operationId:  None,
+            operation_id: None,
             tags:         Vec::new(),
             summary:      None,
             description:  None,
@@ -146,8 +147,8 @@ impl Operation {
         self
     }
 
-    pub fn operationId(mut self, operationId: &'static str) -> Self {
-        self.operationId = Some(operationId);
+    pub fn operation_id(mut self, operation_id: &'static str) -> Self {
+        self.operation_id = Some(operation_id);
         self
     }
     pub fn with_tag(mut self, tag: &'static str) -> Self {
@@ -223,7 +224,7 @@ impl Operation {
     }
 
     #[doc(hidden)]
-    pub fn iter_securitySchemes(&self) -> impl Iterator<Item = SecurityScheme> {
+    pub fn iter_security_schemes(&self) -> impl Iterator<Item = SecurityScheme> {
         self.security.clone().into_iter()
             .map(|map| {
                 let [SecuritySchemeName(ss)] = map.clone()
@@ -248,7 +249,7 @@ impl Operation {
     #[allow(unused)]
     fn map_openapi_operation(op: Operation) -> Operation {
         op
-        .operationId("list_users")
+        .operation_id("list_users")
         .description("This doc comment is used for the\n`description` field of OpenAPI document")
         .summary("...")
         .response_description(200, "List of all users")

--- a/ohkami_openapi/src/paths.rs
+++ b/ohkami_openapi/src/paths.rs
@@ -26,6 +26,7 @@ pub struct Operation {
     #[serde(skip_serializing_if = "Option::is_none")]
     description:  Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "externalDocs")]
     external_cocs: Option<ExternalDoc>,
     #[serde(skip_serializing_if = "is_false")]
     deprecated: bool,

--- a/ohkami_openapi/src/paths.rs
+++ b/ohkami_openapi/src/paths.rs
@@ -26,7 +26,7 @@ pub struct Operation {
     #[serde(skip_serializing_if = "Option::is_none")]
     description:  Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    externalDocs: Option<ExternalDoc>,
+    external_cocs: Option<ExternalDoc>,
     #[serde(skip_serializing_if = "is_false")]
     deprecated: bool,
 
@@ -34,7 +34,8 @@ pub struct Operation {
     parameters: Vec<Parameter>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    requestBody: Option<RequestBody>,
+    #[serde(rename = "requestBody")]
+    requestbody: Option<RequestBody>,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
     security: Vec<Map<SecuritySchemeName, Vec<&'static str>>>,
@@ -124,10 +125,10 @@ impl Operation {
             tags:         Vec::new(),
             summary:      None,
             description:  None,
-            externalDocs: None,
+            external_cocs: None,
             deprecated:   false,
             parameters:   Vec::new(),
-            requestBody:  None,
+            requestbody:  None,
             security:     Vec::new(),
         }
     }
@@ -137,8 +138,8 @@ impl Operation {
         self
     }
 
-    pub fn requestBody(mut self, requestBody: RequestBody) -> Self {
-        self.requestBody = Some(requestBody);
+    pub fn requestbody(mut self, requestbody: RequestBody) -> Self {
+        self.requestbody = Some(requestbody);
         self
     }
 
@@ -163,8 +164,8 @@ impl Operation {
         self.description = Some(description);
         self
     }
-    pub fn externalDocs(mut self, externalDocs: ExternalDoc) -> Self {
-        self.externalDocs = Some(externalDocs);
+    pub fn external_cocs(mut self, external_cocs: ExternalDoc) -> Self {
+        self.external_cocs = Some(external_cocs);
         self
     }
     pub fn deprecated(mut self) -> Self {
@@ -176,7 +177,7 @@ impl Operation {
         match inbound {
             crate::Inbound::None => self,
             crate::Inbound::Security { scheme, scopes } => self.security(scheme, scopes),
-            crate::Inbound::Body(body) => self.requestBody(body),
+            crate::Inbound::Body(body) => self.requestbody(body),
             crate::Inbound::Param(param) => self.param(param),
             crate::Inbound::Params(params) => {
                 for param in params {self = self.param(param)}
@@ -195,12 +196,12 @@ impl Operation {
         }
         self
     }
-    pub fn requestBody_description(
+    pub fn requestbody_description(
         mut self,
         new_description: &'static str
     ) -> Self {
-        if let Some(requestBody) = &mut self.requestBody {
-            requestBody.set_description(new_description);
+        if let Some(requestbody) = &mut self.requestbody {
+            requestbody.set_description(new_description);
         }
         self
     }
@@ -239,7 +240,7 @@ impl Operation {
     pub fn refize_schemas(&mut self) -> impl Iterator<Item = RawSchema> + '_ {
         [/* RawSchema */].into_iter()
             .chain(self.parameters.iter_mut().map(|p| p.schema.refize()).flatten())
-            .chain(self.requestBody.as_mut().map(RequestBody::refize_schemas).into_iter().flatten())
+            .chain(self.requestbody.as_mut().map(RequestBody::refize_schemas).into_iter().flatten())
             .chain(self.responses.refize_schemas())
     }
 }

--- a/ohkami_openapi/src/schema.rs
+++ b/ohkami_openapi/src/schema.rs
@@ -42,11 +42,14 @@ pub struct RawSchema {
     #[serde(skip_serializing_if = "Option::is_none")]
     format: Option<&'static str>,
     #[serde(skip_serializing_if = "<[_]>::is_empty")]
-    anyOf: Vec<SchemaRef>,
+    #[serde(rename = "anyOf")]
+    any_of: Vec<SchemaRef>,
     #[serde(skip_serializing_if = "<[_]>::is_empty")]
-    allOf: Vec<SchemaRef>,
+    #[serde(rename = "allOf")]
+    all_of: Vec<SchemaRef>,
     #[serde(skip_serializing_if = "<[_]>::is_empty")]
-    oneOf: Vec<SchemaRef>,
+    #[serde(rename = "oneOf")]
+    one_of: Vec<SchemaRef>,
 
     /* metadata and flags */
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -62,9 +65,11 @@ pub struct RawSchema {
     #[serde(skip_serializing_if = "is_false")]
     nullable: bool,
     #[serde(skip_serializing_if = "is_false")]
-    readOnly: bool,
+    #[serde(rename = "readOnly")]
+    read_only: bool,
     #[serde(skip_serializing_if = "is_false")]
-    writeOnly: bool,
+    #[serde(rename = "writeOnly")]
+    write_only: bool,
 
     /* string definition */
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -80,31 +85,41 @@ pub struct RawSchema {
     #[serde(skip_serializing_if = "Option::is_none")]
     items: Option<SchemaRef>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    maxItems: Option<usize>,
+    #[serde(rename = "maxItems")]
+    max_items: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    minItems: Option<usize>,
+    #[serde(rename = "minItems")]
+    min_items: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    maxProperties: Option<usize>,
+    #[serde(rename = "maxProperties")]
+    max_properties: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    minProperties: Option<usize>,
+    #[serde(rename = "maxProperties")]
+    min_properties: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    maxLength: Option<usize>,
+    #[serde(rename = "maxLength")]
+    max_length: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    minLength: Option<usize>,
+    #[serde(rename = "maxLength")]
+    min_length: Option<usize>,
     #[serde(skip_serializing_if = "is_false")]
-    uniqueItems: bool,
+    #[serde(rename = "uniqueItems")]
+    unique_items: bool,
 
     /* number,integer definition */
     #[serde(skip_serializing_if = "Option::is_none")]
-    multipleOf: Option<f64>,
+    #[serde(rename = "multipleOf")]
+    multiple_of: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     maximum: Option<f64>,
     #[serde(skip_serializing_if = "is_false")]
-    exclusiveMaximum: bool,
+    #[serde(rename = "exclusiveMaximum")]
+    exclusive_maximum: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     minimum: Option<f64>,
     #[serde(skip_serializing_if = "is_false")]
-    exclusiveMinimum: bool,
+    #[serde(rename = "exclusiveMinimum")]
+    exclusive_minimum: bool,
 }
 impl<T: Type::SchemaType> From<Schema<T>> for RawSchema {
     fn from(schema: Schema<T>) -> Self {
@@ -174,9 +189,9 @@ impl SchemaRef {
         match self {
             SchemaRef::Inline(raw) => {
                 raw.properties.values_mut().for_each(|s| component_schemas.extend(s.refize()));
-                raw.anyOf.iter_mut().for_each(|s| component_schemas.extend(s.refize()));
-                raw.allOf.iter_mut().for_each(|s| component_schemas.extend(s.refize()));
-                raw.oneOf.iter_mut().for_each(|s| component_schemas.extend(s.refize()));
+                raw.any_of.iter_mut().for_each(|s| component_schemas.extend(s.refize()));
+                raw.all_of.iter_mut().for_each(|s| component_schemas.extend(s.refize()));
+                raw.one_of.iter_mut().for_each(|s| component_schemas.extend(s.refize()));
                 raw.items.as_mut().map(|s| component_schemas.extend(s.refize()));
                 if let Some(name) = raw.__name__ {
                     let raw = std::mem::replace(self, SchemaRef::Reference(name));
@@ -202,9 +217,9 @@ const _: (/* constructors */) = {
 
         datatype: Type::any::NAME,
         format: None,
-        anyOf: Vec::new(),
-        allOf: Vec::new(),
-        oneOf: Vec::new(),
+        any_of: Vec::new(),
+        all_of: Vec::new(),
+        one_of: Vec::new(),
 
         /* metadata and flags */
         description: None,
@@ -213,8 +228,8 @@ const _: (/* constructors */) = {
         enumerates:  Vec::new(),
         deprecated:  false,
         nullable:    false,
-        readOnly:    false,
-        writeOnly:   false,
+        read_only:    false,
+        write_only:   false,
 
         /* string definition */
         pattern: None,
@@ -225,20 +240,20 @@ const _: (/* constructors */) = {
 
         /* array definition */
         items:         None,
-        maxItems:      None,
-        minItems:      None,
-        maxProperties: None,
-        minProperties: None,
-        maxLength:     None,
-        minLength:     None,
-        uniqueItems:   false,
+        max_items:      None,
+        min_items:      None,
+        max_properties: None,
+        min_properties: None,
+        max_length:     None,
+        min_length:     None,
+        unique_items:   false,
 
         /* number,integer definition */
-        multipleOf:       None,
+        multiple_of:       None,
         maximum:          None,
-        exclusiveMaximum: false,
+        exclusive_maximum: false,
         minimum:          None,
-        exclusiveMinimum: false,
+        exclusive_minimum: false,
     };
 
     impl Schema<Type::string> {
@@ -294,29 +309,29 @@ const _: (/* constructors */) = {
         }
     }
     impl Schema<Type::any> {
-        pub fn anyOf(schemas: impl SchemaList) -> Self {
+        pub fn any_of(schemas: impl SchemaList) -> Self {
             Self {
                 datatype: PhantomData,
                 raw: RawSchema {
-                    anyOf: SchemaList::collect(schemas),
+                    any_of: SchemaList::collect(schemas),
                     ..ANY
                 }
             }
         }
-        pub fn allOf(schemas: impl SchemaList) -> Self {
+        pub fn all_of(schemas: impl SchemaList) -> Self {
             Self {
                 datatype: PhantomData,
                 raw: RawSchema {
-                    allOf: SchemaList::collect(schemas),
+                    all_of: SchemaList::collect(schemas),
                     ..ANY
                 }
             }
         }
-        pub fn oneOf(schemas: impl SchemaList) -> Self {
+        pub fn one_of(schemas: impl SchemaList) -> Self {
             Self {
                 datatype: PhantomData,
                 raw: RawSchema {
-                    oneOf: SchemaList::collect(schemas),
+                    one_of: SchemaList::collect(schemas),
                     ..ANY
                 }
             }
@@ -374,12 +389,12 @@ impl<T: Type::SchemaType> Schema<T> {
         self.raw.nullable = true;
         self
     }
-    pub fn readOnly(mut self) -> Self {
-        self.raw.readOnly = true;
+    pub fn read_only(mut self) -> Self {
+        self.raw.read_only = true;
         self
     }
-    pub fn writeOnly(mut self) -> Self {
-        self.raw.writeOnly = true;
+    pub fn write_only(mut self) -> Self {
+        self.raw.write_only = true;
         self
     }
 }
@@ -411,32 +426,32 @@ impl Schema<Type::object> {
 
 /* array definition */
 impl Schema<Type::array> {
-    pub fn maxItems(mut self, maxItems: usize) -> Self {
-        self.raw.maxItems = Some(maxItems);
+    pub fn max_items(mut self, max_items: usize) -> Self {
+        self.raw.max_items = Some(max_items);
         self
     }
-    pub fn minItems(mut self, minItems: usize) -> Self {
-        self.raw.minItems = Some(minItems);
+    pub fn min_items(mut self, min_items: usize) -> Self {
+        self.raw.min_items = Some(min_items);
         self
     }
-    pub fn maxProperties(mut self, maxProperties: usize) -> Self {
-        self.raw.maxProperties = Some(maxProperties);
+    pub fn max_properties(mut self, max_properties: usize) -> Self {
+        self.raw.max_properties = Some(max_properties);
         self
     }
-    pub fn minProperties(mut self, minProperties: usize) -> Self {
-        self.raw.minProperties = Some(minProperties);
+    pub fn min_properties(mut self, min_properties: usize) -> Self {
+        self.raw.min_properties = Some(min_properties);
         self
     }
-    pub fn maxLength(mut self, maxLength: usize) -> Self {
-        self.raw.maxLength = Some(maxLength);
+    pub fn max_length(mut self, max_length: usize) -> Self {
+        self.raw.max_length = Some(max_length);
         self
     }
-    pub fn minLength(mut self, minLength: usize) -> Self {
-        self.raw.minLength = Some(minLength);
+    pub fn min_length(mut self, min_length: usize) -> Self {
+        self.raw.min_length = Some(min_length);
         self
     }
-    pub fn uniqueItems(mut self) -> Self {
-        self.raw.uniqueItems = true;
+    pub fn unique_items(mut self) -> Self {
+        self.raw.unique_items = true;
         self
     }
 }
@@ -447,26 +462,26 @@ impl Schema<Type::number> {
         self.raw.format = Some(format);
         self
     }
-    pub fn multipleOf(mut self, n: impl Into<f64>) -> Self {
-        self.raw.multipleOf = Some(n.into());
+    pub fn multiple_of(mut self, n: impl Into<f64>) -> Self {
+        self.raw.multiple_of = Some(n.into());
         self
     }
     pub fn maximum(mut self, maximum: impl Into<f64>) -> Self {
         self.raw.maximum = Some(maximum.into());
         self
     }
-    pub fn exclusiveMaximum(mut self, maximum: impl Into<f64>) -> Self {
+    pub fn exclusive_maximum(mut self, maximum: impl Into<f64>) -> Self {
         self.raw.maximum = Some(maximum.into());
-        self.raw.exclusiveMaximum = true;
+        self.raw.exclusive_maximum = true;
         self
     }
     pub fn minimum(mut self, minimum: impl Into<f64>) -> Self {
         self.raw.minimum = Some(minimum.into());
         self
     }
-    pub fn exclusiveMinimum(mut self, minimum: impl Into<f64>) -> Self {
+    pub fn exclusive_minimum(mut self, minimum: impl Into<f64>) -> Self {
         self.raw.minimum = Some(minimum.into());
-        self.raw.exclusiveMinimum = true;
+        self.raw.exclusive_minimum = true;
         self
     }
 }
@@ -475,26 +490,26 @@ impl Schema<Type::integer> {
         self.raw.format = Some(format);
         self
     }
-    pub fn multipleOf(mut self, n: i32) -> Self {
-        self.raw.multipleOf = Some(n.into());
+    pub fn multiple_of(mut self, n: i32) -> Self {
+        self.raw.multiple_of = Some(n.into());
         self
     }
     pub fn maximum(mut self, maximum: i32) -> Self {
         self.raw.maximum = Some(maximum.into());
         self
     }
-    pub fn exclusiveMaximum(mut self, maximum: i32) -> Self {
+    pub fn exclusive_maximum(mut self, maximum: i32) -> Self {
         self.raw.maximum = Some(maximum.into());
-        self.raw.exclusiveMaximum = true;
+        self.raw.exclusive_maximum = true;
         self
     }
     pub fn minimum(mut self, minimum: i32) -> Self {
         self.raw.minimum = Some(minimum.into());
         self
     }
-    pub fn exclusiveMinimum(mut self, minimum: i32) -> Self {
+    pub fn exclusive_minimum(mut self, minimum: i32) -> Self {
         self.raw.minimum = Some(minimum.into());
-        self.raw.exclusiveMinimum = true;
+        self.raw.exclusive_minimum = true;
         self
     }
 }
@@ -502,7 +517,7 @@ impl Schema<Type::integer> {
 #[cfg(test)]
 fn __usability__() {
     let _user_schema = Schema::object()
-        .property("id", Schema::integer().readOnly())
+        .property("id", Schema::integer().read_only())
         .property("name", Schema::string())
         .optional("age", Schema::integer().minimum(18).maximum(120));
 }

--- a/ohkami_openapi/src/security.rs
+++ b/ohkami_openapi/src/security.rs
@@ -23,10 +23,12 @@ pub struct SecurityScheme {
     scheme: Option<&'static str>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    bearerFormat: Option<&'static str>,
+    #[serde(rename = "bearerFormat")]
+    bearer_format: Option<&'static str>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    openIdConnectUrl: Option<&'static str>,
+    #[serde(rename = "openIdConnectUrl")]
+    openidconnect_url: Option<&'static str>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     flows: Option<oauth2::OAuthFlow>,
@@ -156,46 +158,46 @@ mod oauth2 {
 }
 
 impl SecurityScheme {
-    pub fn Basic(scheme_name: &'static str) -> Self {
+    pub fn basic(scheme_name: &'static str) -> Self {
         Self {
             __name__:  scheme_name,
             auth_type: "http",
             scheme:    Some("basic"),
-            name:None, apikey_in:None, bearerFormat:None, openIdConnectUrl:None, flows:None, description:None
+            name:None, apikey_in:None, bearer_format:None, openidconnect_url:None, flows:None, description:None
         }
     }
-    pub fn Bearer(scheme_name: &'static str, token_format: Option<&'static str>) -> Self {
+    pub fn bearer(scheme_name: &'static str, token_format: Option<&'static str>) -> Self {
         Self {
             __name__:     scheme_name,
             auth_type:    "http",
             scheme:       Some("bearer"),
-            bearerFormat: token_format.into(),
-            name:None, apikey_in:None, openIdConnectUrl:None, flows:None, description:None
+            bearer_format: token_format.into(),
+            name:None, apikey_in:None, openidconnect_url:None, flows:None, description:None
         }
     }
-    pub fn OpenIDConnect(scheme_name: &'static str, url: &'static str) -> Self {
+    pub fn openidconnect(scheme_name: &'static str, url: &'static str) -> Self {
         Self {
             __name__:         scheme_name,
             auth_type:        "openIdConnect",
-            openIdConnectUrl: Some(url),
-            scheme:None, name:None, apikey_in:None, bearerFormat:None, flows:None, description:None
+            openidconnect_url: Some(url),
+            scheme:None, name:None, apikey_in:None, bearer_format:None, flows:None, description:None
         }
     }
-    pub fn APIKey(scheme_name: &'static str, APIKey { apikey_in, name }: APIKey) -> Self {
+    pub fn apikey(scheme_name: &'static str, APIKey { apikey_in, name }: APIKey) -> Self {
         Self {
             __name__:  scheme_name,
             auth_type: "apiKey",
             name:      Some(name),
             apikey_in: Some(apikey_in),
-            scheme:None, bearerFormat:None, openIdConnectUrl:None, flows:None, description:None
+            scheme:None, bearer_format:None, openidconnect_url:None, flows:None, description:None
         }
     }
-    pub fn OAuth2(scheme_name: &'static str, flow: impl Into<oauth2::OAuthFlow>) -> Self {
+    pub fn oauth2(scheme_name: &'static str, flow: impl Into<oauth2::OAuthFlow>) -> Self {
         Self {
             __name__:  scheme_name,
             auth_type: "oauth2",
             flows:     Some(flow.into()),
-            openIdConnectUrl: None, scheme:None, name:None, apikey_in:None, bearerFormat:None, description:None
+            openidconnect_url: None, scheme:None, name:None, apikey_in:None, bearer_format:None, description:None
         }
     }
 

--- a/ohkami_openapi/src/security.rs
+++ b/ohkami_openapi/src/security.rs
@@ -53,18 +53,24 @@ impl APIKey {
 
 #[derive(Serialize, Clone, PartialEq)]
 pub enum OAuthFlow {
-    authorizationCode {
-        authorizationUrl: &'static str,
-        tokenUrl:         &'static str,
+    #[serde(rename = "authorizationCode")]
+    AuthorizationCode {
+        #[serde(rename = "authorizationUrl")]
+        authorization_url: &'static str,
+        #[serde(rename = "tokenUrl")]
+        token_url:         &'static str,
     },
-    implicit {
-        authorizationUrl: &'static str,
+    #[serde(rename = "implicit")]
+    Implicit {
+        authorization_url: &'static str,
     },
-    password {
-        tokenUrl: &'static str,
+    #[serde(rename = "password")]
+    Password {
+        token_url: &'static str,
     },
-    clientCredentials {
-        tokenUrl: &'static str,
+    #[serde(rename = "clientCredentials")]
+    ClientCredentials {
+        token_url: &'static str,
     },
 }
 mod oauth2 {
@@ -73,28 +79,49 @@ mod oauth2 {
     #[derive(Serialize, Clone, PartialEq)]
     #[allow(private_interfaces)]
     pub enum OAuthFlow {
-        authorizationCode {
-            authorizationUrl: &'static str,
-            tokenUrl:         &'static str,
-            refreshUrl: Option<&'static str>, scopes: Map<&'static str, &'static str>
+        #[serde(rename = "authorizationCode")]
+        AuthorizationCode {
+            #[serde(rename = "authorizationUrl")]
+            authorization_url: &'static str,
+            #[serde(rename = "tokenUrl")]
+            token_url: &'static str,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            #[serde(rename = "refreshUrl")]
+            refresh_url: Option<&'static str>,
+            scopes: Map<&'static str, &'static str>
         },
-        implicit {
-            authorizationUrl: &'static str,
-            refreshUrl: Option<&'static str>, scopes: Map<&'static str, &'static str>
+        #[serde(rename = "implicit")]
+        Implicit {
+            #[serde(rename = "authorizationUrl")]
+            authorization_url: &'static str,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            #[serde(rename = "refreshUrl")]
+            refresh_url: Option<&'static str>,
+            scopes: Map<&'static str, &'static str>
         },
-        password {
-            tokenUrl: &'static str,
-            refreshUrl: Option<&'static str>, scopes: Map<&'static str, &'static str>
+        #[serde(rename = "password")]
+        Password {
+            #[serde(rename = "tokenUrl")]
+            token_url: &'static str,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            #[serde(rename = "refreshUrl")]
+            refresh_url: Option<&'static str>,
+            scopes: Map<&'static str, &'static str>
         },
-        clientCredentials {
-            tokenUrl: &'static str,
-            refreshUrl: Option<&'static str>, scopes: Map<&'static str, &'static str>
+        #[serde(rename = "clientCredentials")]
+        ClientCredentials {
+            #[serde(rename = "tokenUrl")]
+            token_url: &'static str,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            #[serde(rename = "refreshUrl")]
+            refresh_url: Option<&'static str>,
+            scopes: Map<&'static str, &'static str>
         },
     }
 
     impl super::OAuthFlow {
-        pub fn refreshUrl(self, refreshUrl: &'static str) -> OAuthFlow {
-            OAuthFlow::from(self).refreshUrl(refreshUrl)
+        pub fn refresh_url(self, refresh_url: &'static str) -> OAuthFlow {
+            OAuthFlow::from(self).refresh_url(refresh_url)
         }
 
         pub fn scope(self, name: &'static str, description: &'static str) -> OAuthFlow {
@@ -102,22 +129,22 @@ mod oauth2 {
         }
     }
     impl OAuthFlow {
-        pub fn refreshUrl(mut self, url: &'static str) -> Self {
+        pub fn refresh_url(mut self, url: &'static str) -> Self {
             match &mut self {
-                | OAuthFlow::authorizationCode { refreshUrl, .. }
-                | OAuthFlow::implicit { refreshUrl, .. }
-                | OAuthFlow::password { refreshUrl, .. }
-                | OAuthFlow::clientCredentials { refreshUrl, .. }
-                => *refreshUrl = Some(url)
+                | OAuthFlow::AuthorizationCode { refresh_url, .. }
+                | OAuthFlow::Implicit { refresh_url, .. }
+                | OAuthFlow::Password { refresh_url, .. }
+                | OAuthFlow::ClientCredentials { refresh_url, .. }
+                => *refresh_url = Some(url)
             }
             self
         }
         pub fn scope(mut self, name: &'static str, description: &'static str) -> Self {
             match &mut self {
-                | OAuthFlow::authorizationCode { scopes, .. }
-                | OAuthFlow::implicit { scopes, .. }
-                | OAuthFlow::password { scopes, .. }
-                | OAuthFlow::clientCredentials { scopes, .. }
+                | OAuthFlow::AuthorizationCode { scopes, .. }
+                | OAuthFlow::Implicit { scopes, .. }
+                | OAuthFlow::Password { scopes, .. }
+                | OAuthFlow::ClientCredentials { scopes, .. }
                 => scopes.insert(name, description)
             }
             self
@@ -126,31 +153,31 @@ mod oauth2 {
     impl From<super::OAuthFlow> for OAuthFlow {
         fn from(it: super::OAuthFlow) -> OAuthFlow {
             match it {
-                super::OAuthFlow::authorizationCode {
-                    authorizationUrl,
-                    tokenUrl,
-                } => Self::authorizationCode {
-                    authorizationUrl,
-                    tokenUrl,
-                    refreshUrl:None, scopes:Map::new()
+                super::OAuthFlow::AuthorizationCode {
+                    authorization_url,
+                    token_url,
+                } => Self::AuthorizationCode {
+                    authorization_url,
+                    token_url,
+                    refresh_url:None, scopes:Map::new()
                 },
-                super::OAuthFlow::implicit {
-                    authorizationUrl,
-                } => Self::implicit {
-                    authorizationUrl,
-                    refreshUrl:None, scopes:Map::new()
+                super::OAuthFlow::Implicit {
+                    authorization_url,
+                } => Self::Implicit {
+                    authorization_url,
+                    refresh_url:None, scopes:Map::new()
                 },
-                super::OAuthFlow::password {
-                    tokenUrl,
-                } => Self::password {
-                    tokenUrl,
-                    refreshUrl:None, scopes:Map::new()
+                super::OAuthFlow::Password {
+                    token_url,
+                } => Self::Password {
+                    token_url,
+                    refresh_url:None, scopes:Map::new()
                 },
-                super::OAuthFlow::clientCredentials {
-                    tokenUrl,
-                } => Self::clientCredentials {
-                    tokenUrl,
-                    refreshUrl:None, scopes:Map::new()
+                super::OAuthFlow::ClientCredentials {
+                    token_url,
+                } => Self::ClientCredentials {
+                    token_url,
+                    refresh_url:None, scopes:Map::new()
                 },
             }
         }

--- a/samples/worker-with-openapi/src/fang.rs
+++ b/samples/worker-with-openapi/src/fang.rs
@@ -45,7 +45,7 @@ impl FangAction for TokenAuth {
     #[cfg(feature="openapi")]
     fn openapi_map_operation(&self, operation: openapi::Operation) -> openapi::Operation {
         operation.security(
-            openapi::SecurityScheme::Bearer("tokenAuth", Some("JSON (user_id, token)")),
+            openapi::SecurityScheme::bearer("tokenAuth", Some("JSON (user_id, token)")),
             &[]
         )
     }


### PR DESCRIPTION
following to

- https://github.com/ohkami-rs/ohkami/pull/485
- https://github.com/ohkami-rs/ohkami/pull/487

This PR partially resolves

- #376 

around `openapi` API, and this is the last piece of them: close #376