### PR TITLE
feat: introduce `Path<T>` and obsolete current implicit path params

### DIFF
--- a/examples/quick_start/src/main.rs
+++ b/examples/quick_start/src/main.rs
@@ -5,7 +5,7 @@ async fn health_check() -> status::NoContent {
     status::NoContent
 }
 
-async fn hello(name: &str) -> String {
+async fn hello(Path(name): Path<&str>) -> String {
     format!("Hello, {name}!")
 }
 

--- a/examples/websocket/src/main.rs
+++ b/examples/websocket/src/main.rs
@@ -15,15 +15,15 @@ async fn echo_text(c: WebSocketContext<'_>) -> WebSocket {
 
 
 async fn echo_text_2(
-    name: String,
-    ctx:  WebSocketContext<'_>
+    Path(name): Path<String>,
+    ctx: WebSocketContext<'_>
 ) -> EchoTextSession<'_> {
     EchoTextSession { name, ctx }
 }
 
 struct EchoTextSession<'ws> {
     name: String,
-    ctx:  WebSocketContext<'ws>,
+    ctx: WebSocketContext<'ws>,
 }
 impl IntoResponse for EchoTextSession<'_> {
     fn into_response(self) -> Response {
@@ -41,7 +41,8 @@ impl IntoResponse for EchoTextSession<'_> {
 }
 
 
-async fn echo_text_3(name: String,
+async fn echo_text_3(
+    Path(name): Path<String>,
     ctx: WebSocketContext<'_>
 ) -> WebSocket {
     ctx.upgrade(|c| async {
@@ -111,7 +112,7 @@ async fn echo_text_3(name: String,
 }
 
 
-async fn echo4(name: String, ws: WebSocketContext<'_>) -> WebSocket {
+async fn echo4(Path(name): Path<String>, ws: WebSocketContext<'_>) -> WebSocket {
     ws.upgrade(|mut c| async {
         /* spawn but not join the handle */
         tokio::spawn(async move {

--- a/ohkami/src/fang/builtin/jwt.rs
+++ b/ohkami/src/fang/builtin/jwt.rs
@@ -31,10 +31,10 @@ use serde::{Serialize, Deserialize};
 /// 
 /// *example.rs*
 /// ```no_run
-/// use ohkami::prelude::*;
-/// use ohkami::typed::status;
-/// use ohkami::fang::{Jwt, JwtToken};
-/// 
+/// use ohkami::{Ohkami, Route, Response};
+/// use ohkami::{format::{Path, Json}, typed::status};
+/// use ohkami::fang::{Context, Jwt, JwtToken};
+/// use ohkami::serde::{Serialize, Deserialize};
 /// 
 /// #[derive(Serialize, Deserialize)]
 /// struct OurJwtPayload {
@@ -46,7 +46,8 @@ use serde::{Serialize, Deserialize};
 ///     Jwt::default("OUR_JWT_SECRET_KEY")
 /// }
 /// 
-/// async fn hello(name: &str,
+/// async fn hello(
+///     Path(name): Path<&str>,
 ///     Context(auth): Context<'_, OurJwtPayload>
 /// ) -> String {
 ///     format!("Hello {name}, you're authorized!")
@@ -76,7 +77,8 @@ use serde::{Serialize, Deserialize};
 /// async fn main() {
 ///     Ohkami::new((
 ///         "/auth".GET(auth),
-///         "/private".By(Ohkami::new((our_jwt(),
+///         "/private".By(Ohkami::new((
+///             our_jwt(),
 ///             "/hello/:name".GET(hello),
 ///         )))
 ///     )).howl("localhost:3000").await

--- a/ohkami/src/fang/builtin/timeout.rs
+++ b/ohkami/src/fang/builtin/timeout.rs
@@ -83,7 +83,7 @@ const _: () = {
     use crate::testing::*;
 
     async fn lazy_greeting(
-        (name, sleep): (&str, u64)
+        Path((name, sleep)): Path<(&str, u64)>
     ) -> String {
         crate::__rt__::sleep(Duration::from_secs(sleep)).await;
 

--- a/ohkami/src/fang/builtin/timeout.rs
+++ b/ohkami/src/fang/builtin/timeout.rs
@@ -14,20 +14,22 @@ use std::time::Duration;
 /// ---
 /// *example.rs*
 /// ```no_run
-/// use ohkami::prelude::*;
-/// use ohkami::fang::Timeout;
+/// use ohkami::{Ohkami, Route};
+/// use ohkami::{format::Path, fang::Timeout};
 /// use std::time::Duration;
 /// 
 /// #[tokio::main]
 /// async fn main() {
-///     Ohkami::new((Timeout::by_secs(10),
+///     Ohkami::new((
+///         Timeout::by_secs(10),
 ///         "/hello/:sleep".GET(sleeping_hello),
 ///     )).howl("0.0.0.0:3000").await
 /// }
 /// 
-/// async fn sleeping_hello(sleep: u64) -> &'static str {
+/// async fn sleeping_hello(
+///     Path(sleep): Path<u64>
+/// ) -> &'static str {
 ///     tokio::time::sleep(Duration::from_secs(sleep)).await;
-///     
 ///     "Hello, I was sleeping ):"
 /// }
 /// ```

--- a/ohkami/src/fang/handler/into_handler.rs
+++ b/ohkami/src/fang/handler/into_handler.rs
@@ -281,6 +281,12 @@ where
     async fn h3(Path(_params): Path<(&str, u64)>) -> Response {todo!()}
 
     struct P1<'req>(std::marker::PhantomData<&'req ()>);
+    #[cfg(feature="openapi")]
+    impl<'p> crate::openapi::Schema for P1<'p> {
+        fn schema() -> impl Into<crate::openapi::SchemaRef> {
+            crate::openapi::string()
+        }
+    }
     impl<'p> FromParam<'p> for P1<'p> {
         type Error = std::convert::Infallible;
         fn from_param(_param: std::borrow::Cow<'p, str>) -> Result<Self, Self::Error> {

--- a/ohkami/src/format/builtin.rs
+++ b/ohkami/src/format/builtin.rs
@@ -13,6 +13,9 @@ pub use text::Text;
 mod html;
 pub use html::Html;
 
+mod path;
+pub use path::{Path, FromParam};
+
 mod query;
 pub use query::Query;
 

--- a/ohkami/src/format/builtin/multipart.rs
+++ b/ohkami/src/format/builtin/multipart.rs
@@ -2,6 +2,8 @@ use crate::FromBody;
 use super::bound::{self, Incoming};
 use ohkami_lib::serde_multipart;
 
+pub use ohkami_lib::serde_multipart::File;
+
 #[cfg(feature="openapi")]
 use crate::openapi;
 
@@ -46,8 +48,6 @@ use crate::openapi;
 /// ## Response
 /// 
 /// not supported
-pub use ohkami_lib::serde_multipart::File;
-
 pub struct Multipart<T: bound::Schema>(pub T);
 
 impl<'req, T: Incoming<'req>> FromBody<'req> for Multipart<T> {

--- a/ohkami/src/format/builtin/path.rs
+++ b/ohkami/src/format/builtin/path.rs
@@ -1,0 +1,243 @@
+use crate::{Request, Response, FromRequest, IntoResponse, util::ErrorMessage};
+use super::bound::{self};
+use std::borrow::Cow;
+
+#[cfg(feature="openapi")]
+use crate::openapi;
+
+/// # Path parameters
+/// 
+/// ```ignore
+/// Path<(T1, T2, ...)> // some params as tuple
+/// Path<T> // single param
+/// ```
+/// 
+/// Parse path parameters of a request into specified type(s)
+/// that impl [`FromParam`], in order of their appearance in the path.
+/// 
+/// When `openapi` feature is activated, each param type is
+/// additionally required to impl `ohkami::openapi::Schema`.
+/// 
+/// ### example
+/// 
+/// ```no_run
+/// use ohkami::format::{Json, Path};
+/// 
+/// # enum MyError {}
+/// # #[derive(ohkami::serde::Serialize)]
+/// # struct Team {}
+/// # #[derive(ohkami::serde::Serialize)]
+/// # struct User {}
+/// 
+/// async fn get_team_info(
+///     Path(id): Path<&str>,
+/// ) -> Result<Team, MyError> {
+///     todo!()
+/// }
+/// 
+/// async fn get_user_info(
+///    Path((team_id, user_id)): Path<(&str, &str)>,
+/// ) -> Result<User, MyError> {
+///    todo!()
+/// }
+/// 
+/// #[tokio::main]
+/// async fn main() {
+///     use ohkami::{Ohkami, Route};
+/// 
+///     Ohkami::new((
+///         "/teams/:id"
+///             .GET(get_team_info),
+///         "/teams/:team_id/users/:user_id"
+///             .GET(get_user_info),
+///     )).howl("localhost:5050").await
+/// }
+/// ```
+pub struct Path<T>(pub T);
+
+/// "Retrieved from a path param", an element of [`Path<_>`].
+/// 
+/// When `openapi` feature is activated, `ohkami::openapi::Schema`
+/// is required to be impl.
+/// 
+/// ### required
+/// - `type Errpr`
+/// - `fn from_param`
+pub trait FromParam<'p>: bound::Schema + Sized {
+    /// If this extraction never fails, `std::convert::Infallible` is recomended.
+    type Error: IntoResponse;
+
+    /// `param` is already percent-decoded：
+    /// 
+    /// - `Cow::Borrowed(&'p str)` if not encoded in request
+    /// - `Cow::Owned(String)` if encoded and ohkami has decoded
+    fn from_param(param: Cow<'p, str>) -> Result<Self, Self::Error>;
+
+    #[inline(always)]
+    fn from_raw_param(raw_param: &'p [u8]) -> Result<Self, Response> {
+        Self::from_param(
+            ohkami_lib::percent_decode_utf8(raw_param)
+                .map_err(|_e| {
+                    #[cfg(debug_assertions)] crate::WARNING!(
+                        "Failed to decode percent encoded param `{}`: {_e}",
+                        raw_param.escape_ascii()
+                    );
+                    Response::InternalServerError()
+                })?
+        ).map_err(IntoResponse::into_response)
+    }
+
+    #[cfg(feature="openapi")]
+    fn openapi_param() -> openapi::Parameter {
+        openapi::Parameter::in_path(Self::schema())
+    }
+}
+const _: () = {
+    impl<'p> FromParam<'p> for String {
+        type Error = std::convert::Infallible;
+
+        #[inline(always)]
+        fn from_param(param: Cow<'p, str>) -> Result<Self, Self::Error> {
+            Ok(match param {
+                Cow::Owned(s)    => s,
+                Cow::Borrowed(s) => s.into()
+            })
+        }
+    }
+    impl<'p> FromParam<'p> for Cow<'p, str> {
+        type Error = std::convert::Infallible;
+
+        #[inline(always)]
+        fn from_param(param: Cow<'p, str>) -> Result<Self, Self::Error> {
+            Ok(param)
+        }
+    }
+    impl<'p> FromParam<'p> for &'p str {
+        type Error = ErrorMessage;
+
+        #[inline(always)]
+        fn from_param(param: Cow<'p, str>) -> Result<Self, Self::Error> {
+            match param {
+                Cow::Borrowed(s) => Ok(s),
+                Cow::Owned(_) => Err({
+                    #[cold] #[inline(never)]
+                    fn unexpected(param: &str) -> ErrorMessage {                        
+                        crate::WARNING!("\
+                            `&str` can't handle percent encoded parameters. \
+                            Use `Cow<'_, str>` or `String` to handle them. \
+                        ");
+                        ErrorMessage(format!(    
+                            "Unexpected path params `{param}`: percent encoded"
+                        ))
+                    } unexpected(&param)
+                }),
+            }
+        }
+    }
+
+    macro_rules! unsigned_integers {
+        ($( $unsigned_int:ty ),*) => {
+            $(
+                impl<'p> FromParam<'p> for $unsigned_int {
+                    type Error = ErrorMessage;
+
+                    fn from_param(param: Cow<'p, str>) -> Result<Self, Self::Error> {
+                        ::byte_reader::Reader::new(param.as_bytes())
+                            .read_uint()
+                            .map(|i| Self::try_from(i).ok())
+                            .flatten()
+                            .ok_or_else(|| ErrorMessage(format!("Unexpected path param")))
+                    }
+                }
+            )*
+        };
+    }
+    unsigned_integers! { u8, u16, u32, u64, usize }
+
+    macro_rules! signed_integers {
+        ($( $signed_int:ty ),*) => {
+            $(
+                impl<'p> FromParam<'p> for $signed_int {
+                    type Error = ErrorMessage;
+
+                    fn from_param(param: Cow<'p, str>) -> Result<Self, Self::Error> {
+                        ::byte_reader::Reader::new(param.as_bytes())
+                            .read_int()
+                            .map(|i| Self::try_from(i).ok())
+                            .flatten()
+                            .ok_or_else(|| ErrorMessage(format!("Unexpected path param")))
+                    }
+                }
+            )*
+        };
+    }
+    signed_integers! { i8, i16, i32, i64, isize }
+};
+
+impl<'req, P: FromParam<'req>> FromRequest<'req> for Path<P> {
+    type Error = Response;
+
+    fn from_request(req: &'req Request) -> Option<Result<Self, Self::Error>> {
+        // SAFETY:
+        // 
+        // 1. This extraction is executed only in a handler (created by `IntoHandler::into_handler`)
+        // 2. Before `IntoHandler::into_handler` is called, `router::base::Router::finalize`
+        //    has already checked that the number of params expected by the handler
+        //    matches the number of params in the request path.
+        let p = unsafe { req.path.assume_one_param() };
+        Some(P::from_raw_param(p).map(Path))
+    }
+
+    #[cfg(feature="openapi")]
+    fn openapi_inbound() -> openapi::Inbound {
+        openapi::Inbound::Params(vec![P::openapi_param()])
+    }
+
+    fn n_params() -> usize {
+        1
+    }
+}
+
+impl<'req, P1: FromParam<'req>> FromRequest<'req> for Path<(P1,)> {
+    type Error = Response;
+
+    fn from_request(req: &'req Request) -> Option<Result<Self, Self::Error>> {
+        // SAFETY: same as above
+        let p = unsafe { req.path.assume_one_param() };
+        Some(P1::from_raw_param(p).map(|p1| Path((p1,))))
+    }
+
+    #[cfg(feature="openapi")]
+    fn openapi_inbound() -> openapi::Inbound {
+        openapi::Inbound::Params(vec![P1::openapi_param()])
+    }
+
+    fn n_params() -> usize {
+        1
+    }
+}
+
+impl<'req, P1: FromParam<'req>, P2: FromParam<'req>> FromRequest<'req> for Path<(P1, P2)> {
+    type Error = Response;
+
+    fn from_request(req: &'req Request) -> Option<Result<Self, Self::Error>> {
+        // SAFETY: same as above
+        let (p1, p2) = unsafe { req.path.assume_two_params() };
+        Some(match (P1::from_raw_param(p1), P2::from_raw_param(p2)) {
+            (Ok(p1), Ok(p2)) => Ok(Path((p1, p2))),
+            (Err(e), _) | (_, Err(e)) => Err(e),
+        })
+    }
+
+    #[cfg(feature="openapi")]
+    fn openapi_inbound() -> openapi::Inbound {
+        openapi::Inbound::Params(vec![
+            P1::openapi_param(),
+            P2::openapi_param(),
+        ])
+    }
+
+    fn n_params() -> usize {
+        2
+    }
+}

--- a/ohkami/src/format/builtin/path.rs
+++ b/ohkami/src/format/builtin/path.rs
@@ -21,9 +21,13 @@ use crate::openapi;
 /// ### example
 /// 
 /// ```no_run
+/// use ohkami::{Ohkami, Route};
 /// use ohkami::format::{Json, Path};
 /// 
 /// # enum MyError {}
+/// # impl ohkami::IntoResponse for MyError {
+/// #     fn into_response(self) -> ohkami::Response {todo!()}
+/// # }
 /// # #[derive(ohkami::serde::Serialize)]
 /// # struct Team {}
 /// # #[derive(ohkami::serde::Serialize)]
@@ -31,20 +35,18 @@ use crate::openapi;
 /// 
 /// async fn get_team_info(
 ///     Path(id): Path<&str>,
-/// ) -> Result<Team, MyError> {
+/// ) -> Result<Json<Team>, MyError> {
 ///     todo!()
 /// }
 /// 
 /// async fn get_user_info(
 ///    Path((team_id, user_id)): Path<(&str, &str)>,
-/// ) -> Result<User, MyError> {
+/// ) -> Result<Json<User>, MyError> {
 ///    todo!()
 /// }
 /// 
 /// #[tokio::main]
 /// async fn main() {
-///     use ohkami::{Ohkami, Route};
-/// 
 ///     Ohkami::new((
 ///         "/teams/:id"
 ///             .GET(get_team_info),

--- a/ohkami/src/lib.rs
+++ b/ohkami/src/lib.rs
@@ -180,7 +180,7 @@ pub(crate) static CONFIG: config::Config = config::Config::new();
 pub mod testing;
 
 mod request;
-pub use request::{Request, Method, FromRequest, FromParam, FromBody};
+pub use request::{Request, Method, FromRequest, FromBody};
 pub use ::ohkami_macros::FromRequest;
 
 mod response;
@@ -206,6 +206,7 @@ pub use fang::{handler, Fang, FangProc};
 mod tls;
 
 pub mod format;
+pub use crate::format::{Path, Query};
 
 pub mod header;
 
@@ -233,7 +234,7 @@ pub mod prelude {
     pub use crate::{Request, Response, IntoResponse, Method, Status};
     pub use crate::util::FangAction;
     pub use crate::serde::{Serialize, Deserialize};
-    pub use crate::format::{Json, Query};
+    pub use crate::format::{Path, Query, Json};
     pub use crate::fang::Context;
 
     #[cfg(feature="__rt__")]

--- a/ohkami/src/ohkami/_test.rs
+++ b/ohkami/src/ohkami/_test.rs
@@ -12,14 +12,14 @@ fn my_ohkami() -> Ohkami {
 
     let profiles_ohkami = Ohkami::new((
         "/:username"
-            .GET(|username: String| async  move {
+            .GET(|Path(username): Path<String>| async  move {
                 format!("get_profile of user `{username}`")
             }),
         "/:username/follow"
-            .POST(|username: String| async move {
+            .POST(|Path(username): Path<String>| async move {
                 format!("follow_user `{username}`")
             })
-            .DELETE(|username: String| async move {
+            .DELETE(|Path(username): Path<String>| async move {
                 format!("unfollow_user `{username}`")
             })
     ));
@@ -32,31 +32,31 @@ fn my_ohkami() -> Ohkami {
             .GET(|| async {"get_feed"}),
         "/:slug".By(Ohkami::new((
             "/"
-                .GET(|slug: String| async move {
+                .GET(|Path(slug): Path<String>| async move {
                     format!("get_article {slug}")
                 })
-                .PUT(|slug: String| async move {
+                .PUT(|Path(slug): Path<String>| async move {
                     format!("put_article {slug}")
                 })
-                .DELETE(|slug: String| async move {
+                .DELETE(|Path(slug): Path<String>| async move {
                     format!("delete_article {slug}")
                 }),
             "/comments"
-                .POST(|slug: String| async move {
+                .POST(|Path(slug): Path<String>| async move {
                     format!("post_comments {slug}")
                 })
-                .GET(|slug: String| async move {
+                .GET(|Path(slug): Path<String>| async move {
                     format!("get_comments {slug}")
                 }),
             "/comments/:id"
-                .DELETE(|(slug, id): (String, usize)| async move {
+                .DELETE(|Path((slug, id)): Path<(String, usize)>| async move {
                     format!("delete_comment {slug} / {id}")
                 }),
             "/favorite"
-                .POST(|slug: String| async move {
+                .POST(|Path(slug): Path<String>| async move {
                     format!("favorite_article {slug}")
                 })
-                .DELETE(|slug: String| async move {
+                .DELETE(|Path(slug): Path<String>| async move {
                     format!("unfavorite_article {slug}")
                 }),
         )))
@@ -377,7 +377,7 @@ fn my_ohkami() -> Ohkami {
         \t `GET /hello/{you name here}`"
     }
 
-    async fn hello(name: std::borrow::Cow<'_, str>) -> String {
+    async fn hello(Path(name): Path<std::borrow::Cow<'_, str>>) -> String {
         format!("Hello, {name}!")
     }
 
@@ -757,7 +757,7 @@ fn method_dependent_fang_applying() {
     BUT the route `/hello` captures only 0 param(s)"
 ]
 fn panics_unexpected_path_params() {
-    async fn hello_name(name: &str) -> String {
+    async fn hello_name(Path(name): Path<&str>) -> String {
         format!("Hello, {name}!")
     }
 
@@ -773,10 +773,10 @@ fn panics_unexpected_path_params() {
     BUT the route `/hello/:name` captures only 1 param(s)"
 ]
 fn check_path_params_counted_accumulatedly() {
-    async fn hello_name(name: &str) -> String {
+    async fn hello_name(Path(name): Path<&str>) -> String {
         format!("Hello, {name}!")
     }
-    async fn hello_name_age((name, age): (&str, u8)) -> String {
+    async fn hello_name_age(Path((name, age)): Path<(&str, u8)>) -> String {
         format!("Hello, {name} ({age})!")
     }
 

--- a/ohkami_openapi/src/lib.rs
+++ b/ohkami_openapi/src/lib.rs
@@ -77,22 +77,22 @@ const _: () = {
 
     impl Schema for u8 {
         fn schema() -> impl Into<schema::SchemaRef> {
-            integer()
+            integer().format("uint8")
         }
     }
     impl Schema for u16 {
         fn schema() -> impl Into<schema::SchemaRef> {
-            integer()
+            integer().format("uint16")
         }
     }
     impl Schema for u32 {
         fn schema() -> impl Into<schema::SchemaRef> {
-            integer()
+            integer().format("uint32")
         }
     }
     impl Schema for u64 {
         fn schema() -> impl Into<schema::SchemaRef> {
-            integer()
+            integer().format("uint64")
         }
     }
     impl Schema for usize {
@@ -103,12 +103,12 @@ const _: () = {
 
     impl Schema for i8 {
         fn schema() -> impl Into<schema::SchemaRef> {
-            integer()
+            integer().format("int8")
         }
     }
     impl Schema for i16 {
         fn schema() -> impl Into<schema::SchemaRef> {
-            integer()
+            integer().format("int16")
         }
     }
     impl Schema for i32 {

--- a/ohkami_openapi/src/lib.rs
+++ b/ohkami_openapi/src/lib.rs
@@ -64,7 +64,7 @@ pub trait Schema {
     fn schema() -> impl Into<schema::SchemaRef>;
 }
 const _: () = {
-    impl Schema for &str {
+    impl Schema for str {
         fn schema() -> impl Into<schema::SchemaRef> {
             string()
         }
@@ -154,18 +154,18 @@ const _: () = {
         }
     }
 
-    impl<S: Schema + ToOwned> Schema for std::borrow::Cow<'_, S> {
+    impl<S: Schema + ToOwned + ?Sized> Schema for std::borrow::Cow<'_, S> {
         fn schema() -> impl Into<schema::SchemaRef> {
             S::schema()
         }
     }
-    impl<S: Schema> Schema for std::sync::Arc<S> {
+    impl<S: Schema + ?Sized> Schema for std::sync::Arc<S> {
         fn schema() -> impl Into<schema::SchemaRef> {
             S::schema()
         }
     }
 
-    impl<S: Schema> Schema for &S {
+    impl<S: Schema + ?Sized> Schema for &S {
         fn schema() -> impl Into<schema::SchemaRef> {
             S::schema()
         }

--- a/samples/openapi-schema-enums/openapi.json.sample
+++ b/samples/openapi-schema-enums/openapi.json.sample
@@ -60,7 +60,8 @@
                           "type": "object",
                           "properties": {
                             "age": {
-                              "type": "integer"
+                              "type": "integer",
+                              "format": "uint8"
                             },
                             "username": {
                               "type": "string"
@@ -303,7 +304,8 @@
         "type": "object",
         "properties": {
           "age": {
-            "type": "integer"
+            "type": "integer",
+            "format": "uint8"
           },
           "name": {
             "type": "string"
@@ -323,7 +325,8 @@
                 "type": "object",
                 "properties": {
                   "age": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "uint8"
                   },
                   "name": {
                     "type": "string"

--- a/samples/openapi-schema-from-into/openapi.json.sample
+++ b/samples/openapi-schema-from-into/openapi.json.sample
@@ -17,7 +17,8 @@
                 "type": "object",
                 "properties": {
                   "age": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "uint8"
                   },
                   "name": {
                     "type": "string"
@@ -53,7 +54,8 @@
                       "type": "object",
                       "properties": {
                         "age": {
-                          "type": "integer"
+                          "type": "integer",
+                          "format": "uint8"
                         },
                         "name": {
                           "type": "string"
@@ -86,7 +88,8 @@
                 "type": "object",
                 "properties": {
                   "age": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "uint8"
                   },
                   "name": {
                     "type": "string"

--- a/samples/openapi-tags/openapi.json.sample
+++ b/samples/openapi-tags/openapi.json.sample
@@ -121,7 +121,8 @@
                     "type": "object",
                     "properties": {
                       "age": {
-                        "type": "integer"
+                        "type": "integer",
+                        "format": "uint8"
                       },
                       "id": {
                         "type": "integer",
@@ -156,7 +157,8 @@
                 "type": "object",
                 "properties": {
                   "age": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "uint8"
                   },
                   "name": {
                     "type": "string"
@@ -178,7 +180,8 @@
                   "type": "object",
                   "properties": {
                     "age": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint8"
                     },
                     "id": {
                       "type": "integer",
@@ -211,7 +214,8 @@
             "in": "path",
             "name": "id",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "format": "int32"
             },
             "required": true
           }
@@ -225,7 +229,8 @@
                   "type": "object",
                   "properties": {
                     "age": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint8"
                     },
                     "id": {
                       "type": "integer",

--- a/samples/openapi-tags/src/main.rs
+++ b/samples/openapi-tags/src/main.rs
@@ -45,7 +45,7 @@ mod users {
         }))
     }
 
-    async fn get_user_profile(id: i32) -> Json<User> {
+    async fn get_user_profile(Path(id): Path<i32>) -> Json<User> {
         Json(User {
             id,
             name: "unknown".into(),

--- a/samples/petstore/openapi.json.sample
+++ b/samples/petstore/openapi.json.sample
@@ -109,7 +109,8 @@
             "in": "path",
             "name": "petId",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "format": "uint64"
             },
             "required": true
           }
@@ -144,7 +145,8 @@
             "in": "path",
             "name": "petId",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "format": "uint64"
             },
             "required": true
           }
@@ -180,7 +182,8 @@
             "type": "string"
           },
           "statusCode": {
-            "type": "integer"
+            "type": "integer",
+            "format": "uint16"
           }
         },
         "required": [
@@ -192,7 +195,8 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "integer"
+            "type": "integer",
+            "format": "uint64"
           },
           "name": {
             "type": "string"

--- a/samples/petstore/src/main.rs
+++ b/samples/petstore/src/main.rs
@@ -1,5 +1,5 @@
 use ohkami::prelude::*;
-use ohkami::format::{Json, Query};
+use ohkami::format::{Json, Path, Query};
 use ohkami::typed::status;
 use ohkami::openapi;
 use std::sync::Arc;
@@ -133,7 +133,7 @@ struct CreatePetRequest<'req> {
 /// Find a pet of the `id`.
 /// The parameter `id` must be unsigned 64-bit integer.
 async fn show_pet_by_id(
-    id: u64,
+    Path(id): Path<u64>,
     Context(db): Context<'_, Arc<mock::DB>>,
 ) -> Result<Json<Pet>, Error> {
     let pet = db.read().await.get(&id)
@@ -145,7 +145,7 @@ async fn show_pet_by_id(
     Ok(Json(pet))
 }
 
-async fn edit_pet_profile(_id: u64) {}
+async fn edit_pet_profile(Path(_id): Path<u64>) {}
 
 async fn show_pets_detail() {}
 

--- a/samples/realworld/src/handlers/articles.rs
+++ b/samples/realworld/src/handlers/articles.rs
@@ -119,7 +119,8 @@ async fn feed_articles(
     }))
 }
 
-async fn get_article_by_slug(slug: &str,
+async fn get_article_by_slug(
+    Path(slug): Path<&str>,
     Context(pool): Context<'_, PgPool>,
 ) -> Result<Json<SingleArticleResponse>, RealWorldError> {
     let article = sqlx::QueryBuilder::new(ArticleEntity::base_query())
@@ -228,7 +229,8 @@ async fn create_article(
     )))
 }
 
-async fn update_article(slug: &str,
+async fn update_article(
+    Path(slug): Path<&str>,
     Json(body): Json<UpdateArticleRequest<'_>>,
     Context(auth): Context<'_, JwtPayload>,
     Context(pool): Context<'_, PgPool>,
@@ -285,7 +287,8 @@ async fn update_article(slug: &str,
     }))
 }
 
-async fn delete_article(slug: &str,
+async fn delete_article(
+    Path(slug): Path<&str>,
     Context(auth): Context<'_, JwtPayload>,
     Context(pool): Context<'_, PgPool>,
 ) -> Result<NoContent, RealWorldError> {
@@ -301,7 +304,8 @@ async fn delete_article(slug: &str,
     }
 }
 
-async fn add_article_comment(slug: &str,
+async fn add_article_comment(
+    Path(slug): Path<&str>,
     Json(body): Json<AddCommentRequest<'_>>,
     Context(auth): Context<'_, JwtPayload>,
     Context(pool): Context<'_, PgPool>,
@@ -354,7 +358,8 @@ async fn add_article_comment(slug: &str,
     )))
 }
 
-async fn get_article_comments(slug: &str,
+async fn get_article_comments(
+    Path(slug): Path<&str>,
     Context(auth): Context<'_, Option<JwtPayload>>,
     Context(pool): Context<'_, PgPool>,
 ) -> Result<Json<MultipleCommentsResponse>, RealWorldError> {
@@ -390,7 +395,8 @@ async fn get_article_comments(slug: &str,
     ))
 }
 
-async fn delete_article_comment_by_id((slug, id): (&str, usize),
+async fn delete_article_comment_by_id(
+    Path((slug, id)): Path<(&str, usize)>,
     Context(auth): Context<'_, JwtPayload>,
     Context(pool): Context<'_, PgPool>,
 ) -> Result<NoContent, RealWorldError> {
@@ -414,7 +420,8 @@ async fn delete_article_comment_by_id((slug, id): (&str, usize),
     }
 }
 
-async fn favorite_article(slug: &str,
+async fn favorite_article(
+    Path(slug): Path<&str>,
     Context(auth): Context<'_, JwtPayload>,
     Context(pool): Context<'_, PgPool>,
 ) -> Result<Json<SingleArticleResponse>, RealWorldError> {
@@ -441,7 +448,8 @@ async fn favorite_article(slug: &str,
     }))
 }
 
-async fn unfavorite_article(slug: &str,
+async fn unfavorite_article(
+    Path(slug): Path<&str>,
     Context(auth): Context<'_, JwtPayload>,
     Context(pool): Context<'_, PgPool>,
 ) -> Result<Json<SingleArticleResponse>, RealWorldError> {

--- a/samples/realworld/src/handlers/profiles.rs
+++ b/samples/realworld/src/handlers/profiles.rs
@@ -19,7 +19,8 @@ pub fn profiles_ohkami() -> Ohkami {
     ))
 }
 
-async fn get_profile(username: &str,
+async fn get_profile(
+    Path(username): Path<&str>,
     Context(auth): Context<'_, JwtPayload>,
     Context(pool): Context<'_, PgPool>
 ) -> Result<Json<ProfileResponse>, RealWorldError> {
@@ -43,7 +44,8 @@ async fn get_profile(username: &str,
     ))
 }
 
-async fn follow(username: &str,
+async fn follow(
+    Path(username): Path<&str>,
     Context(auth): Context<'_, JwtPayload>,
     Context(pool): Context<'_, PgPool>,
 ) -> Result<Json<ProfileResponse>, RealWorldError> {
@@ -80,7 +82,8 @@ async fn follow(username: &str,
     ))
 }
 
-async fn unfollow(username: &str,
+async fn unfollow(
+    Path(username): Path<&str>,
     Context(auth): Context<'_, JwtPayload>,
     Context(pool): Context<'_, PgPool>,
 ) -> Result<Json<ProfileResponse>, RealWorldError> {

--- a/samples/worker-durable-websocket/src/lib.rs
+++ b/samples/worker-durable-websocket/src/lib.rs
@@ -13,7 +13,8 @@ async fn main() -> Ohkami {
     ))
 }
 
-async fn ws_chatroom(room_name: &str,
+async fn ws_chatroom(
+    Path(room_name): Path<&str>,
     ctx: WebSocketContext<'_>,
     Bindings { ROOMS, .. }: Bindings,
 ) -> Result<WebSocket, worker::Error> {

--- a/samples/worker-with-global-bindings/openapi.json
+++ b/samples/worker-with-global-bindings/openapi.json
@@ -29,10 +29,12 @@
                     "type": "object",
                     "properties": {
                       "age": {
-                        "type": "integer"
+                        "type": "integer",
+                        "format": "uint8"
                       },
                       "id": {
-                        "type": "integer"
+                        "type": "integer",
+                        "format": "uint32"
                       },
                       "name": {
                         "type": "string"
@@ -59,7 +61,8 @@
                 "type": "object",
                 "properties": {
                   "age": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "uint8"
                   },
                   "name": {
                     "type": "string"
@@ -81,10 +84,12 @@
                   "type": "object",
                   "properties": {
                     "age": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint8"
                     },
                     "id": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "name": {
                       "type": "string"
@@ -109,7 +114,8 @@
             "in": "path",
             "name": "id",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "format": "uint32"
             },
             "required": true
           }
@@ -123,10 +129,12 @@
                   "type": "object",
                   "properties": {
                     "age": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint8"
                     },
                     "id": {
-                      "type": "integer"
+                      "type": "integer",
+                      "format": "uint32"
                     },
                     "name": {
                       "type": "string"

--- a/samples/worker-with-global-bindings/src/lib.rs
+++ b/samples/worker-with-global-bindings/src/lib.rs
@@ -114,7 +114,7 @@ mod repository {
 mod routes {
     use crate::repository::{self, UserRepository};
     use ohkami::{Ohkami, Route};
-    use ohkami::format::Json;
+    use ohkami::format::{Path, Json};
     use ohkami::fang::Context;
     use ohkami::typed::status;
     use ohkami::serde::{Serialize, Deserialize};
@@ -157,7 +157,7 @@ mod routes {
     }
 
     pub async fn show_user<U: UserRepository>(
-        id: u32,
+        Path(id): Path<u32>,
         Context(r): Context<'_, U>,
     ) -> Result<Json<User>, crate::Error> {
         let user_row = r.get_by_id(id).await?

--- a/samples/worker-with-openapi/openapi.json.loggedin.sample
+++ b/samples/worker-with-openapi/openapi.json.loggedin.sample
@@ -10,7 +10,7 @@
       "description": "local dev"
     },
     {
-      "url": "https://ohkami-worker-with-openapi.{{ ACCOUNT_NAME }}.workers.dev",
+      "url": "https://ohkami-worker-with-openapi.kanarus.workers.dev",
       "description": "production"
     }
   ],
@@ -162,7 +162,8 @@
             "in": "path",
             "name": "id",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "format": "int32"
             },
             "required": true
           }
@@ -193,7 +194,8 @@
             "in": "path",
             "name": "id",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "format": "int32"
             },
             "required": true
           }
@@ -206,7 +208,8 @@
                 "type": "object",
                 "properties": {
                   "age": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "uint8"
                   },
                   "location": {
                     "type": "string"
@@ -286,7 +289,8 @@
         "type": "object",
         "properties": {
           "age": {
-            "type": "integer"
+            "type": "integer",
+            "format": "uint8"
           },
           "id": {
             "type": "integer",

--- a/samples/worker-with-openapi/openapi.json.sample
+++ b/samples/worker-with-openapi/openapi.json.sample
@@ -158,7 +158,8 @@
             "in": "path",
             "name": "id",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "format": "int32"
             },
             "required": true
           }
@@ -189,7 +190,8 @@
             "in": "path",
             "name": "id",
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "format": "int32"
             },
             "required": true
           }
@@ -202,7 +204,8 @@
                 "type": "object",
                 "properties": {
                   "age": {
-                    "type": "integer"
+                    "type": "integer",
+                    "format": "uint8"
                   },
                   "location": {
                     "type": "string"
@@ -282,7 +285,8 @@
         "type": "object",
         "properties": {
           "age": {
-            "type": "integer"
+            "type": "integer",
+            "format": "uint8"
           },
           "id": {
             "type": "integer",

--- a/samples/worker-with-openapi/src/lib.rs
+++ b/samples/worker-with-openapi/src/lib.rs
@@ -46,7 +46,8 @@ pub fn ohkami() -> Ohkami {
     ))
 }
 
-async fn show_user_profile(id: ID,
+async fn show_user_profile(
+    Path(id): Path<ID>,
     Bindings { DB, .. }: Bindings,
 ) -> Result<Json<UserProfile>, APIError> {
     let user_proifle = DB.prepare("SELECT id, name, location, age FROM users WHERE id = ?")
@@ -57,7 +58,8 @@ async fn show_user_profile(id: ID,
     Ok(Json(user_proifle))
 }
 
-async fn edit_profile(id: ID,
+async fn edit_profile(
+    Path(id): Path<ID>,
     Json(req): Json<EditProfileRequest<'_>>,
     Context(TokenAuthed { user_id, .. }): Context<'_, TokenAuthed>,
     Bindings { DB, .. }: Bindings,


### PR DESCRIPTION
- close https://github.com/ohkami-rs/ohkami/issues/458

Current

```rust
async fn handler(id: &str, Json(body): Json<Body>) -> ...
```

style depends on the **implicit** rule that the first argument of a handler represents path parameters if its type doesn't implement `FromRequest` trait.

This will be **not intuitive** for most people, at least than explicit `Path(param): Path<T>` style:

```rust
async fn handler(Path(id): Path<&str>, Json(body): Json<Body>) -> ...
```

This PR **breakingly** introduces the `Path<T>` replacing with current implicit path params system.