### PR TITLE
dx: put `#[diagnostic::do_not_recommend]` for local fangs' `IntoHandler` impls

### DIFF
--- a/ohkami/src/fang/handler/into_handler.rs
+++ b/ohkami/src/fang/handler/into_handler.rs
@@ -275,7 +275,7 @@ where
 #[test] fn handler_args() {
     use crate::claw::param::{Path, FromParam};
 
-    async fn h0(_: String) -> &'static str {""}
+    async fn h0() -> &'static str {""}
     async fn h1(Path(_param): Path<String>) -> Response {todo!()}
     async fn h2(Path(_param): Path<&str>) -> Response {todo!()}
     async fn h3(Path(_params): Path<(&str, u64)>) -> Response {todo!()}

--- a/ohkami/src/fang/handler/into_handler.rs
+++ b/ohkami/src/fang/handler/into_handler.rs
@@ -275,7 +275,7 @@ where
 #[test] fn handler_args() {
     use crate::claw::param::{Path, FromParam};
 
-    async fn h0() -> &'static str {""}
+    async fn h0(_: String) -> &'static str {""}
     async fn h1(Path(_param): Path<String>) -> Response {todo!()}
     async fn h2(Path(_param): Path<&str>) -> Response {todo!()}
     async fn h3(Path(_params): Path<(&str, u64)>) -> Response {todo!()}

--- a/ohkami/src/fang/handler/with_local_fangs.rs
+++ b/ohkami/src/fang/handler/with_local_fangs.rs
@@ -1,7 +1,7 @@
 use super::{Handler, IntoHandler};
 use super::super::{Fang, BoxedFPC, middleware::Fangs};
 
-
+#[diagnostic::do_not_recommend]
 impl<H: IntoHandler<T>, T, F1> IntoHandler<(F1, H, T)> for (F1, H)
 where
     F1: Fang<BoxedFPC>
@@ -19,6 +19,7 @@ where
     }
 }
 
+#[diagnostic::do_not_recommend]
 impl<H: IntoHandler<T>, T, F1, F2> IntoHandler<(F1, F2, H, T)> for (F1, F2, H)
 where
     F1: Fang<F2::Proc>,
@@ -38,6 +39,7 @@ where
     }
 }
 
+#[diagnostic::do_not_recommend]
 impl<H: IntoHandler<T>, T, F1, F2, F3> IntoHandler<(F1, F2, F3, H, T)> for (F1, F2, F3, H)
 where
     F1: Fang<F2::Proc>,
@@ -58,6 +60,7 @@ where
     }
 }
 
+#[diagnostic::do_not_recommend]
 impl<H: IntoHandler<T>, T, F1, F2, F3, F4> IntoHandler<(F1, F2, F3, F4, H, T)> for (F1, F2, F3, F4, H)
 where
     F1: Fang<F2::Proc>,


### PR DESCRIPTION
Current `IntoHandler` error message is like:

```txt
error[E0277]: the trait bound `fn(String) -> ... {h0}: IntoHandler<_>` is not satisfied
   --> ohkami/src/fang/handler/into_handler.rs:319:50
    |
319 |             $( let _ = IntoHandler::into_handler($function); )*
    |                        ------------------------- ^^^^^^^^^ unsatisfied trait bound
    |                        |
    |                        required by a bound introduced by this call
...
323 |     assert_handlers! { h0 h1 h2 h3 h4 }
    |     ----------------------------------- in this macro invocation
    |
    = help: the trait `IntoHandler<_>` is not implemented for fn item `fn(String) -> impl Future<Output = &str> {h0}`
    = help: the following other types implement trait `IntoHandler<T>`:
              `(F1, F2, F3, F4, H)` implements `IntoHandler<(F1, F2, F3, F4, H, T)>`
              `(F1, F2, F3, H)` implements `IntoHandler<(F1, F2, F3, H, T)>`
              `(F1, F2, H)` implements `IntoHandler<(F1, F2, H, T)>`
              `(F1, H)` implements `IntoHandler<(F1, H, T)>`
    = note: the full name for the type has been written to '/home/kanarus/projects/ohkami-rs/ohkami/target/debug/deps/ohkami-1d569f0ea870cb55.long-type-10253879756820112383.txt'
    = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the macro `assert_handlers` (in Nightly builds, run with -Z macro-backtrace for more info)
```

but the second `help`:

```txt
    = help: the following other types implement trait `IntoHandler<T>`:
              `(F1, F2, F3, F4, H)` implements `IntoHandler<(F1, F2, F3, F4, H, T)>`
              `(F1, F2, F3, H)` implements `IntoHandler<(F1, F2, F3, H, T)>`
              `(F1, F2, H)` implements `IntoHandler<(F1, F2, H, T)>`
              `(F1, H)` implements `IntoHandler<(F1, H, T)>`
```

will never be helpful, and **maybe even misleading**, for users encountering `IntoHandler` errors. So this PR omits it with `#[diagnostic::do_not_recommend]`:

```txt
error[E0277]: the trait bound `fn(String) -> ... {h0}: IntoHandler<_>` is not satisfied
   --> ohkami/src/fang/handler/into_handler.rs:312:50
    |
312 |             $( let _ = IntoHandler::into_handler($function); )*
    |                        ------------------------- ^^^^^^^^^ unsatisfied trait bound
    |                        |
    |                        required by a bound introduced by this call
...
316 |     assert_handlers! { h0 h1 h2 h3 h4 }
    |     ----------------------------------- in this macro invocation
    |
    = help: the trait `IntoHandler<_>` is not implemented for fn item `fn(String) -> impl Future<Output = &str> {h0}`
    = note: the full name for the type has been written to '/home/kanarus/projects/ohkami-rs/ohkami/target/debug/deps/ohkami-1d569f0ea870cb55.long-type-14423504065865114042.txt'
    = note: consider using `--verbose` to print the full type name to the console
    = note: this error originates in the macro `assert_handlers` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0277`.
error: could not compile `ohkami` (lib test) due to 1 previous error
```