### PR TITLE
enhance(Route): deprecate `.Dir()` and introduce `.Mount()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Hello, your_name!
 
 - `.GET()`, `.POST()`, `.PUT()`, `.PATCH()`, `.DELETE()`, `.OPTIONS()` to define API endpoints
 - `.By({another Ohkami})` to nest `Ohkami`s
-- `.Dir({dir_path})` to serve static directory
+- `.Mount({directory_path})` to serve static directory
   (pre-compressed files with `gzip`, `deflate`, `br`, `zstd` are supported)
 
 Here `GET`, `POST`, etc. takes a *handler* function:
@@ -714,7 +714,7 @@ use ohkami::{Ohkami, Route};
 #[tokio::main]
 async fn main() {
     Ohkami::new((
-        "/".Dir("./dist"),
+        "/".Mount("./dist"),
     )).howl("0.0.0.0:3030").await
 }
 ```

--- a/examples/static_files/src/main.rs
+++ b/examples/static_files/src/main.rs
@@ -17,7 +17,7 @@ impl Default for Options {
 
 fn ohkami(Options { omit_dot_html, serve_dotfiles, etag }: Options) -> Ohkami {
     Ohkami::new((
-        "/".Dir("./public")
+        "/".Mount("./public")
             .omit_extensions(if omit_dot_html {&["html"]} else {&[]})
             .serve_dotfiles(serve_dotfiles)
             .etag(etag),

--- a/examples/websocket/src/main.rs
+++ b/examples/websocket/src/main.rs
@@ -144,7 +144,7 @@ async fn main() {
     }
     
     Ohkami::new((Logger,
-        "/".Dir("./template").omit_extensions(&[".html"]),
+        "/".Mount("./template").omit_extensions(&[".html"]),
         "/echo1".GET(echo_text),
         "/echo2/:name".GET(echo_text_2),
         "/echo3/:name".GET(echo_text_3),

--- a/ohkami/src/ohkami/dir.rs
+++ b/ohkami/src/ohkami/dir.rs
@@ -59,7 +59,7 @@ impl StaticFile {
 }
 
 impl Dir {
-    pub(super) fn new(route: &'static str, dir_path: PathBuf) -> io::Result<Self> {
+    pub(super) fn new(route: &'static str, dir_path: &Path) -> io::Result<Self> {
         let dir_path = dir_path.canonicalize()?;
 
         if !dir_path.is_dir() {

--- a/ohkami/src/ohkami/mod.rs
+++ b/ohkami/src/ohkami/mod.rs
@@ -426,7 +426,7 @@ impl Ohkami {
     /// 
     /// ### static directory serving
     /// 
-    /// `.Dir` mounts a directory and serves all files in it/its sub directories.
+    /// `.Mount({directory_path})` mounts a directory and serves all files in it/its sub directories.
     /// 
     /// This doesn't work on `rt_worker` ( of course because there Ohkami can't
     /// touch your local file system ). Consider using `asset` of wrangler.{toml/json}
@@ -438,7 +438,7 @@ impl Ohkami {
     /// # fn __() -> Ohkami {
     /// # let another_ohkami = Ohkami::new(());
     /// Ohkami::new(
-    ///     "/public".Dir("./path/to/dir"),
+    ///     "/public".Mount("./path/to/dir"),
     /// )
     /// # }
     /// ```

--- a/ohkami/src/ohkami/routing.rs
+++ b/ohkami/src/ohkami/routing.rs
@@ -120,7 +120,12 @@ macro_rules! Route {
             /// Both pre-compressed file(s) and the original file are required to be in the directory.
             /// 
             /// See methods's docs for options.
-            fn Dir(self, static_dir_path: &'static str) -> Dir;
+            fn Mount(self, directory_path: impl AsRef<std::path::Path>) -> Dir;
+            
+            #[deprecated(note = "Use `Mount` instead")]
+            fn Dir(self, path: &'static str) -> Dir {
+                self.Mount(path)
+            }
         }
 
         impl Route for &'static str {
@@ -138,17 +143,11 @@ macro_rules! Route {
             }
 
             #[cfg(feature="__rt_native__")]
-            fn Dir(self, path: &'static str) -> Dir {
+            fn Mount(self, path: impl AsRef<std::path::Path>) -> Dir {
                 // Check `self` is valid route
                 let _ = RouteSegments::from_literal(self);
-
-                match Dir::new(
-                    self,
-                    path.into()
-                ) {
-                    Ok(dir) => dir,
-                    Err(e) => panic!("{e}")
-                }
+                
+                Dir::new(self, path.as_ref()).expect(&format!("invalid path to serve: `{}`", path.as_ref().display()))
             }
         }
     };


### PR DESCRIPTION
introducing `.Mount()` method with deprecating `.Dir()` in `Route` trait:

```rust
            #[cfg(feature="__rt_native__")]
            /// Serve static files from a directory.
            /// 
            /// Common comprssion formats ( `gzip`, `deflate`, `br`, `zstd` )
            /// are supported : pre-compressed files by these algorithms are
            /// automatically detected by the file extension and used by handler
            /// at the original file name, not directly by the file name.
            /// (e.g. not served at `GET /index.js.gz`, but used for response for `GET /index.js`)
            /// Both pre-compressed file(s) and the original file are required to be in the directory.
            /// 
            /// See methods's docs for options.
            fn Mount(self, directory_path: impl AsRef<std::path::Path>) -> Dir;
            
            #[deprecated(note = "Use `Mount` instead")]
            fn Dir(self, path: &'static str) -> Dir {
                self.Mount(path)
            }
```