### PR TITLE
chore(CI): add temporal workaround for bug of nightly-2025-08-12

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,10 +33,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
-          targets:   x86_64-unknown-linux-gnu, wasm32-unknown-unknown
+          targets:   wasm32-unknown-unknown
       - name: WORKAROUND-FOR-nightly-2025-08-12
         if:   ${{ matrix.toolchain == 'nightly' }}
-        run:  rustup default nightly-2025-08-08
+        run:  |
+          rustup default nightly-2025-08-08
+          rustup target add wasm32-unknown-unknown
 
       - name: Cache cargo bin
         id:   cache_cargo_bin


### PR DESCRIPTION
The workaround planned in:

- https://github.com/ohkami-rs/ohkami/pull/519#issuecomment-3184895787

for `rustc nightly-2025-08-12`'s bug.

related:

- https://github.com/launchbadge/sqlx/issues/3973
- https://github.com/rust-lang/rust/issues/145288
- https://github.com/rust-lang/rust/pull/145338