### PR TITLE
rename(util): `timeout_in` into `with_timeout`

### DIFF
--- a/ohkami/src/fang/builtin/timeout.rs
+++ b/ohkami/src/fang/builtin/timeout.rs
@@ -70,7 +70,7 @@ const _: () = {
     }
     impl<Inner: FangProc> FangProc for TimeoutProc<Inner> {
         async fn bite<'b>(&'b self, req: &'b mut Request) -> Response {
-            crate::util::timeout_in(self.time, self.inner.bite(req)).await
+            crate::util::with_timeout(self.time, self.inner.bite(req)).await
                 .unwrap_or_else(|| Response::InternalServerError().with_text("timeout"))
         }
     }

--- a/ohkami/src/ohkami/mod.rs
+++ b/ohkami/src/ohkami/mod.rs
@@ -1116,7 +1116,7 @@ mod test {
     #[test]
     fn can_howl_on_any_native_async_runtime() {
         __rt__::testing::block_on(async {
-            crate::util::timeout_in(
+            crate::util::with_timeout(
                 std::time::Duration::from_secs(3),
                 Ohkami::new(()).howl(("localhost", __rt__::testing::PORT))
             ).await
@@ -1194,7 +1194,7 @@ mod test {
                 .with_single_cert(cert_chain, key)
                 .expect("Failed to build TLS configuration");
 
-            crate::util::timeout_in(
+            crate::util::with_timeout(
                 std::time::Duration::from_secs(3),
                 Ohkami::new(()).howls(("localhost", __rt__::testing::PORT), tls_config)
             ).await

--- a/ohkami/src/session/mod.rs
+++ b/ohkami/src/session/mod.rs
@@ -5,7 +5,7 @@ mod connection;
 use std::{any::Any, pin::Pin, sync::Arc, time::Duration};
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use crate::response::Upgrade;
-use crate::util::timeout_in;
+use crate::util::with_timeout;
 use crate::router::r#final::Router;
 use crate::{Request, Response};
 
@@ -60,7 +60,7 @@ impl Session {
         let upgrade = loop {
             req.clear();
             // Apply a fresh timeout for each read, thus resetting the timer on activity.
-            let read_result = timeout_in(
+            let read_result = with_timeout(
                 Duration::from_secs(crate::CONFIG.keepalive_timeout()),
                 async { req.as_mut().read(&mut self.connection).await }
             ).await;

--- a/ohkami/src/util.rs
+++ b/ohkami/src/util.rs
@@ -179,7 +179,7 @@ const _: () = {
 };
 
 #[cfg(feature="__rt_native__")]
-pub fn timeout_in<T>(
+pub fn with_timeout<T>(
     duration: std::time::Duration,
     proc:     impl std::future::Future<Output = T>
 ) -> impl std::future::Future<Output = Option<T>> {


### PR DESCRIPTION
for better naturality