### PR TITLE
fix(Mount): `omit_extension`'s doc and behavior to accept both `\.?ext`

### DIFF
--- a/examples/static_files/src/main.rs
+++ b/examples/static_files/src/main.rs
@@ -19,10 +19,10 @@ impl Default for Options {
 
 fn ohkami(Options { omit_html, omit_dot_html, serve_dotfiles, etag }: Options) -> Ohkami {
     let omit_extensions = match (omit_html, omit_dot_html) {
-        (true, true) => &["html", ".html"],
-        (true, false) => &["html"],
-        (false, true) => &[".html"],
-        (false, false) => &[],
+        (true, true) => &["html", ".html"][..],
+        (true, false) => &["html"][..],
+        (false, true) => &[".html"][..],
+        (false, false) => &[][..],
     };
     
     Ohkami::new((

--- a/ohkami/src/ohkami/dir.rs
+++ b/ohkami/src/ohkami/dir.rs
@@ -114,7 +114,7 @@ impl Dir {
         })
     }
 
-    /// Whether to serve dotfiles like `.abc` (default: false)
+    /// Whether to serve dotfiles like `.gitignore` (default: false)
     /// 
     /// When `false`, files of name starting with `.` will be ignored.
     pub fn serve_dotfiles(mut self, yes: bool) -> Self {
@@ -122,10 +122,13 @@ impl Dir {
         self
     }
 
-    /// File extensions (leading `.` trimmed) that should not be appeared in server path.
-    /// For example, if you omit `[".html"]`, `/abc.html` will be served at `/abc` instead of `/abc.html`.
+    /// File extensions that should not be appeared in server path.
     /// 
-    /// As a special case, `index.html` will be served at `/` when `".html"` is omitted.
+    /// For example, if you omit `&["html"]` or `&[".html"]` (both styles works the same),
+    /// `/abc.html` will be served at `/abc` instead of `/abc.html`.
+    /// 
+    /// As a special case, `index.html` will be served at `/path/to/dir`
+    /// instead of `/path/to/dir/index` when `.html` is omitted.
     pub fn omit_extensions(mut self, extensions_to_omit: &'static [&'static str]) -> Self {
         self.omit_extensions = extensions_to_omit;
         self

--- a/ohkami/src/ohkami/routing.rs
+++ b/ohkami/src/ohkami/routing.rs
@@ -218,6 +218,9 @@ const _: () = {
                 }
 
                 for ext_to_omit in self.omit_extensions {
+                    // normalize it
+                    let ext_to_omit = ext_to_omit.trim_start_matches('.');
+                    
                     if let Some(without_ext) = file_name.strip_suffix(&format!(".{ext_to_omit}")) {
                         let _ = path.pop();
 

--- a/ohkami/src/ohkami/routing.rs
+++ b/ohkami/src/ohkami/routing.rs
@@ -224,7 +224,7 @@ const _: () = {
                     if let Some(without_ext) = file_name.strip_suffix(&format!(".{ext_to_omit}")) {
                         let _ = path.pop();
 
-                        if without_ext == "index" && *ext_to_omit == "html" {
+                        if without_ext == "index" && ext_to_omit == "html" {
                             // If the file is `index.html` and `.html` is omitted,
                             // the path should be `/` instead of `/index`.
                             assert_eq!(file_name, "index.html");


### PR DESCRIPTION
- close https://github.com/ohkami-rs/ohkami/issues/518
- tested by examples/static_files's `test_omit_dot_html` and `test_omit_html` (via examples/test.sh by CI)

(just in case: `\.?ext` in the PR title is just for clear description of the behavior, not meaning use of regex crate)