### PR TITLE
fix(request): avoid panic in str conversion

### DIFF
--- a/ohkami/src/request/_test_parse.rs
+++ b/ohkami/src/request/_test_parse.rs
@@ -11,15 +11,15 @@ use ohkami_lib::{Slice, CowSlice};
 fn parse_path() {
     let mut path = Path::uninit();
     path.init_with_request_bytes(b"/abc").unwrap();
-    assert_eq!(&*path, "/abc");
+    assert_eq!(path.str(), "/abc");
 
     let mut path = Path::uninit();
     path.init_with_request_bytes(b"/abc/").unwrap();
-    assert_eq!(&*path, "/abc");
+    assert_eq!(path.str(), "/abc");
 
     let mut path = Path::uninit();
     path.init_with_request_bytes(b"/").unwrap();
-    assert_eq!(&*path, "/");
+    assert_eq!(path.str(), "/");
 }
 
 macro_rules! assert_parse {


### PR DESCRIPTION
- close https://github.com/ohkami-rs/ohkami/issues/540
- breaking: remove `AsRef` and `Deref` impl for `request::Path`
- add: `request::Path::bytes(&self) -> &[u8]` ( non-str version of `request::Path::str` )