### PR TITLE
fix(fangs): correctly handle thread-per-core runtime like glommio

### DIFF
--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -52,15 +52,15 @@ anysc-rustls = { version = "0.1", optional = true }
 
 
 [features]
-rt_tokio = ["__rt_native__", "__io_tokio__",
+rt_tokio = ["__rt_native__", "__rt_threaded__", "__io_tokio__",
     "dep:tokio","tokio/rt","tokio/net","tokio/time",
     "mews?/rt_tokio",
 ]
-rt_smol = ["__rt_native__", "__io_futures__",
+rt_smol = ["__rt_native__", "__rt_threaded__", "__io_futures__",
     "dep:smol",
     "mews?/rt_smol",
 ]
-rt_nio = ["__rt_native__", "__io_tokio__",
+rt_nio = ["__rt_native__", "__rt_threaded__", "__io_tokio__",
     "dep:nio",
     "mews?/rt_nio",
 ]
@@ -73,7 +73,7 @@ rt_worker = ["__rt__",
     "dep:worker", "worker/d1", "worker/queue",
     "ohkami_macros/worker",
 ]
-rt_lambda = ["__rt__",
+rt_lambda = ["__rt__", "__rt_threaded__",
     "dep:lambda_runtime",
     "dep:tokio", "tokio/rt", # lambda_runtime internally depends on tokio runtime
     "ohkami_lib/stream",     # lambda_runtime's interface always requires stream
@@ -85,10 +85,11 @@ ws      = ["ohkami_lib/stream", "dep:mews", "dep:futures-util", "futures-util/io
 tls     = ["dep:rustls", "dep:anysc-rustls"]
 
 ##### internal #####
-__rt__         = []
-__rt_native__  = ["__rt__", "dep:mime_guess", "dep:ctrlc"]
-__io_tokio__   = ["dep:tokio","tokio/io-util", "anysc-rustls?/io_tokio"]
-__io_futures__ = ["dep:futures-util","futures-util/io", "anysc-rustls?/io_futures"]
+__rt__          = []
+__rt_threaded__ = ["__rt__"]
+__rt_native__   = ["__rt__", "dep:mime_guess", "dep:ctrlc"]
+__io_tokio__    = ["dep:tokio","tokio/io-util", "anysc-rustls?/io_tokio"]
+__io_futures__  = ["dep:futures-util","futures-util/io", "anysc-rustls?/io_futures"]
 
 ##### DEBUG #####
 DEBUG = ["tokio?/rt-multi-thread", "tokio?/macros"]

--- a/ohkami/src/fang/bound.rs
+++ b/ohkami/src/fang/bound.rs
@@ -4,27 +4,27 @@ use std::future::Future;
 
 pub use dispatch::*;
 
-#[cfg(not(feature="rt_worker"))]
+#[cfg(feature="__rt_threaded__")]
 mod dispatch {
-    pub trait SendSyncOnNative: Send + Sync {}
-    impl<T: Send + Sync> SendSyncOnNative for T {}
+    pub trait SendSyncOnThreaded: Send + Sync {}
+    impl<T: Send + Sync> SendSyncOnThreaded for T {}
 
     #[allow(unused)]
-    pub trait SendOnNative: Send {}
-    impl<T: Send> SendOnNative for T {}
+    pub trait SendOnThreaded: Send {}
+    impl<T: Send> SendOnThreaded for T {}
 }
-#[cfg(feature="rt_worker")]
+#[cfg(not(feature="__rt_threaded__"))]
 mod dispatch {
-    pub trait SendSyncOnNative {}
-    impl<T> SendSyncOnNative for T {}
+    pub trait SendSyncOnThreaded {}
+    impl<T> SendSyncOnThreaded for T {}
 
-    pub trait SendOnNative {}
-    impl<T> SendOnNative for T {}
+    pub trait SendOnThreaded {}
+    impl<T> SendOnThreaded for T {}
 }
 
 #[allow(unused)]
-pub trait SendOnNativeFuture<T>: Future<Output = T> + SendOnNative {}
-impl<T, F: Future<Output = T> + SendOnNative> SendOnNativeFuture<T> for F {}
+pub trait SendOnThreadedFuture<T>: Future<Output = T> + SendOnThreaded {}
+impl<T, F: Future<Output = T> + SendOnThreaded> SendOnThreadedFuture<T> for F {}
 
-pub(crate) trait FPCBound: FangProcCaller + SendSyncOnNative {}
-impl<T: FangProcCaller + SendSyncOnNative> FPCBound for T {}
+pub(crate) trait FPCBound: FangProcCaller + SendSyncOnThreaded {}
+impl<T: FangProcCaller + SendSyncOnThreaded> FPCBound for T {}

--- a/ohkami/src/fang/builtin/basicauth.rs
+++ b/ohkami/src/fang/builtin/basicauth.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use crate::fang::SendSyncOnNative;
+use crate::fang::SendSyncOnThreaded;
 
 #[cfg(feature="openapi")]
 use crate::openapi;
@@ -46,7 +46,7 @@ use crate::openapi;
 #[derive(Clone, Debug)]
 pub struct BasicAuth<S>
 where
-    S: AsRef<str> + Clone + SendSyncOnNative + 'static
+    S: AsRef<str> + Clone + SendSyncOnThreaded + 'static
 {
     pub username: S,
     pub password: S
@@ -54,7 +54,7 @@ where
 
 impl<S> BasicAuth<S>
 where
-    S: AsRef<str> + Clone + SendSyncOnNative + 'static
+    S: AsRef<str> + Clone + SendSyncOnThreaded + 'static
 {
     #[inline]
     fn matches(&self,
@@ -82,7 +82,7 @@ const _: () = {
 
     impl<S> FangAction for BasicAuth<S>
     where
-        S: AsRef<str> + Clone + SendSyncOnNative + 'static
+        S: AsRef<str> + Clone + SendSyncOnThreaded + 'static
     {
         #[inline]
         async fn fore<'a>(&'a self, req: &'a mut Request) -> Result<(), Response> {
@@ -105,7 +105,7 @@ const _: () = {
 
     impl<S, const N: usize> FangAction for [BasicAuth<S>; N]
     where
-        S: AsRef<str> + Clone + SendSyncOnNative + 'static
+        S: AsRef<str> + Clone + SendSyncOnThreaded + 'static
     {
         #[inline]
         async fn fore<'a>(&'a self, req: &'a mut Request) -> Result<(), Response> {

--- a/ohkami/src/fang/builtin/context.rs
+++ b/ohkami/src/fang/builtin/context.rs
@@ -1,5 +1,5 @@
 use crate::{Request, Response, FromRequest};
-use crate::fang::{FangAction, SendSyncOnNative};
+use crate::fang::{FangAction, SendSyncOnThreaded};
 
 /// # Request Context
 /// 
@@ -29,9 +29,9 @@ use crate::fang::{FangAction, SendSyncOnNative};
 /// }
 /// ```
 #[derive(Clone, Debug)]
-pub struct Context<'req, T: SendSyncOnNative + 'static>(pub &'req T);
+pub struct Context<'req, T: SendSyncOnThreaded + 'static>(pub &'req T);
 
-impl<T: SendSyncOnNative + 'static> Context<'static, T>
+impl<T: SendSyncOnThreaded + 'static> Context<'static, T>
 where
     T: Clone
 {
@@ -39,9 +39,9 @@ where
         return ContextAction(data);
 
         #[derive(Clone)]
-        struct ContextAction<T: Clone + SendSyncOnNative + 'static>(T);
+        struct ContextAction<T: Clone + SendSyncOnThreaded + 'static>(T);
 
-        impl<T: Clone + SendSyncOnNative + 'static> FangAction for ContextAction<T> {
+        impl<T: Clone + SendSyncOnThreaded + 'static> FangAction for ContextAction<T> {
             #[inline]
             async fn fore<'a>(&'a self, req: &'a mut Request) -> Result<(), Response> {
                 req.context.set(self.0.clone());
@@ -51,7 +51,7 @@ where
     }
 }
 
-impl<'req, T: SendSyncOnNative + 'static> FromRequest<'req> for Context<'req, T> {
+impl<'req, T: SendSyncOnThreaded + 'static> FromRequest<'req> for Context<'req, T> {
     type Error = std::convert::Infallible;
 
     #[inline]

--- a/ohkami/src/fang/middleware/mod.rs
+++ b/ohkami/src/fang/middleware/mod.rs
@@ -1,9 +1,9 @@
 pub mod util;
-use super::{Fang, BoxedFPC, SendSyncOnNative};
+use super::{Fang, BoxedFPC, SendSyncOnThreaded};
 
 
 #[allow(private_interfaces)]
-pub trait Fangs: SendSyncOnNative + 'static {
+pub trait Fangs: SendSyncOnThreaded + 'static {
     // returning box for object-safety
     fn build(&self, inner: BoxedFPC) -> BoxedFPC;
 

--- a/ohkami/src/lib.rs
+++ b/ohkami/src/lib.rs
@@ -91,25 +91,26 @@ mod __rt__ {
     #[cfg(feature="rt_nio")]
     pub(crate) use nio::time::sleep;
     #[cfg(feature="rt_glommio")]
-    pub(crate) fn sleep(duration: std::time::Duration) -> impl std::future::Future<Output = ()> + Send {
-        return SendFuture(glommio::timer::sleep(duration));
-
-        ///////////////////////////////////////////////////////////
-
-        use std::{future::Future, pin::Pin, task::{Context, Poll}};
-
-        struct SendFuture<F>(F);
-
-        // SAFETY: sleep is executed on the same thread in glommio
-        unsafe impl<F> Send for SendFuture<F> {}
-
-        impl<F: Future<Output = ()>> Future for SendFuture<F> {
-            type Output = ();
-            fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-                unsafe {self.map_unchecked_mut(|this| &mut this.0)}.poll(cx)
-            }
-        }
-    }
+    pub(crate) use glommio::timer::sleep;
+//    pub(crate) fn sleep(duration: std::time::Duration) -> impl std::future::Future<Output = ()> + Send {
+//        return SendFuture(glommio::timer::sleep(duration));
+//
+//        ///////////////////////////////////////////////////////////
+//
+//        use std::{future::Future, pin::Pin, task::{Context, Poll}};
+//
+//        struct SendFuture<F>(F);
+//
+//        // SAFETY: sleep is executed on the same thread in glommio
+//        unsafe impl<F> Send for SendFuture<F> {}
+//
+//        impl<F: Future<Output = ()>> Future for SendFuture<F> {
+//            type Output = ();
+//            fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+//                unsafe {self.map_unchecked_mut(|this| &mut this.0)}.poll(cx)
+//            }
+//        }
+//    }
 
     #[cfg(any(feature="rt_tokio", feature="rt_smol", feature="rt_nio"))]
     mod task {

--- a/ohkami/src/lib.rs
+++ b/ohkami/src/lib.rs
@@ -92,25 +92,6 @@ mod __rt__ {
     pub(crate) use nio::time::sleep;
     #[cfg(feature="rt_glommio")]
     pub(crate) use glommio::timer::sleep;
-//    pub(crate) fn sleep(duration: std::time::Duration) -> impl std::future::Future<Output = ()> + Send {
-//        return SendFuture(glommio::timer::sleep(duration));
-//
-//        ///////////////////////////////////////////////////////////
-//
-//        use std::{future::Future, pin::Pin, task::{Context, Poll}};
-//
-//        struct SendFuture<F>(F);
-//
-//        // SAFETY: sleep is executed on the same thread in glommio
-//        unsafe impl<F> Send for SendFuture<F> {}
-//
-//        impl<F: Future<Output = ()>> Future for SendFuture<F> {
-//            type Output = ();
-//            fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-//                unsafe {self.map_unchecked_mut(|this| &mut this.0)}.poll(cx)
-//            }
-//        }
-//    }
 
     #[cfg(any(feature="rt_tokio", feature="rt_smol", feature="rt_nio"))]
     mod task {

--- a/ohkami/src/ohkami/_test.rs
+++ b/ohkami/src/ohkami/_test.rs
@@ -185,11 +185,11 @@ fn my_ohkami() -> Ohkami {
     }
     struct IncrementProc<Inner: FangProc>(Inner);
     impl<Inner: FangProc> FangProc for IncrementProc<Inner> {
-        fn bite<'b>(&'b self, req: &'b mut Request) -> impl std::future::Future<Output = Response> + Send {
+        async fn bite<'b>(&'b self, req: &'b mut Request) -> Response {
             crate::DEBUG!("Called `Increment`");
 
             *N().lock().unwrap() += 1;
-            self.0.bite(req)
+            self.0.bite(req).await
         }
     }
 

--- a/ohkami/src/ohkami/mod.rs
+++ b/ohkami/src/ohkami/mod.rs
@@ -1006,10 +1006,6 @@ mod sync {
                     WAKER_INDEX.fetch_add(1, Ordering::Relaxed)
                 };
 
-                #[cfg(debug_assertions)] {
-                    assert_eq!(index, WAKERS.read().unwrap().len());
-                }
-
                 /* ensure that `WAKERS` has the same numbers of `Waker`s as `CtrlC` instances */
                 WAKERS.write().unwrap().push(AtomicPtr::new(null_mut()));
 

--- a/ohkami/src/ohkami/mod.rs
+++ b/ohkami/src/ohkami/mod.rs
@@ -1147,8 +1147,9 @@ mod test {
         });
     }
 
+    #[cfg(feature="__rt_threaded__")]
     #[test]
-    fn ohkami_is_send_sync_static_on_native() {
+    fn ohkami_is_send_sync_static_on_rt_native_threaded() {
         fn is_send_sync_static<T: Send + Sync + 'static>(_: T) {}
 
         let o = Ohkami::new((

--- a/ohkami/src/request/context.rs
+++ b/ohkami/src/request/context.rs
@@ -1,11 +1,11 @@
-use crate::fang::SendSyncOnNative;
+use crate::fang::SendSyncOnThreaded;
 use ohkami_lib::map::TupleMap;
 use std::any::{Any, TypeId};
 
-#[cfg(feature="rt_worker")]
-type StoreItem = Box<dyn Any>;
-#[cfg(not(feature="rt_worker"))]
+#[cfg(feature="__rt_threaded__")]
 type StoreItem = Box<dyn Any + Send + Sync>;
+#[cfg(not(feature="__rt_threaded__"))]
+type StoreItem = Box<dyn Any>;
 
 pub struct Context {
     store: Option<Box<TupleMap<TypeId, StoreItem>>>,
@@ -51,7 +51,7 @@ impl Context {
 
 impl Context {
     #[inline]
-    pub fn set<Data: SendSyncOnNative + 'static>(&mut self, value: Data) {
+    pub fn set<Data: SendSyncOnThreaded + 'static>(&mut self, value: Data) {
         if self.store.is_none() {
             self.store = Some(Box::new(TupleMap::new()));
         }
@@ -60,7 +60,7 @@ impl Context {
     }
 
     #[inline]
-    pub fn get<Data: SendSyncOnNative + 'static>(&self) -> Option<&Data> {
+    pub fn get<Data: SendSyncOnThreaded + 'static>(&self) -> Option<&Data> {
         self.store.as_ref().and_then(|map| map
             .get(&TypeId::of::<Data>())
             .map(|boxed| {

--- a/ohkami/src/request/query.rs
+++ b/ohkami/src/request/query.rs
@@ -85,7 +85,8 @@ const _: () = {
 
 #[cfg(not(feature="rt_worker"))]
 #[cfg(test)]
-#[test] fn query_iter() {
+#[test]
+fn query_iter() {
     let case = QueryParams(Slice::from_bytes(b"abc=def&xyz=123"));
     assert_eq!(case.iter().collect::<Vec<_>>(), [
         ("abc".into(), "def".into()),

--- a/ohkami/src/util.rs
+++ b/ohkami/src/util.rs
@@ -62,7 +62,7 @@ macro_rules! push_unchecked {
 
 pub use crate::fang::FangAction;
 
-pub use crate::fang::bound::{SendOnNative, SendSyncOnNative};
+pub use crate::fang::bound::{SendOnThreaded, SendSyncOnThreaded};
 
 pub use ohkami_lib::{percent_decode, percent_decode_utf8, percent_encode};
 

--- a/samples/issue_550_glommio/Cargo.toml
+++ b/samples/issue_550_glommio/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name    = "issue_550_glommio"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+# set `default-features = false` to assure "DEBUG" feature be off even when DEBUGing `../ohkami`
+ohkami  = { path = "../../ohkami", default-features = false, features = ["rt_glommio"] }
+glommio = "0.9"
+
+[features]
+DEBUG = ["ohkami/DEBUG"]

--- a/samples/issue_550_glommio/README.md
+++ b/samples/issue_550_glommio/README.md
@@ -1,0 +1,6 @@
+# A regression sample to reproduce issue #550
+
+To test [issue #550](https://github.com/ohkami-rs/ohkami/issues/550), run `cargo run`.
+
+As for v0.24.0, this fails to compile as described in the issue.
+v0.24.1 fixes it.

--- a/samples/issue_550_glommio/src/main.rs
+++ b/samples/issue_550_glommio/src/main.rs
@@ -1,0 +1,20 @@
+use ohkami::prelude::*;
+use ohkami::util::num_cpus;
+use glommio::{LocalExecutorPoolBuilder, PoolPlacement, CpuSet, executor};
+
+async fn echo_id(Path(id): Path<String>) -> String {
+    // let executor = executor();
+    // executor.spawn_blocking(move || id).await
+    id
+}
+
+fn main() {
+    LocalExecutorPoolBuilder::new(PoolPlacement::MaxSpread(
+        dbg!(num_cpus::get()), dbg!(CpuSet::online().ok())
+    )).on_all_shards(|| {
+        Ohkami::new((
+            "/user/:id"
+                .GET(echo_id),
+        )).howl("0.0.0.0:3000")
+    }).unwrap().join_all();
+}

--- a/samples/issue_550_glommio/src/main.rs
+++ b/samples/issue_550_glommio/src/main.rs
@@ -3,9 +3,8 @@ use ohkami::util::num_cpus;
 use glommio::{LocalExecutorPoolBuilder, PoolPlacement, CpuSet, executor};
 
 async fn echo_id(Path(id): Path<String>) -> String {
-    // let executor = executor();
-    // executor.spawn_blocking(move || id).await
-    id
+    let executor = executor();
+    executor.spawn_blocking(move || id).await
 }
 
 fn main() {

--- a/samples/test.sh
+++ b/samples/test.sh
@@ -4,6 +4,9 @@ set -Ceu
 
 SAMPLES=$(pwd)
 
+cd $SAMPLES/issue_550_glommio && \
+    cargo check
+
 cd $SAMPLES/openapi-schema-enums && \
     cargo run && \
     diff openapi.json openapi.json.sample


### PR DESCRIPTION
- close #550 
- tested by:
  - samples/issue_550_glommio (via samples/test.sh by CI)
  - ohkami::fang::handler::into_handler::handler_args test (via CI)

---

This PR adds `__rt_threaded__` internal feature flag and changes fang::bound to:

- `SendSyncOnNative` -> `SendSyncOnThreaded`
- `SendOnNative` -> `SendOnThreaded`
- `SendOnNativeFuture` -> `SendOnThreadedFuture`

to correctly handle thread-per-core async runtimes including `glommio`: `__rt_threaded__` is activated by

- `rt_tokio`
- `rt_smol`
- `rt_nio`
- `rt_lambda`

and not activated by

- `rt_glommio`
- `rt_worker`

Additionally, removing an wrong debug assertion in `ohkami::sync::CtrlC::new`: `assert_eq!(index, WAKERS.read().unwrap().len());`.
(There just the amount number of them matters, not the index order. This assertion will cause some panics in thread-per-core runtimes)