### PR TITLE
Add support for monoio runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ exclude  = [
     "benches_rt/nio",
     "benches_rt/smol",
     "benches_rt/tokio",
+    "benches_rt/monoio",
     "benches_rt/vs_actix-web",
 ]
 

--- a/README.md
+++ b/README.md
@@ -206,12 +206,13 @@ async fn handler1(
 
 ## Feature flags
 
-### `"rt_tokio"`, `"rt_smol"`, `"rt_nio"`, `"rt_glommio"` : native async runtime
+### `"rt_tokio"`, `"rt_smol"`, `"rt_nio"`, `"rt_glommio"`, `"rt_monoio"` : native async runtime
 
 - [tokio](https://github.com/tokio-rs/tokio) _v1.\*.\*_
 - [smol](https://github.com/smol-rs/smol) _v2.\*.\*_
 - [nio](https://github.com/nurmohammed840/nio) _v0.0.\*_
 - [glommio](https://github.com/DataDog/glommio) _v0.9.\*_
+- [monoio](https://github.com/bytedance/monoio) _v0.2.\*_
 
 ### `"rt_worker"` : Cloudflare Workers
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -17,7 +17,7 @@ tasks:
   test:core:
     deps:
       - task: test:no_rt
-      - for:  [tokio, smol, nio, glommio, lambda, worker]
+      - for:  [tokio, smol, nio, glommio, monoio, lambda, worker]
         task: test:rt
         vars: { rt: '{{.ITEM}}' }
   test:other:
@@ -30,7 +30,7 @@ tasks:
   check:
     deps:
       - task: check:no_rt
-      - for:  [tokio, smol, nio, glommio, lambda]
+      - for:  [tokio, smol, nio, glommio, monoio, lambda]
         task: check:rt-native
         vars: { rt: '{{.ITEM}}' }
       - task: check:rt_worker
@@ -41,7 +41,7 @@ tasks:
     cmds:
       - cd benches && cargo bench --features DEBUG --no-run
       - cd benches_rt/vs_actix-web && cargo check
-      - for: [tokio, smol, nio, glommio]
+      - for: [tokio, smol, nio, glommio, monoio]
         cmd: cd benches_rt/{{.ITEM}} && cargo check
 
   bench:

--- a/benches_rt/monoio/Cargo.toml
+++ b/benches_rt/monoio/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name    = "ohkami_benches-with-monoio"
+version = "0.0.0"
+edition = "2024"
+authors = ["kanarus <kanarus786@gmail.com>"]
+
+[dependencies]
+# set `default-features = false` to assure "DEBUG" feature be off even when DEBUGing `../ohkami`
+ohkami  = { path = "../../ohkami", default-features = false, features = ["rt_monoio"] }
+monoio  = { version = "0.2" }
+
+[profile.release]
+lto           = true
+panic         = "abort"
+codegen-units = 1
+
+[features]
+DEBUG = ["ohkami/DEBUG"]

--- a/benches_rt/monoio/src/bin/param.rs
+++ b/benches_rt/monoio/src/bin/param.rs
@@ -1,0 +1,20 @@
+use ohkami::prelude::*;
+
+
+#[inline(always)]
+async fn echo_id(Path(id): Path<String>) -> String {
+    id
+}
+
+fn main() {
+    monoio::RuntimeBuilder::<monoio::FusionDriver>::new()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on({
+            Ohkami::new((
+                "/user/:id"
+                .GET(echo_id),
+            )).howl("0.0.0.0:3000")
+        })
+}

--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -32,6 +32,8 @@ tokio          = { version = "1",    optional = true }
 smol           = { version = "2",    optional = true }
 nio            = { version = "0.0",  optional = true }
 glommio        = { version = "0.9",  optional = true }
+monoio         = { version = "0.2",  optional = true }
+monoio-compat  = { version = "0.2",  optional = true }
 worker         = { version = "0.6",  optional = true }
 lambda_runtime = { version = "0.14", optional = true }
 
@@ -68,6 +70,10 @@ rt_glommio = ["__rt_native__", "__io_futures__",
     "dep:glommio",
     "mews?/rt_glommio",
     "dep:num_cpus",
+]
+rt_monoio = ["__rt_native__", "__io_tokio__",
+    "dep:monoio",
+    "dep:monoio-compat",
 ]
 rt_worker = ["__rt__",
     "dep:worker", "worker/d1", "worker/queue",


### PR DESCRIPTION
I saw #446. monoio does provide [`monoio-compat`](https://crates.io/crates/monoio-compat) to convert to tokio types so decided to give it a try. Haven't tested this extensively yes but it seems to work with the minimal `benches_rt` example.