### PR TITLE
feat: add support for compio runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ exclude  = [
     "benches_rt/smol",
     "benches_rt/tokio",
     "benches_rt/monoio",
+    "benches_rt/compio",
     "benches_rt/vs_actix-web",
 ]
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <br>
 
 - *macro-less and type-safe* APIs for declarative, ergonomic code
-- *runtime-flexible* ： `tokio`, `smol`, `nio`, `glommio`, `monoio` and `worker` (Cloudflare Workers), `lambda` (AWS Lambda)
+- *runtime-flexible* ： `tokio`, `smol`, `nio`, `glommio`, `monoio`, `compio` and `worker` (Cloudflare Workers), `lambda` (AWS Lambda)
 - good performance, no-network testing, well-structured middlewares, Server-Sent Events, WebSocket, highly integrated OpenAPI document generation, ...
 
 <div align="right">
@@ -206,13 +206,14 @@ async fn handler1(
 
 ## Feature flags
 
-### `"rt_tokio"`, `"rt_smol"`, `"rt_nio"`, `"rt_glommio"`, `"rt_monoio"` : native async runtime
+### `"rt_tokio"`, `"rt_smol"`, `"rt_nio"`, `"rt_glommio"`, `"rt_monoio"`, `"rt_compio"` : native async runtime
 
 - [tokio](https://github.com/tokio-rs/tokio) _v1.\*.\*_
 - [smol](https://github.com/smol-rs/smol) _v2.\*.\*_
 - [nio](https://github.com/nurmohammed840/nio) _v0.0.\*_
 - [glommio](https://github.com/DataDog/glommio) _v0.9.\*_
 - [monoio](https://github.com/bytedance/monoio) _v0.2.\*_
+- [compio](https://github.com/compio-rs/compio) _v0.15.\*_
 
 ### `"rt_worker"` : Cloudflare Workers
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -17,7 +17,7 @@ tasks:
   test:core:
     deps:
       - task: test:no_rt
-      - for:  [tokio, smol, nio, glommio, monoio, lambda, worker]
+      - for:  [tokio, smol, nio, glommio, monoio, compio, lambda, worker]
         task: test:rt
         vars: { rt: '{{.ITEM}}' }
   test:other:
@@ -32,7 +32,7 @@ tasks:
       - task: check:fmt
       - task: check:clippy
       - task: check:no_rt
-      - for:  [tokio, smol, nio, glommio, monoio, lambda]
+      - for:  [tokio, smol, nio, glommio, monoio, compio, lambda]
         task: check:rt-native
         vars: { rt: '{{.ITEM}}' }
       - task: check:rt_worker
@@ -43,7 +43,7 @@ tasks:
     cmds:
       - cd benches && cargo bench --features DEBUG --no-run
       - cd benches_rt/vs_actix-web && cargo check
-      - for: [tokio, smol, nio, glommio, monoio]
+      - for: [tokio, smol, nio, glommio, monoio, compio]
         cmd: cd benches_rt/{{.ITEM}} && cargo check
 
   bench:
@@ -100,7 +100,7 @@ tasks:
   check:fmt:
     cmds:
       - cargo fmt --check
-  
+
   check:clippy:
     cmds:
       - cargo clippy --all-targets --features DEBUG,rt_tokio,sse,ws,openapi,tls -- --deny warnings   # threaded runtime

--- a/benches_rt/compio/Cargo.toml
+++ b/benches_rt/compio/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name    = "ohkami_benches-with-compio"
+version = "0.0.0"
+edition = "2024"
+authors = ["kanarus <kanarus786@gmail.com>"]
+
+[dependencies]
+# set `default-features = false` to assure "DEBUG" feature be off even when DEBUGing `../ohkami`
+ohkami  = { path = "../../ohkami", default-features = false, features = ["rt_compio"] }
+compio = { version = "0.15" }
+
+[profile.release]
+lto           = true
+panic         = "abort"
+codegen-units = 1
+
+[features]
+DEBUG = ["ohkami/DEBUG"]

--- a/benches_rt/compio/src/bin/param.rs
+++ b/benches_rt/compio/src/bin/param.rs
@@ -1,0 +1,16 @@
+use ohkami::prelude::*;
+
+
+#[inline(always)]
+async fn echo_id(Path(id): Path<String>) -> String {
+    id
+}
+
+fn main() {
+    compio::runtime::Runtime::new().unwrap().block_on({
+        Ohkami::new((
+            "/user/:id"
+            .GET(echo_id),
+        )).howl("0.0.0.0:3000")
+    })
+}

--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -36,6 +36,7 @@ nio            = { version = "0.0",  optional = true }
 glommio        = { version = "0.9",  optional = true }
 monoio         = { version = "0.2",  optional = true, features = ["signal"] }
 monoio-compat  = { version = "0.2",  optional = true }
+compio         = { version = "0.15", optional = true, features = ["io-compat", "time"] }
 worker         = { version = "0.6",  optional = true }
 lambda_runtime = { version = "0.14", optional = true }
 
@@ -72,6 +73,9 @@ rt_glommio = ["__rt_native__", "__io_futures__",
 rt_monoio = ["__rt_native__", "__io_tokio__",
     "dep:monoio",
     "dep:monoio-compat",
+]
+rt_compio = ["__rt_native__", "__io_futures__",
+    "dep:compio",
 ]
 rt_worker = ["__rt__",
     "dep:worker", "worker/d1", "worker/queue",

--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -36,7 +36,7 @@ nio            = { version = "0.0",  optional = true }
 glommio        = { version = "0.9",  optional = true }
 monoio         = { version = "0.2",  optional = true, features = ["signal"] }
 monoio-compat  = { version = "0.2",  optional = true }
-compio         = { version = "0.15", optional = true, features = ["io-compat", "time"] }
+compio         = { version = "0.16", optional = true, features = ["io-compat", "time"] }
 worker         = { version = "0.6",  optional = true }
 lambda_runtime = { version = "0.14", optional = true }
 


### PR DESCRIPTION
I probably should've opened an issue first, but the change is quite simple so I decided to just implement and played around with it. Feel free to not merge if it's not suitable.

This adds support for the [`compio`](https://github.com/compio-rs/compio) runtime, another thread per core runtime that supports macOS, Linux and Windows. The API is similar to that of `monoio` and they do provide a `futures` compat layer. It same problem with Ctrl+C as `monoio` stated in #564. However, running the same benchmark as you did `564` the performance seems to be lower that other runtimes.