### PR TITLE
fix(worker): `#[wasm_bindgen]` handling in `#[DurableObject]`

### DIFF
--- a/ohkami_macros/src/worker.rs
+++ b/ohkami_macros/src/worker.rs
@@ -365,11 +365,11 @@ pub fn DurableObject(args: TokenStream, object: TokenStream) -> Result<TokenStre
             // `#[wasm_bindgen]` attribute fully uses this module
             use ::worker::wasm_bindgen;
 
-            #[::worker::wasm_bindgen::prelude::wasm_bindgen]
+            #[::worker::wasm_bindgen::prelude::wasm_bindgen(wasm_bindgen = ::worker::wasm_bindgen)]
             #[::ohkami::__internal__::consume_struct]
             #object
 
-            #[::worker::wasm_bindgen::prelude::wasm_bindgen]
+            #[::worker::wasm_bindgen::prelude::wasm_bindgen(wasm_bindgen = ::worker::wasm_bindgen)]
             impl #name {
                 #(#methods)*
             }


### PR DESCRIPTION
Currently `samples/worker-durable-websocket` fails to compile:

```stdout
cargo check
   Compiling ohkami_macros v0.24.1 (/home/kanarus/projects/ohkami-rs/ohkami/ohkami_macros)
    Checking ohkami v0.24.1 (/home/kanarus/projects/ohkami-rs/ohkami/ohkami)
    Checking worker-with-openapi v0.1.0 (/home/kanarus/projects/ohkami-rs/ohkami/samples/worker-durable-websocket)
error[E0433]: failed to resolve: could not find `wasm_bindgen` in the list of imported crates
 --> src/room.rs:7:1
  |
7 | #[DurableObject]
  | ^^^^^^^^^^^^^^^^ could not find `wasm_bindgen` in the list of imported crates
  |
  = note: this error originates in the attribute macro `::ohkami::wasm_bindgen::prelude::wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)

error: cannot find attribute `wasm_bindgen` in this scope
 --> src/room.rs:7:1
  |
7 | #[DurableObject]
  | ^^^^^^^^^^^^^^^^
  |
note: `wasm_bindgen` is imported here, but it is a crate, not an attribute
 --> src/room.rs:7:1
  |
7 | #[DurableObject]
  | ^^^^^^^^^^^^^^^^
  = note: this error originates in the attribute macro `::ohkami::wasm_bindgen::prelude::wasm_bindgen` which comes from the expansion of the attribute macro `DurableObject` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the trait bound `Room: IntoWasmAbi` is not satisfied
 --> src/room.rs:7:1
  |
7 | #[DurableObject]
  | ^^^^^^^^^^^^^^^^ the trait `IntoWasmAbi` is not implemented for `Room`
  |
  = help: the following other types implement trait `IntoWasmAbi`:
            &'a ArrayBuffer
            &'a BigInt
            &'a BigInt64Array
            &'a BigUint64Array
            &'a CacheQueryOptions
            &'a CacheStorage
            &'a CfVersionMetadata
            &'a Collator
          and 396 others
  = note: required for `Room` to implement `ReturnWasmAbi`
  = note: this error originates in the attribute macro `wasm_bindgen::prelude::__wasm_bindgen_class_marker` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the trait bound `Room: IntoWasmAbi` is not satisfied
 --> src/room.rs:7:1
  |
7 | #[DurableObject]
  | ^^^^^^^^^^^^^^^^ the trait `IntoWasmAbi` is not implemented for `Room`
  |
  = help: the following other types implement trait `IntoWasmAbi`:
            &'a ArrayBuffer
            &'a BigInt
            &'a BigInt64Array
            &'a BigUint64Array
            &'a CacheQueryOptions
            &'a CacheStorage
            &'a CfVersionMetadata
            &'a Collator
          and 396 others
  = note: required for `Room` to implement `ReturnWasmAbi`
  = note: this error originates in the attribute macro `::ohkami::wasm_bindgen::prelude::wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the trait bound `Room: ohkami::wasm_bindgen::describe::WasmDescribe` is not satisfied
   --> src/room.rs:8:8
    |
  8 | struct Room {
    |        ^^^^ the trait `ohkami::wasm_bindgen::describe::WasmDescribe` is not implemented for `Room`
    |
    = help: the following other types implement trait `ohkami::wasm_bindgen::describe::WasmDescribe`:
              &T
              &mut T
              ()
              *const T
              *mut T
              ArrayBuffer
              BigInt
              BigInt64Array
            and 197 others
note: required by a bound in `return_abi`
   --> /home/kanarus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wasm-bindgen-0.2.101/src/convert/traits.rs:237:26
    |
237 | pub trait ReturnWasmAbi: WasmDescribe {
    |                          ^^^^^^^^^^^^ required by this bound in `ReturnWasmAbi::return_abi`
...
243 |     fn return_abi(self) -> Self::Abi;
    |        ---------- required by a bound in this associated function

error[E0277]: JavaScript constructors are not supported for `Room`
  --> src/room.rs:7:1
   |
 7 | #[DurableObject]
   | ^^^^^^^^^^^^^^^^ this function cannot be the constructor of `Room`
   |
   = help: the trait `SupportsConstructor` is not implemented for `Room`
   = note: `#[wasm_bindgen(constructor)]` is only supported for `struct`s and cannot be used for `enum`s.
   = note: Consider removing the `constructor` option and using a regular static method instead.
   = help: the following other types implement trait `SupportsConstructor`:
             MinifyConfig
             R2Range
note: required by a bound in `CheckSupportsConstructor`
  --> /home/kanarus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wasm-bindgen-0.2.101/src/rt/marker.rs:15:40
   |
15 | pub struct CheckSupportsConstructor<T: SupportsConstructor>(T);
   |                                        ^^^^^^^^^^^^^^^^^^^ required by this bound in `CheckSupportsConstructor`
   = note: this error originates in the attribute macro `wasm_bindgen::prelude::__wasm_bindgen_class_marker` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: the trait bound `Room: ohkami::wasm_bindgen::describe::WasmDescribe` is not satisfied
 --> src/room.rs:8:8
  |
8 | struct Room {
  |        ^^^^ the trait `ohkami::wasm_bindgen::describe::WasmDescribe` is not implemented for `Room`
  |
  = help: the following other types implement trait `ohkami::wasm_bindgen::describe::WasmDescribe`:
            &T
            &mut T
            ()
            *const T
            *mut T
            ArrayBuffer
            BigInt
            BigInt64Array
          and 197 others

error[E0277]: the trait bound `Room: RefMutFromWasmAbi` is not satisfied
 --> src/room.rs:8:8
  |
8 | struct Room {
  |        ^^^^ the trait `RefMutFromWasmAbi` is not implemented for `Room`
  |
  = help: the following other types implement trait `RefMutFromWasmAbi`:
            MinifyConfig
            R2Range
            [MaybeUninit<f32>]
            [MaybeUninit<f64>]
            [MaybeUninit<i16>]
            [MaybeUninit<i32>]
            [MaybeUninit<i64>]
            [MaybeUninit<i8>]
          and 18 others

error[E0277]: the trait bound `Room: RefMutFromWasmAbi` is not satisfied
 --> src/room.rs:7:1
  |
7 | #[DurableObject]
  | ^^^^^^^^^^^^^^^^ the trait `RefMutFromWasmAbi` is not implemented for `Room`
  |
  = help: the following other types implement trait `RefMutFromWasmAbi`:
            MinifyConfig
            R2Range
            [MaybeUninit<f32>]
            [MaybeUninit<f64>]
            [MaybeUninit<i16>]
            [MaybeUninit<i32>]
            [MaybeUninit<i64>]
            [MaybeUninit<i8>]
          and 18 others
  = note: this error originates in the attribute macro `wasm_bindgen::prelude::__wasm_bindgen_class_marker` (in Nightly builds, run with -Z macro-backtrace for more info)

Some errors have detailed explanations: E0277, E0433.
For more information about an error, try `rustc --explain E0277`.
error: could not compile `worker-with-openapi` (lib) due to 17 previous errors
```

The factor for this error is handling of `#[wasm_bindgen]` exported from `wasm_bindgen` that is re-exported from `worker`. It's fixed just by:

```diff
- #[::worker::wasm_bindgen::prelude::wasm_bindgen]
+ #[::worker::wasm_bindgen::prelude::wasm_bindgen(wasm_bindgen = ::worker::wasm_bindgen)]
```