### PR TITLE
enhance(fang): allow some wildcard syntax for `Cors::with_trusted_origins`

### DIFF
--- a/examples/jwt/src/main.rs
+++ b/examples/jwt/src/main.rs
@@ -2,7 +2,7 @@ use ohkami::prelude::*;
 use ohkami::fang::{Jwt, JwtToken};
 
 fn jwt() -> Jwt<JwtPayload> {
-    Jwt::default(std::env::var("JWT_SECRET").unwrap())
+    Jwt::new_hs256(std::env::var("JWT_SECRET").unwrap())
 }
 
 #[derive(Serialize, Deserialize)]

--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -46,6 +46,9 @@ hmac   = { version = "0.12", default-features = false }
 sha2   = { version = "0.10", default-features = false }
 uuid   = { version = "1.22" }
 
+# parsing
+http        = { version = "1.4.1" }
+
 # optional
 mime_guess   = { version = "2.0", optional = true }
 ctrlc        = { version = "3.5",  optional = true }

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -22,30 +22,50 @@ mod timeout;
 pub use timeout::Timeout;
 
 fn validate_origin(origin: &str) -> Result<(), &'static str> {
+    //Adds a check for the first characters being http or https, so it cannot be malformed like foobarhttp://example.org/
+    if !origin.starts_with("http") {
+        return Err("invalid origin: 'http' or 'https' scheme is required at the start of the string.")
+    }
     let Some(("http" | "https", rest)) = origin.split_once("://") else {
-        return Err("invalid origin: 'http' or 'https' scheme is required");
+        return Err("invalid origin: 'http' or 'https' scheme is required.");
     };
+    //Adds a check for the maximum length of a domain
+    if rest.chars().count() > 253 {
+        return Err("invalid origin: maximum length 253 for domain exceeded.")
+    }
     let (host, port) = rest
         .split_once(':')
         .map_or((rest, None), |(h, p)| (h, Some(p)));
-    if port.is_some_and(|p| !p.chars().all(|c| c.is_ascii_digit())) {
-        return Err("invalid origin: port must be a number");
+     if port.is_some_and(|p| p != "*" && p.parse::<u16>().is_err()) {
+        return Err("invalid origin: port must be a number between 0 and 65535 or wildcard '*'.");
     }
-    if !host.starts_with(|c: char| c.is_ascii_alphabetic()) {
-        return Err("invalid origin: host must start with an alphabetic character");
+    if !host.starts_with(|c: char| c.is_ascii_alphanumeric() || c == '*') {
+        return Err("invalid origin: host must start with an alphanumeric character or wildcard '*'.");
     }
     if !host.split('.').all(|part| {
         !part.is_empty()
-            && part
-                .chars()
-                .all(|c| matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_'))
+        && part.chars().all(|c| matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '*')
+        && part.chars().count() <= 63)
     }) {
-        if host.contains(['/', '?', '#']) {
+        return if host.contains(['/', '?', '#']) {
             // helpful error message for common mistake
-            return Err("invalid origin: path, query and fragment are not allowed");
+            Err("invalid origin: path, query and fragment are not allowed.")
         } else {
-            return Err("invalid origin: invalid host");
+            Err("invalid origin: invalid host.")
         }
     }
+
+    if host.contains('.') {
+        let Some((subdomain, sld)) = host.split_once('.') else {
+            return Err("invalid origin: invalid host")
+        };
+
+        if sld.split('.').all(|part| part.chars().all(|c| c.is_numeric())) {
+            if subdomain == "*" {
+                return Err("invalid origin: subdomain wildcard not allowed in IP")
+            }
+        }
+    }
+
     Ok(())
 }

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -26,13 +26,10 @@ mod timeout;
 pub use timeout::Timeout;
 
 /* #660 will replace this with an original struct
-   (providing almost the same interface as this
-   using original implementations internally)
+   (providing almost the same interface as this using original implementations internally)
 */
-// Just wrapping `https::uri::Uri` for now
-// to skip most difficult things in parsing,
-// so we only have to handle HTTP-origin-specific rules
-// on the top of the generic `Uri`.
+// Just wrapping `https::uri::Uri` for now to skip most difficult things in parsing,
+// so we only have to handle HTTP-origin-specific rules on the top of the generic `Uri`.
 #[derive(Clone, Debug)]
 pub struct Origin(Uri);
 
@@ -53,8 +50,31 @@ pub enum Scheme {
 }
 
 impl Origin {
-    /* This replaces current `fn validate_origin` entirely */
-    /// Parse string into HTTP origin
+    /// Parse string into HTTP origin.
+    ///
+    /// # Arguments
+    /// * `s`: &str - The string that represents the URI that should be added to the Origin struct.
+    ///
+    /// returns: Self (Origin)
+    ///
+    /// # Examples
+    /// ```rust
+    /// fn run() {
+    ///     Origin::new("https://localhost:3000").unwrap();
+    /// }
+    /// ```
+    /// # Errors
+    ///
+    /// This function will return an error if the given URI string fails the validation included in this function.
+    /// Rules include:
+    ///
+    /// - Generalistic http::uri::Uri rules for URI's.
+    /// - Scheme must be either HTTP or HTTPS.
+    /// - URI length mustn't exceed 255 characters in total.
+    /// - URI parts mustn't exceed 63 characters per.
+    /// - Ports must be numeric.
+    /// - IP strings like 192.168.1.0 cannot have wildcards.
+    ///
     fn new(s: &str) -> Result<Self, OriginError> {
         use http::uri::{Uri, Scheme};
 
@@ -90,12 +110,10 @@ impl Origin {
             return Err(OriginError::FaultyPort)
         }
 
-        // TODO: Add more if necessary
-
         Ok(Self(uri))
     }
 
-    // Accessor methods for origin components; for example:
+    /// Returns the scheme of this [`Origin`].
     #[allow(unused)]
     fn scheme(&self) -> Scheme {
         if self.0.scheme() == Some(&http::uri::Scheme::HTTP) {
@@ -107,15 +125,18 @@ impl Origin {
         // we just have to access `.scheme` field or something like that
     }
 
+    /// Returns the port of this [`Origin`].
     fn port(&self) -> Option<u16> {
         self.0.port_u16()
     }
 
+    /// Returns the host of this [`Origin`].
     #[allow(unused)]
     fn host(&self) -> Option<&str> {
         self.0.host()
     }
 
+    /// Returns the host as subdomain and domain of this [`Origin`] in a tuple struct like (subdomain: Option<&str>, domain: &str).
     fn host_as_subdomain_and_domain(&self) -> (Option<&str>, &str) {
         if let Some(host) = self.0.host() {
             host.split_once('.')
@@ -131,8 +152,6 @@ impl Origin {
         }
 
     }
-
-    // and more... (as needed)
 }
 
 impl Display for Origin {

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -16,56 +16,17 @@ pub use context::Context;
 pub mod enamel;
 pub use enamel::Enamel;
 
+use http::uri::{InvalidUri, Uri};
+
 #[cfg(feature = "__rt_native__")]
 mod timeout;
 #[cfg(feature = "__rt_native__")]
 pub use timeout::Timeout;
 
 fn validate_origin(origin: &str) -> Result<(), &'static str> {
-    //Adds a check for the first characters being http or https, so it cannot be malformed like foobarhttp://example.org/
-    if !origin.starts_with("http") {
-        return Err("invalid origin: 'http' or 'https' scheme is required at the start of the string.")
+    if let Ok(_) = origin.parse::<Uri>() {
+        Ok(())
+    } else {
+        Err("Unable to parse Uri.")
     }
-    let Some(("http" | "https", rest)) = origin.split_once("://") else {
-        return Err("invalid origin: 'http' or 'https' scheme is required.");
-    };
-    //Adds a check for the maximum length of a domain
-    if rest.chars().count() > 253 {
-        return Err("invalid origin: maximum length 253 for domain exceeded.")
-    }
-    let (host, port) = rest
-        .split_once(':')
-        .map_or((rest, None), |(h, p)| (h, Some(p)));
-     if port.is_some_and(|p| p != "*" && p.parse::<u16>().is_err()) {
-        return Err("invalid origin: port must be a number between 0 and 65535 or wildcard '*'.");
-    }
-    if !host.starts_with(|c: char| c.is_ascii_alphanumeric() || c == '*') {
-        return Err("invalid origin: host must start with an alphanumeric character or wildcard '*'.");
-    }
-    if !host.split('.').all(|part| {
-        !part.is_empty()
-        && part.chars().all(|c| matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '*')
-        && part.chars().count() <= 63)
-    }) {
-        return if host.contains(['/', '?', '#']) {
-            // helpful error message for common mistake
-            Err("invalid origin: path, query and fragment are not allowed.")
-        } else {
-            Err("invalid origin: invalid host.")
-        }
-    }
-
-    if host.contains('.') {
-        let Some((subdomain, sld)) = host.split_once('.') else {
-            return Err("invalid origin: invalid host")
-        };
-
-        if sld.split('.').all(|part| part.chars().all(|c| c.is_numeric())) {
-            if subdomain == "*" {
-                return Err("invalid origin: subdomain wildcard not allowed in IP")
-            }
-        }
-    }
-
-    Ok(())
 }

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -75,7 +75,7 @@ impl Origin {
 
         // Additional validation
         // Validate scheme is HTTP or HTTPS
-        if let Some(scheme) = uri.scheme() && scheme != &Scheme::HTTP && scheme != &Scheme::HTTPS {
+        if uri.scheme().is_none_or(|s| s != &Scheme::HTTP && s != &Scheme::HTTPS) {
             return Err(OriginError::FaultyScheme);
         }
 

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -163,8 +163,47 @@ impl std::fmt::Display for OriginError {
     }
 }
 
+#[cfg(test)]
 mod test {
+    use super::{Origin, OriginError};
 
-    // #[test]
+    #[test]
+    fn origin_scheme_invalidation() {
+        let origin = "foobarhttp://example.com";
+        assert_eq!(OriginError::FaultyScheme, Origin::new(origin).unwrap_err())
+    }
 
+    #[test]
+    fn origin_length_invalidation() {
+        let origin = "https://thisisaridiculouslylongurithatshoulddefinitelybeinvalidaccordingtothistest.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com";
+        assert_eq!(OriginError::FaultyUriLength, Origin::new(origin).unwrap_err())
+    }
+
+    #[test]
+    fn origin_part_length_invalidation() {
+        let origin = "https://www.abcdefghijklmnopqrstuvwxyzabcdefghijklmnoqrstuvwxyzabcdefghijklmnopqrstuvwxyz.com";
+        assert_eq!(OriginError::FaultyUriPartLength, Origin::new(origin).unwrap_err())
+    }
+
+    #[test]
+    fn origin_port_invalidation() {
+        let origin = "http://example.com:abcd";
+        assert_eq!(OriginError::FaultyPort, Origin::new(origin).unwrap_err())
+    }
+
+    #[test]
+    fn origin_deny_invalid_ip_port_range() {
+        // Origin:new with a faulty IP should give OriginError::FaultyPort. This error cannot be compared with super::CorsOriginValue::matches(), due to it being an error.
+        assert_eq!(
+            OriginError::FaultyPort,
+            Origin::new("https://192.168.1.0:80080").unwrap_err(),
+        )
+    }
+
+    #[test]
+    fn origin_host_invalidation() {
+        assert!(
+            Origin::new("http://%example.com").is_err() //Gives InvalidUri error, which's enums aren't public so unable to directly compare.
+        )
+    }
 }

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -1,5 +1,5 @@
 mod basicauth;
-use core::{fmt::Display, option::Option::Some};
+use core::{fmt::{Display, write}, option::Option::Some};
 use std::fmt::Formatter;
 pub use basicauth::BasicAuth;
 
@@ -25,16 +25,6 @@ mod timeout;
 #[cfg(feature = "__rt_native__")]
 pub use timeout::Timeout;
 
-fn validate_origin(origin: &str) -> Result<(), &'static str> {
-    if origin.parse::<Uri>().is_ok() {
-        Ok(())
-    } else {
-        Err("Unable to parse Uri.")
-    }
-}
-
-// builtin.rs
-
 /* #660 will replace this with an original struct
    (providing almost the same interface as this
    using original implementations internally)
@@ -43,14 +33,16 @@ fn validate_origin(origin: &str) -> Result<(), &'static str> {
 // to skip most difficult things in parsing,
 // so we only have to handle HTTP-origin-specific rules
 // on the top of the generic `Uri`.
+#[derive(Clone, Debug)]
 struct Origin(Uri);
 
+#[derive(Debug)]
 enum OriginError {
     InvalidUri(InvalidUri),
-    InvalidScheme,
-    InvalidPathLength,
-    InvalidPartLength,
-    InvalidPort,
+    FaultyScheme,
+    FaultyUriLength,
+    FaultyUriPartLength,
+    FaultyPort,
     //...
 }
 
@@ -71,25 +63,23 @@ impl Origin {
         // Additional validation
         // Validate scheme is HTTP or HTTPS
         if let Some(scheme) = uri.scheme() && scheme != &Scheme::HTTP && scheme != &Scheme::HTTPS {
-            return Err(OriginError::InvalidScheme);
+            return Err(OriginError::FaultyScheme);
         }
 
         // Validate max path length
         if uri.path().chars().count() > u8::MAX as usize {
-            return Err(OriginError::InvalidPathLength)
+            return Err(OriginError::FaultyUriLength)
         }
 
         // Validate max part length
         if !uri.path().split('.').all(|part| part.chars().count() <= 63) {
-            return Err(OriginError::InvalidPartLength)
+            return Err(OriginError::FaultyUriPartLength)
         }
 
-        // // Make sure port isn't made out of letters, and doesn't exceed `u16::MAX`
-        // if let Some(port) = uri.port() {
-        //     if !port.as_str().chars().all(|c| c.is_numeric()) {
-        //         return Err(OriginError::InvalidPort)
-        //     }
-        // }
+        // Check if user intended to add a port to Origin, but it's parsed out by http::uri::Uri, return invalid port error
+        if let Some((_, rest)) = s.split_once(':') && rest.contains(':') && uri.port_u16().is_none() {
+            return Err(OriginError::FaultyPort)
+        }
 
         // TODO: Add more if necessary
 
@@ -158,5 +148,19 @@ impl Origin {
 impl Display for Origin {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+impl Display for OriginError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let output = match self {
+            OriginError::InvalidUri(_) => { "Invalid URI." }
+            OriginError::FaultyScheme => { "Please use HTTP or HTTPS as scheme." }
+            OriginError::FaultyUriLength => { "Uri length mustn't exceed 255 characters in total." }
+            OriginError::FaultyUriPartLength => { "Uri part length mustn't exceed 63 characters." }
+            OriginError::FaultyPort => { "Port number was expected." }
+        };
+
+        write!(f, "{}", output)
     }
 }

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -111,11 +111,14 @@ impl Origin {
 
     fn host_as_subdomain_and_domain(&self) -> (Option<&str>, &str) {
         if let Some(host) = self.0.host() {
-            let (subdomain, domain) = host
-                .split_once('.')
-                .map_or((None, host), |(s, d)| (Some(s), d));
-
-            (subdomain, domain)
+            host.split_once('.')
+                .map_or((None, host), |(subdomain, domain)| {
+                    if domain.contains('.') {
+                        (Some(subdomain), domain)
+                    } else {
+                        (None, host)
+                    }
+                })
         } else {
             (None, "")
         }

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -66,14 +66,16 @@ impl Origin {
             return Err(OriginError::FaultyScheme);
         }
 
-        // Validate max path length
-        if uri.path().chars().count() > u8::MAX as usize {
-            return Err(OriginError::FaultyUriLength)
-        }
+        if let Some(host) = uri.host() {
+            // Validate max host length
+            if host.chars().count() > u8::MAX as usize {
+                return Err(OriginError::FaultyUriLength)
+            }
 
-        // Validate max part length
-        if !uri.path().split('.').all(|part| part.chars().count() <= 63) {
-            return Err(OriginError::FaultyUriPartLength)
+            // Validate max part length
+            if !host.split('.').all(|part| part.chars().count() <= 63) {
+                return Err(OriginError::FaultyUriPartLength)
+            }
         }
 
         // Check if user intended to add a port to Origin, but it's parsed out by http::uri::Uri, return invalid port error
@@ -134,8 +136,8 @@ impl Display for OriginError {
         let output = match self {
             OriginError::InvalidUri(_) => { "Invalid URI." }
             OriginError::FaultyScheme => { "Please use HTTP or HTTPS as scheme." }
-            OriginError::FaultyUriLength => { "Uri length mustn't exceed 255 characters in total." }
-            OriginError::FaultyUriPartLength => { "Uri part length mustn't exceed 63 characters." }
+            OriginError::FaultyUriLength => { "URI length mustn't exceed 255 characters in total." }
+            OriginError::FaultyUriPartLength => { "URI part length mustn't exceed 63 characters." }
             OriginError::FaultyPort => { "Port number was expected." }
         };
 

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -99,6 +99,8 @@ impl Origin {
             if split_host.len() < 4 && host.chars().all(|c| c.is_numeric() || c == '.') {
                 return Err(OriginError::FaultyIp)
             }
+        } else {
+            return Err(OriginError::MalformedUri)
         }
 
         // Check if user intended to add a port to Origin, but it's parsed out by http::uri::Uri, return invalid port error

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -81,7 +81,7 @@ impl Origin {
 
         if let Some(host) = uri.host() {
             // Validate max host length
-            if host.chars().count() > u8::MAX as usize {
+            if host.chars().count() > 253 {
                 return Err(OriginError::FaultyUriLength)
             }
 
@@ -113,8 +113,6 @@ impl Origin {
         } else {
             Scheme::Https // definitely Https because of `Self::new` parser logic
         }
-        // #606 will remove such heuristic if-else and then
-        // we just have to access `.scheme` field or something like that
     }
 
     /// Returns the port of this [`Origin`].
@@ -128,22 +126,6 @@ impl Origin {
         self.0.host()
     }
 
-    /// Returns the host as subdomain and domain of this [`Origin`] in a tuple struct like (subdomain: Option<&str>, domain: &str).
-    fn host_as_subdomain_and_domain(&self) -> (Option<&str>, &str) {
-        if let Some(host) = self.0.host() {
-            host.split_once('.')
-                .map_or((None, host), |(subdomain, domain)| {
-                    if domain.contains('.') {
-                        (Some(subdomain), domain)
-                    } else {
-                        (None, host)
-                    }
-                })
-        } else {
-            (None, "")
-        }
-
-    }
 }
 
 impl Display for Origin {
@@ -157,7 +139,7 @@ impl Display for OriginError {
         let output = match self {
             OriginError::InvalidUri(_) => { "Invalid URI." }
             OriginError::FaultyScheme => { "Please use HTTP or HTTPS as scheme." }
-            OriginError::FaultyUriLength => { "URI length mustn't exceed 255 characters in total." }
+            OriginError::FaultyUriLength => { "URI length mustn't exceed 253 characters in total." }
             OriginError::FaultyUriPartLength => { "URI part length mustn't exceed 63 characters." }
             OriginError::FaultyPort => { "Port number was expected." }
             OriginError::FaultyIp => { "Ip was misformatted." }

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -16,7 +16,7 @@ pub use context::Context;
 pub mod enamel;
 pub use enamel::Enamel;
 
-use http::uri::{InvalidUri, Uri};
+use http::uri::Uri;
 
 #[cfg(feature = "__rt_native__")]
 mod timeout;
@@ -24,7 +24,7 @@ mod timeout;
 pub use timeout::Timeout;
 
 fn validate_origin(origin: &str) -> Result<(), &'static str> {
-    if let Ok(_) = origin.parse::<Uri>() {
+    if origin.parse::<Uri>().is_ok() {
         Ok(())
     } else {
         Err("Unable to parse Uri.")

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -1,4 +1,6 @@
 mod basicauth;
+use core::{fmt::Display, option::Option::Some};
+use std::fmt::Formatter;
 pub use basicauth::BasicAuth;
 
 mod cors;
@@ -68,10 +70,8 @@ impl Origin {
 
         // Additional validation
         // Validate scheme is HTTP or HTTPS
-        if let Some(scheme) = uri.scheme() {
-            if scheme != &Scheme::HTTP && scheme != &Scheme::HTTPS {
-                return Err(OriginError::InvalidScheme);
-            }
+        if let Some(scheme) = uri.scheme() && scheme != &Scheme::HTTP && scheme != &Scheme::HTTPS {
+            return Err(OriginError::InvalidScheme);
         }
 
         // Validate max path length
@@ -84,14 +84,12 @@ impl Origin {
             return Err(OriginError::InvalidPartLength)
         }
 
-        // Make sure port isn't made out of letters, and doesn't exceed `u16::MAX`
-        if let Some(port) = uri.port() {
-            if port.as_u16() > u16::MAX {
-                return Err(OriginError::InvalidPort)
-            } else if port.as_str() != "" {
-                return Err(OriginError::InvalidPort)
-            }
-        }
+        // // Make sure port isn't made out of letters, and doesn't exceed `u16::MAX`
+        // if let Some(port) = uri.port() {
+        //     if !port.as_str().chars().all(|c| c.is_numeric()) {
+        //         return Err(OriginError::InvalidPort)
+        //     }
+        // }
 
         // TODO: Add more if necessary
 
@@ -108,5 +106,57 @@ impl Origin {
         // #606 will remove such heuristic if-else and then
         // we just have to access `.scheme` field or something like that
     }
+
+    fn port(&self) -> Option<u16> {
+        self.0.port_u16()
+    }
+
+    fn host(&self) -> Option<&str> {
+        self.0.host()
+    }
+
+    fn subdomain(&self) -> Option<&str> {
+        if let Some(host) = self.0.host() {
+            let (subdomain, _) = host
+                .split_once('.')
+                .map_or((None, host), |(s, r)| (Some(s), r));
+
+            subdomain
+        } else {
+            None
+        }
+    }
+
+    fn domain(&self) -> Option<&str> {
+        if let Some(host) = self.0.host() {
+            let (_, domain) = host
+                .split_once('.')
+                .map_or((None, host), |(s, r)| (Some(s), r));
+
+            Some(domain)
+        } else {
+            None
+        }
+    }
+
+    fn host_as_tuple(&self) -> (Option<&str>, &str) {
+        if let Some(host) = self.0.host() {
+            let (subdomain, domain) = host
+                .split_once('.')
+                .map_or((None, host), |(s, d)| (Some(s), d));
+
+            (subdomain, domain)
+        } else {
+            (None, "")
+        }
+
+    }
+
     // and more... (as needed)
+}
+
+impl Display for Origin {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
 }

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -43,6 +43,7 @@ pub enum OriginError {
     FaultyUriLength,
     FaultyUriPartLength,
     FaultyPort,
+    FaultyIp,
     //...
 }
 
@@ -72,9 +73,15 @@ impl Origin {
                 return Err(OriginError::FaultyUriLength)
             }
 
+            let split_host: Vec<&str> = host.split('.').collect();
+
             // Validate max part length
-            if !host.split('.').all(|part| part.chars().count() <= 63) {
+            if !split_host.iter().all(|part| part.chars().count() <= 63) {
                 return Err(OriginError::FaultyUriPartLength)
+            }
+
+            if split_host.len() < 4 && host.chars().all(|c| c.is_numeric() || c == '.') {
+                return Err(OriginError::FaultyIp)
             }
         }
 
@@ -142,6 +149,7 @@ impl Display for OriginError {
             OriginError::FaultyUriLength => { "URI length mustn't exceed 255 characters in total." }
             OriginError::FaultyUriPartLength => { "URI part length mustn't exceed 63 characters." }
             OriginError::FaultyPort => { "Port number was expected." }
+            OriginError::FaultyIp => { "Ip was misformatted." }
         };
 
         write!(f, "{}", output)

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -16,7 +16,7 @@ pub use context::Context;
 pub mod enamel;
 pub use enamel::Enamel;
 
-use http::uri::Uri;
+use http::uri::{InvalidUri, Uri};
 
 #[cfg(feature = "__rt_native__")]
 mod timeout;
@@ -29,4 +29,84 @@ fn validate_origin(origin: &str) -> Result<(), &'static str> {
     } else {
         Err("Unable to parse Uri.")
     }
+}
+
+// builtin.rs
+
+/* #660 will replace this with an original struct
+   (providing almost the same interface as this
+   using original implementations internally)
+*/
+// Just wrapping `https::uri::Uri` for now
+// to skip most difficult things in parsing,
+// so we only have to handle HTTP-origin-specific rules
+// on the top of the generic `Uri`.
+struct Origin(Uri);
+
+enum OriginError {
+    InvalidUri(InvalidUri),
+    InvalidScheme,
+    InvalidPathLength,
+    InvalidPartLength,
+    InvalidPort,
+    //...
+}
+
+enum Scheme {
+    Http,
+    Https
+}
+
+impl Origin {
+    /* This replaces current `fn validate_origin` entirely */
+    /// Parse string into HTTP origin
+    fn new(s: &str) -> Result<Self, OriginError> {
+        use http::uri::{Uri, Scheme};
+
+        let uri = s.parse::<Uri>()
+            .map_err(OriginError::InvalidUri)?;
+
+        // Additional validation
+        // Validate scheme is HTTP or HTTPS
+        if let Some(scheme) = uri.scheme() {
+            if scheme != &Scheme::HTTP && scheme != &Scheme::HTTPS {
+                return Err(OriginError::InvalidScheme);
+            }
+        }
+
+        // Validate max path length
+        if uri.path().chars().count() > u8::MAX as usize {
+            return Err(OriginError::InvalidPathLength)
+        }
+
+        // Validate max part length
+        if !uri.path().split('.').all(|part| part.chars().count() <= 63) {
+            return Err(OriginError::InvalidPartLength)
+        }
+
+        // Make sure port isn't made out of letters, and doesn't exceed `u16::MAX`
+        if let Some(port) = uri.port() {
+            if port.as_u16() > u16::MAX {
+                return Err(OriginError::InvalidPort)
+            } else if port.as_str() != "" {
+                return Err(OriginError::InvalidPort)
+            }
+        }
+
+        // TODO: Add more if necessary
+
+        Ok(Self(uri))
+    }
+
+    // Accessor methods for origin components; for example:
+    fn scheme(&self) -> Scheme {
+        if self.0.scheme() == Some(&http::uri::Scheme::HTTP) {
+            Scheme::Http
+        } else {
+            Scheme::Https // definitely Https because of `Self::new` parser logic
+        }
+        // #606 will remove such heuristic if-else and then
+        // we just have to access `.scheme` field or something like that
+    }
+    // and more... (as needed)
 }

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -1,5 +1,4 @@
 mod basicauth;
-use std::fmt::{Display, Formatter};
 pub use basicauth::BasicAuth;
 
 mod cors;
@@ -37,8 +36,7 @@ pub enum OriginError {
     FaultyUriLength,
     FaultyUriPartLength,
     FaultyPort,
-    FaultyIp,
-    //...
+    FaultyIp
 }
 
 #[derive(PartialEq)]
@@ -107,7 +105,6 @@ impl Origin {
     }
 
     /// Returns the scheme of this [`Origin`].
-    #[allow(unused)]
     fn scheme(&self) -> Scheme {
         if self.0.scheme() == Some(&http::uri::Scheme::HTTP) {
             Scheme::Http
@@ -122,21 +119,37 @@ impl Origin {
     }
 
     /// Returns the host of this [`Origin`].
-    #[allow(unused)]
     fn host(&self) -> Option<&str> {
         self.0.host()
     }
 
 }
 
-impl Display for Origin {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl std::fmt::Display for Origin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
-impl Display for OriginError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl PartialEq for OriginError {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            // `http::uri::InvalidUri` doesn't implement `PartialEq`
+            (Self::InvalidUri(a), Self::InvalidUri(b)) =>
+                a.to_string() == b.to_string(),
+            | (Self::FaultyScheme, Self::FaultyScheme)
+            | (Self::FaultyUriLength, Self::FaultyUriLength)
+            | (Self::FaultyUriPartLength, Self::FaultyUriPartLength)
+            | (Self::FaultyPort, Self::FaultyPort)
+            | (Self::FaultyIp, Self::FaultyIp)
+            => true,
+            _ => false
+        }
+    }
+}
+
+impl std::fmt::Display for OriginError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let output = match self {
             OriginError::InvalidUri(_) => { "Invalid URI." }
             OriginError::FaultyScheme => { "Please use HTTP or HTTPS as scheme." }

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -121,8 +121,8 @@ impl Origin {
         self.0.port_u16()
     }
 
-    fn host(&self) -> Option<&str> {
-        self.0.host()
+    fn host(&self) -> &str {
+        self.0.host().expect("host MUST NOT be empty in Origin.")
     }
 
 }

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -1,5 +1,5 @@
 mod basicauth;
-use core::{fmt::{Display, write}, option::Option::Some};
+use core::{fmt::Display, option::Option::Some};
 use std::fmt::Formatter;
 pub use basicauth::BasicAuth;
 
@@ -34,10 +34,10 @@ pub use timeout::Timeout;
 // so we only have to handle HTTP-origin-specific rules
 // on the top of the generic `Uri`.
 #[derive(Clone, Debug)]
-struct Origin(Uri);
+pub struct Origin(Uri);
 
 #[derive(Debug)]
-enum OriginError {
+pub enum OriginError {
     InvalidUri(InvalidUri),
     FaultyScheme,
     FaultyUriLength,
@@ -46,7 +46,7 @@ enum OriginError {
     //...
 }
 
-enum Scheme {
+pub enum Scheme {
     Http,
     Https
 }
@@ -87,6 +87,7 @@ impl Origin {
     }
 
     // Accessor methods for origin components; for example:
+    #[allow(unused)]
     fn scheme(&self) -> Scheme {
         if self.0.scheme() == Some(&http::uri::Scheme::HTTP) {
             Scheme::Http
@@ -101,35 +102,12 @@ impl Origin {
         self.0.port_u16()
     }
 
+    #[allow(unused)]
     fn host(&self) -> Option<&str> {
         self.0.host()
     }
 
-    fn subdomain(&self) -> Option<&str> {
-        if let Some(host) = self.0.host() {
-            let (subdomain, _) = host
-                .split_once('.')
-                .map_or((None, host), |(s, r)| (Some(s), r));
-
-            subdomain
-        } else {
-            None
-        }
-    }
-
-    fn domain(&self) -> Option<&str> {
-        if let Some(host) = self.0.host() {
-            let (_, domain) = host
-                .split_once('.')
-                .map_or((None, host), |(s, r)| (Some(s), r));
-
-            Some(domain)
-        } else {
-            None
-        }
-    }
-
-    fn host_as_tuple(&self) -> (Option<&str>, &str) {
+    fn host_as_subdomain_and_domain(&self) -> (Option<&str>, &str) {
         if let Some(host) = self.0.host() {
             let (subdomain, domain) = host
                 .split_once('.')

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -162,3 +162,9 @@ impl std::fmt::Display for OriginError {
         write!(f, "{}", output)
     }
 }
+
+mod test {
+
+    // #[test]
+
+}

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -41,6 +41,7 @@ pub enum OriginError {
     //...
 }
 
+#[derive(PartialEq)]
 pub enum Scheme {
     Http,
     Https
@@ -64,7 +65,7 @@ impl Origin {
     /// - Scheme must be either HTTP or HTTPS.
     /// - URI length mustn't exceed 255 characters in total.
     /// - URI parts mustn't exceed 63 characters per.
-    /// - Ports must be numeric.
+    /// - Ports must be numeric and <= 65535 (u16::MAX).
     /// - IP strings like 192.168.1.0 cannot have wildcards.
     ///
     fn new(s: &str) -> Result<Self, OriginError> {

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -36,7 +36,8 @@ pub enum OriginError {
     FaultyUriLength,
     FaultyUriPartLength,
     FaultyPort,
-    FaultyIp
+    FaultyIp,
+    MalformedUri
 }
 
 #[derive(PartialEq)]
@@ -82,6 +83,10 @@ impl Origin {
             // Validate max host length
             if host.chars().count() > 253 {
                 return Err(OriginError::FaultyUriLength)
+            }
+
+            if host.contains("..") {
+                return Err(OriginError::MalformedUri)
             }
 
             let split_host: Vec<&str> = host.split('.').collect();
@@ -139,6 +144,7 @@ impl PartialEq for OriginError {
             | (Self::FaultyUriPartLength, Self::FaultyUriPartLength)
             | (Self::FaultyPort, Self::FaultyPort)
             | (Self::FaultyIp, Self::FaultyIp)
+            | (Self::MalformedUri, Self::MalformedUri)
             => true,
             _ => false
         }
@@ -154,6 +160,7 @@ impl std::fmt::Display for OriginError {
             OriginError::FaultyUriPartLength => { "URI part length mustn't exceed 63 characters." }
             OriginError::FaultyPort => { "Port number was expected." }
             OriginError::FaultyIp => { "Ip was misformatted." }
+            OriginError::MalformedUri => { "URI is malformed." }
         };
 
         write!(f, "{}", output)
@@ -165,35 +172,71 @@ mod test {
     use super::{Origin, OriginError};
 
     #[test]
+    fn origin_invalid_origin_ip_invalidation() {
+        assert_eq!(
+            &Origin::new("https://192.168.a.58:8080").unwrap_err(),
+            &OriginError::FaultyIp
+        )
+    }
+
+    #[test]
+    fn origin_wildcard_in_extension_invalidation() {
+        assert_eq!(
+            &Origin::new("https://test.example.*:8080").unwrap_err(),
+            &OriginError::MalformedUri
+        )
+    }
+
+    #[test]
+    fn origin_wildcard_in_sld_invalidation() {
+        assert_eq!(
+            &Origin::new("https://test.*.com:8080").unwrap_err(),
+            &OriginError::MalformedUri
+        )
+    }
+
+    #[test]
+    fn origin_faulty_wildcard_in_ip_invalidation() {
+        assert_eq!(
+            &Origin::new("https://192.*.1.15:8080").unwrap_err(),
+            &OriginError::FaultyIp
+        );
+
+        assert_eq!(
+            &Origin::new("https://*.168.1.15:8080").unwrap_err(),
+            &OriginError::FaultyIp
+        )
+    }
+
+    #[test]
     fn origin_scheme_invalidation() {
-        let origin = "foobarhttp://example.com";
-        assert_eq!(OriginError::FaultyScheme, Origin::new(origin).unwrap_err())
+        assert_eq!(OriginError::FaultyScheme, Origin::new("foobarhttp://example.com").unwrap_err())
     }
 
     #[test]
     fn origin_length_invalidation() {
         let origin = "https://thisisaridiculouslylongurithatshoulddefinitelybeinvalidaccordingtothistest.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com";
-        assert_eq!(OriginError::FaultyUriLength, Origin::new(origin).unwrap_err())
+        assert_eq!(Origin::new(origin).unwrap_err(), OriginError::FaultyUriLength)
     }
 
     #[test]
     fn origin_part_length_invalidation() {
         let origin = "https://www.abcdefghijklmnopqrstuvwxyzabcdefghijklmnoqrstuvwxyzabcdefghijklmnopqrstuvwxyz.com";
-        assert_eq!(OriginError::FaultyUriPartLength, Origin::new(origin).unwrap_err())
+        assert_eq!(Origin::new(origin).unwrap_err(), OriginError::FaultyUriPartLength)
     }
 
     #[test]
     fn origin_port_invalidation() {
-        let origin = "http://example.com:abcd";
-        assert_eq!(OriginError::FaultyPort, Origin::new(origin).unwrap_err())
+        assert_eq!(Origin::new("http://example.com:abcd").unwrap_err(), OriginError::FaultyPort)
     }
 
     #[test]
-    fn origin_deny_invalid_ip_port_range() {
-        // Origin:new with a faulty IP should give OriginError::FaultyPort. This error cannot be compared with super::CorsOriginValue::matches(), due to it being an error.
+    fn origin_invalid_ip_port_range_invalidation() {
+        // Origin:new with a faulty IP should give OriginError::FaultyPort.
+        // This error cannot be compared with super::CorsOriginValue::matches(), due to it being an error.
         assert_eq!(
-            OriginError::FaultyPort,
             Origin::new("https://192.168.1.0:80080").unwrap_err(),
+            OriginError::FaultyPort
         )
     }
 
@@ -202,5 +245,18 @@ mod test {
         assert!(
             Origin::new("http://%example.com").is_err() //Gives InvalidUri error, which's enums aren't public so unable to directly compare.
         )
+    }
+
+    #[test]
+    fn origin_malformed_uri_invalidation() {
+        assert_eq!(
+            &OriginError::MalformedUri,
+            &Origin::new("https://a..example.com").unwrap_err()
+        );
+
+        assert_eq!(
+            &OriginError::MalformedUri,
+            &Origin::new("https://..example.com").unwrap_err()
+        );
     }
 }

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -1,6 +1,5 @@
 mod basicauth;
-use core::{fmt::Display, option::Option::Some};
-use std::fmt::Formatter;
+use std::fmt::{Display, Formatter};
 pub use basicauth::BasicAuth;
 
 mod cors;
@@ -18,8 +17,6 @@ pub use context::Context;
 pub mod enamel;
 pub use enamel::Enamel;
 
-use http::uri::{InvalidUri, Uri};
-
 #[cfg(feature = "__rt_native__")]
 mod timeout;
 #[cfg(feature = "__rt_native__")]
@@ -31,11 +28,11 @@ pub use timeout::Timeout;
 // Just wrapping `https::uri::Uri` for now to skip most difficult things in parsing,
 // so we only have to handle HTTP-origin-specific rules on the top of the generic `Uri`.
 #[derive(Clone, Debug)]
-pub struct Origin(Uri);
+pub struct Origin(http::uri::Uri);
 
 #[derive(Debug)]
 pub enum OriginError {
-    InvalidUri(InvalidUri),
+    InvalidUri(http::uri::InvalidUri),
     FaultyScheme,
     FaultyUriLength,
     FaultyUriPartLength,
@@ -51,11 +48,6 @@ pub enum Scheme {
 
 impl Origin {
     /// Parse string into HTTP origin.
-    ///
-    /// # Arguments
-    /// * `s`: &str - The string that represents the URI that should be added to the Origin struct.
-    ///
-    /// returns: Self (Origin)
     ///
     /// # Examples
     /// ```rust

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -104,7 +104,6 @@ impl Origin {
         Ok(Self(uri))
     }
 
-    /// Returns the scheme of this [`Origin`].
     fn scheme(&self) -> Scheme {
         if self.0.scheme() == Some(&http::uri::Scheme::HTTP) {
             Scheme::Http
@@ -113,12 +112,10 @@ impl Origin {
         }
     }
 
-    /// Returns the port of this [`Origin`].
     fn port(&self) -> Option<u16> {
         self.0.port_u16()
     }
 
-    /// Returns the host of this [`Origin`].
     fn host(&self) -> Option<&str> {
         self.0.host()
     }

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -70,7 +70,7 @@ impl Origin {
     /// - Host length mustn't exceed 253 characters in total.
     /// - Host Label parts mustn't exceed 63 characters per.
     /// - Ports must be numeric and <= 65535 (u16::MAX).
-    /// - IP strings like 192.168.1.0 cannot have wildcards.
+    /// - IP strings like 192.168.1.0 must adhere to their respective rules for IPv4 or IPv6.
     /// - Labels consist of only letters, digits, or hyphens. Cannot start or end with hyphens.
     ///
     fn new(s: &str) -> Result<Self, OriginError> {
@@ -83,9 +83,10 @@ impl Origin {
         // Validate scheme is HTTP or HTTPS
         if uri.scheme().is_none_or(|s| s != &Scheme::HTTP && s != &Scheme::HTTPS) {
             return Err(OriginError::FaultyScheme);
-        } else if let Some(schemeless_uri) = s.strip_prefix(&(uri.scheme_str().unwrap().to_string() + "://"))
-            && schemeless_uri.chars().any(|c| matches!(c, '#' | '/' | '?')) {
-            // If given Origin string contains a path, fragment or query, give InvalidSuffix error.
+        }
+
+        if s.split_once("://").unwrap().1.contains(&['/', '?', '#']) {
+            // If given Origin string contains a path, fragment or query
             return Err(OriginError::InvalidSuffix)
         }
 
@@ -227,37 +228,53 @@ mod test {
     #[test]
     fn origin_invalid_origin_ip_invalidation() {
         assert_eq!(
-            &Origin::new("https://192.*.1.15:8080").unwrap_err(),
-            &OriginError::InvalidHost
+            Origin::new("https://192.*.1.15:8080").unwrap_err(),
+            OriginError::InvalidHost,
         );
         assert_eq!(
-            &Origin::new("https://*.168.1.15:8080").unwrap_err(),
-            &OriginError::InvalidHost
+            Origin::new("https://*.168.1.15:8080").unwrap_err(),
+            OriginError::InvalidHost
         );
     }
 
     #[test]
     fn origin_host_invalidation() {
         assert_eq!(
-            &Origin::new("https://test.example.*:8080").unwrap_err(),
-            &OriginError::InvalidHost
+            Origin::new("https://test.example.*:8080").unwrap_err(),
+            OriginError::InvalidHost
         );
+
         assert_eq!(
-            &Origin::new("https://test.*.com:8080").unwrap_err(),
-            &OriginError::InvalidHost
+            Origin::new("https://test.*.com:8080").unwrap_err(),
+            OriginError::InvalidHost
         );
+
         assert!(
-            &Origin::new("https://ëxample.com:8080").is_err(),
+            Origin::new("https://ëxample.com:8080").is_err()
+        );
+
+        assert!(
+            Origin::new("http://%example.com").is_err() //Gives InvalidUri error, which's enums aren't public so unable to directly compare.
+        );
+
+        assert_eq!(
+            Origin::new("https://a..example.com").unwrap_err(),
+            OriginError::InvalidHost
+        );
+
+        assert_eq!(
+            Origin::new("https://..example.com").unwrap_err(),
+            OriginError::InvalidHost
         );
     }
 
     #[test]
     fn origin_scheme_invalidation() {
-        assert_eq!(OriginError::FaultyScheme, Origin::new("foobarhttp://example.com").unwrap_err());
-        assert_eq!(OriginError::FaultyScheme, Origin::new("example.com").unwrap_err());
-        assert_eq!(OriginError::FaultyScheme, Origin::new("sub.example.com").unwrap_err());
-        assert_eq!(OriginError::FaultyScheme, Origin::new("192.168.1.0").unwrap_err());
-        assert_eq!(OriginError::FaultyScheme, Origin::new("sub.example.com:8080").unwrap_err());
+        assert_eq!(Origin::new("foobarhttp://example.com").unwrap_err(), OriginError::FaultyScheme);
+        assert_eq!(Origin::new("example.com").unwrap_err(), OriginError::FaultyScheme);
+        assert_eq!(Origin::new("sub.example.com").unwrap_err(), OriginError::FaultyScheme);
+        assert_eq!(Origin::new("192.168.1.0").unwrap_err(), OriginError::FaultyScheme);
+        assert_eq!(Origin::new("sub.example.com:8080").unwrap_err(), OriginError::FaultyScheme);
     }
 
     #[test]
@@ -287,8 +304,8 @@ mod test {
     }
 
     #[test]
-    fn origin_uri_with_path_invalidation() {
-        // Origin::new cannot have a path in it and should throw an error.
+    fn origin_uri_with_invalid_suffix_invalidation() {
+        // Origin::new cannot have a path, fragment or query in it and should throw an error.
         assert_eq!(
             Origin::new("https://192.168.1.0#hello").unwrap_err(),
             OriginError::InvalidSuffix
@@ -332,31 +349,14 @@ mod test {
     }
 
     #[test]
-    fn origin_malformed_uri_invalidation() {
-        assert!(
-            Origin::new("http://%example.com").is_err() //Gives InvalidUri error, which's enums aren't public so unable to directly compare.
-        );
-
-        assert_eq!(
-            &Origin::new("https://a..example.com").unwrap_err(),
-            &OriginError::InvalidHost
-        );
-
-        assert_eq!(
-            &Origin::new("https://..example.com").unwrap_err(),
-            &OriginError::InvalidHost
-        );
-    }
-
-    #[test]
     fn origin_non_existent_host_invalidation() {
         assert_eq!(
-            &Origin::new("/api/hello").unwrap_err(),
-            &OriginError::FaultyScheme
+            Origin::new("/api/hello").unwrap_err(),
+            OriginError::FaultyScheme
         );
 
         assert!(
-            &Origin::new("https:///api/hello").is_err() // http::URI gives an InvalidUri InvalidScheme error
+            Origin::new("https:///api/hello").is_err() // http::URI gives an InvalidUri InvalidScheme error
         );
 
     }

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -96,12 +96,12 @@ impl Origin {
                 return Err(OriginError::InvalidHost)
             }
 
+            // No digits allowed in gTLDs
             if host.chars().any(|c| !(c.is_ascii_digit() | ":.".contains(c)))
-                && tld.chars().nth(0).is_some_and(|c| !c.is_ascii_alphabetic()) {
+                && !tld.chars().all(|c| c.is_ascii_alphabetic()) {
                 return Err(OriginError::FaultyTLD)
             }
         }
-
 
         // Validate max host length
         if host.chars().count() > 253 {
@@ -261,7 +261,11 @@ mod test {
     #[test]
     fn origin_host_invalidation() {
         assert_eq!(
-            &Origin::new("https://192.168.a.58:8080").unwrap_err(), // Disallowed by ICANN root rules, allowed by RFC 1123
+            &Origin::new("https://192.168.a.58:8080").unwrap_err(), // Disallowed by ICANN gTLD rules, allowed by RFC 1123
+            &OriginError::FaultyTLD
+        );
+        assert_eq!(
+            &Origin::new("https://example.1bc:8080").unwrap_err(), // Disallowed by ICANN gTLD rules, allowed by RFC 1123
             &OriginError::FaultyTLD
         );
         assert_eq!(

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -85,14 +85,17 @@ impl Origin {
             return Err(OriginError::InvalidHost)
         };
 
-        let Some((_sld, tld)) = host.rsplit_once('.') else {
-            return Err(OriginError::InvalidHost)
-        };
+        if host != "localhost" {
+            let Some((_sld, tld)) = host.rsplit_once('.') else {
+                return Err(OriginError::InvalidHost)
+            };
 
-        // This means a random . was appended to host without a tld
-        if tld.is_empty() {
-            return Err(OriginError::InvalidHost)
+            // This means a random . was appended to host without a tld
+            if tld.is_empty() {
+                return Err(OriginError::InvalidHost)
+            }
         }
+
 
         // Validate max host length
         if host.chars().count() > 253 {

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -37,6 +37,7 @@ pub enum OriginError {
     FaultyUriPartLength,
     FaultyPort,
     FaultyIp,
+    FaultyTLD,
     DisallowedCharacter,
     MalformedUri,
     InvalidHost,
@@ -94,6 +95,11 @@ impl Origin {
             if tld.is_empty() {
                 return Err(OriginError::InvalidHost)
             }
+
+            if host.chars().any(|c| !(c.is_ascii_digit() | ":.".contains(c)))
+                && tld.chars().nth(0).is_some_and(|c| !c.is_ascii_alphabetic()) {
+                return Err(OriginError::FaultyTLD)
+            }
         }
 
 
@@ -102,7 +108,7 @@ impl Origin {
             return Err(OriginError::FaultyUriLength)
         }
 
-        if !host.chars().all(|c| c.is_alphanumeric() || ".:-".contains(c)) {
+        if !host.chars().all(|c| c.is_ascii_alphanumeric() || ".:-".contains(c)) {
             return Err(OriginError::DisallowedCharacter)
         }
 
@@ -112,26 +118,23 @@ impl Origin {
 
         let split_host: Vec<&str> = host.split('.').collect();
 
-        // Validate max part length
-        if !split_host.iter().all(|part| part.chars().count() <= 63) {
+        // Validate max part length & check if no part starts or ends with a hyphen.
+        if split_host.iter().any(|part| part.chars().count() > 63) {
             return Err(OriginError::FaultyUriPartLength)
+        }
+
+        if split_host.iter().any(|part| part.starts_with('-') || part.ends_with('-')) {
+            return Err(OriginError::DisallowedCharacter)
         }
 
         if split_host.len() < 4 && host.chars().all(|c| c.is_numeric() || c == '.') {
             return Err(OriginError::FaultyIp)
         }
 
-        /* TODO: Is this validation needed? If needed, does this correctly work in IPv6
-         In the first place, for what input is this validation needed ?
-
-         Even if considering only IPv4, when an input is something meeting condition
-         `s.split_once(':') && rest.contains(':') && uri.port_u16().is_none()`,
-         it seems already rejected as InvalidUri error at the beginning of Origin::new and this validation seems never used
-         Check if user intended to add a port to Origin, but it's parsed out by http::uri::Uri, return invalid port error
-
-         Read RFC 1123 & 952 to determine whether or not this should or shouldn't be allowed
-         */
-        if let Some((_, rest)) = s.split_once(':') && rest.contains(':') && uri.port_u16().is_none() {
+        // WORKAROUND: At now, `http::uri::Uri` silently parses with an invalid port value,
+        // and then its `.port()` or `.port_u16()` just returns `None`.
+        // (https://github.com/hyperium/http/issues/509)
+        if uri.authority().is_some_and(|authority| authority.as_str().contains(':') && uri.port().is_none()) {
             return Err(OriginError::FaultyPort)
         }
 
@@ -174,6 +177,7 @@ impl PartialEq for OriginError {
             | (Self::FaultyUriPartLength, Self::FaultyUriPartLength)
             | (Self::FaultyPort, Self::FaultyPort)
             | (Self::FaultyIp, Self::FaultyIp)
+            | (Self::FaultyTLD, Self::FaultyTLD)
             | (Self::InvalidHost, Self::InvalidHost)
             | (Self::MalformedUri, Self::MalformedUri)
             | (Self::DisallowedCharacter, Self::DisallowedCharacter)
@@ -185,19 +189,18 @@ impl PartialEq for OriginError {
 
 impl std::fmt::Display for OriginError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let output = match self {
+        write!(f, "{}", match self {
             OriginError::InvalidUri(_) => { "Invalid URI." }
             OriginError::FaultyScheme => { "Please use HTTP or HTTPS as scheme." }
             OriginError::FaultyUriLength => { "URI length mustn't exceed 253 characters in total." }
             OriginError::FaultyUriPartLength => { "URI part length mustn't exceed 63 characters." }
             OriginError::FaultyPort => { "Port number was expected." }
             OriginError::FaultyIp => { "Ip was misformatted." }
+            OriginError::FaultyTLD => { "TLDs may not start with a digit." }
             OriginError::InvalidHost => { "Invalid URI for usage in Origin." }
             OriginError::MalformedUri => { "URI is malformed." }
-            OriginError::DisallowedCharacter => { "Origin URI contains a disallowed character. (Must be alphanumeric or either of -.:" }
-        };
-
-        write!(f, "{}", output)
+            OriginError::DisallowedCharacter => { "Origin URI contains a disallowed character. (Must be alphanumeric or either of -.: and can't start or end with a hyphen)" }
+        })
     }
 }
 
@@ -206,7 +209,7 @@ mod test {
     use super::{Origin, OriginError};
 
     #[test]
-    fn origin_validate_valid_origins_ips() {
+    fn origin_validate_valid_origins_with_ip() {
         assert!(Origin::new("http://192.168.1.2").is_ok());
         assert!(Origin::new("https://192.168.1.2").is_ok());
         assert!(Origin::new("https://192.168.1.2:3000").is_ok());
@@ -214,41 +217,64 @@ mod test {
     }
 
     #[test]
-    fn origin_validate_valid_origins() {
+    fn origin_validate_valid_origins_with_domain() {
         assert!(Origin::new("http://example.com").is_ok());
         assert!(Origin::new("https://example.com").is_ok());
         assert!(Origin::new("https://example.com:3000").is_ok());
         assert!(Origin::new("https://example.com:80").is_ok());
         assert!(Origin::new("https://sub.example.com").is_ok());
         assert!(Origin::new("https://sub.example.com:3000").is_ok());
+        assert!(Origin::new("https://3xample.com").is_ok());
+        assert!(Origin::new("https://3xample.com").is_ok());
+        assert!(Origin::new("https://3xample.com:8080").is_ok());
+        assert!(Origin::new("https://sub.3xample.com:8080").is_ok());
+    }
+
+    #[test]
+    fn origin_validate_valid_origins_with_fqdn() {
+        assert!(Origin::new("http://localhost").is_ok());
+        assert!(Origin::new("https://localhost").is_ok());
+        assert!(Origin::new("http://localhost:3000").is_ok());
+        assert!(Origin::new("https://localhost:3000").is_ok());
+    }
+
+    #[test]
+    fn origin_invalidate_invalid_origins_with_fqdn() {
+        assert!(Origin::new("http://example").is_err());
+        assert!(Origin::new("https://example").is_err());
+        assert!(Origin::new("http://example:3000").is_err());
+        assert!(Origin::new("https://example:3000").is_err());
     }
 
     #[test]
     fn origin_invalid_origin_ip_invalidation() {
         assert_eq!(
-            &Origin::new("https://192.168.a.58:8080").unwrap_err(), // TODO: Fix OK from Origin -> Err
-            &OriginError::DisallowedCharacter
+            &Origin::new("https://192.*.1.15:8080").unwrap_err(),
+            &OriginError::FaultyTLD
         );
         assert_eq!(
-            &Origin::new("https://192.*.1.15:8080").unwrap_err(), // TODO: Fix OK from Origin -> Err
-            &OriginError::DisallowedCharacter
+            &Origin::new("https://*.168.1.15:8080").unwrap_err(),
+            &OriginError::FaultyTLD
         );
-        assert_eq!(
-            &Origin::new("https://*.168.1.15:8080").unwrap_err(), // TODO: Fix OK from Origin -> Err
-            &OriginError::DisallowedCharacter
-        )
     }
 
     #[test]
     fn origin_host_invalidation() {
         assert_eq!(
-            &Origin::new("https://test.example.*:8080").unwrap_err(), // TODO: Fix OK from Origin -> Err
-            &OriginError::DisallowedCharacter
+            &Origin::new("https://192.168.a.58:8080").unwrap_err(), // Disallowed by ICANN root rules, allowed by RFC 1123
+            &OriginError::FaultyTLD
         );
         assert_eq!(
-            &Origin::new("https://test.*.com:8080").unwrap_err(), // TODO: Fix OK from Origin -> Err
+            &Origin::new("https://test.example.*:8080").unwrap_err(),
+            &OriginError::FaultyTLD
+        );
+        assert_eq!(
+            &Origin::new("https://test.*.com:8080").unwrap_err(),
             &OriginError::DisallowedCharacter
-        )
+        );
+        assert!(
+            &Origin::new("https://ëxample.com:8080").is_err(),
+        );
     }
 
     #[test]

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -90,7 +90,7 @@ impl Origin {
         };
 
         // This means a random . was appended to host without a tld
-        if tld == "" {
+        if tld.is_empty() {
             return Err(OriginError::InvalidHost)
         }
 

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -37,6 +37,7 @@ pub enum OriginError {
     FaultyPort,
     FaultyIp,
     InvalidHost,
+    InvalidSuffix,
 }
 
 #[derive(PartialEq)]
@@ -64,9 +65,9 @@ impl Origin {
     /// Rules include:
     ///
     /// - Generalistic http::uri::Uri rules for URI's.
-    /// - URI must not be a path, and instead must be e.g. "sub.example.com"
+    /// - URI must not contain path, query or fragment, and instead must be e.g. "https://sub.example.com"
     /// - Scheme must be either HTTP or HTTPS.
-    /// - Host length mustn't exceed 255 characters in total.
+    /// - Host length mustn't exceed 253 characters in total.
     /// - Host Label parts mustn't exceed 63 characters per.
     /// - Ports must be numeric and <= 65535 (u16::MAX).
     /// - IP strings like 192.168.1.0 cannot have wildcards.
@@ -82,6 +83,10 @@ impl Origin {
         // Validate scheme is HTTP or HTTPS
         if uri.scheme().is_none_or(|s| s != &Scheme::HTTP && s != &Scheme::HTTPS) {
             return Err(OriginError::FaultyScheme);
+        } else if let Some(schemeless_uri) = s.strip_prefix(&(uri.scheme_str().unwrap().to_string() + "://"))
+            && schemeless_uri.chars().any(|c| matches!(c, '#' | '/' | '?')) {
+            // If given Origin string contains a path, fragment or query, give InvalidSuffix error.
+            return Err(OriginError::InvalidSuffix)
         }
 
         let Some(host) = uri.host() else {
@@ -132,8 +137,8 @@ impl Origin {
     }
 
     fn host(&self) -> &str {
-        // assured by `Origin::new` + .unwrap()
-        self.0.host().expect("host MUST NOT be empty in Origin.")
+        // assured by `Origin::new`
+        self.0.host().unwrap()
     }
 
 }
@@ -156,6 +161,7 @@ impl PartialEq for OriginError {
             | (Self::FaultyPort, Self::FaultyPort)
             | (Self::FaultyIp, Self::FaultyIp)
             | (Self::InvalidHost, Self::InvalidHost)
+            | (Self::InvalidSuffix, Self::InvalidSuffix)
             => true,
             _ => false
         }
@@ -171,6 +177,7 @@ impl std::fmt::Display for OriginError {
             OriginError::FaultyPort => { "Port number was expected." }
             OriginError::FaultyIp => { "Ip was misformatted." }
             OriginError::InvalidHost => { "Invalid URI for usage in Origin. (e.g. Part length mustn't exceed 63 characters, start and end with a digit or letter)" }
+            OriginError::InvalidSuffix => { "URI should not contain a path, query or segment. (e.g. 'https://example.com/hello' should be 'https://example.com' )" }
         })
     }
 }
@@ -273,6 +280,51 @@ mod test {
             Origin::new("https://192.168.1.0:80080").unwrap_err(),
             OriginError::FaultyPort
         )
+    }
+
+    #[test]
+    fn origin_uri_with_path_invalidation() {
+        // Origin::new cannot have a path in it and should throw an error.
+        assert_eq!(
+            Origin::new("https://192.168.1.0#hello").unwrap_err(),
+            OriginError::InvalidSuffix
+        );
+        assert_eq!(
+            Origin::new("https://192.168.1.0/hello").unwrap_err(),
+            OriginError::InvalidSuffix
+        );
+        assert_eq!(
+            Origin::new("https://192.168.1.0/#hello").unwrap_err(),
+            OriginError::InvalidSuffix
+        );
+        assert_eq!(
+            Origin::new("https://192.168.1.0/?q=hello").unwrap_err(),
+            OriginError::InvalidSuffix
+        );
+        assert_eq!(
+            Origin::new("https://192.168.1.0?q=hello").unwrap_err(),
+            OriginError::InvalidSuffix
+        );
+        assert_eq!(
+            Origin::new("https://example.com/hello").unwrap_err(),
+            OriginError::InvalidSuffix
+        );
+        assert_eq!(
+            Origin::new("https://example.com/?q=helloworld").unwrap_err(),
+            OriginError::InvalidSuffix
+        );
+        assert_eq!(
+            Origin::new("https://example.com?q=helloworld").unwrap_err(),
+            OriginError::InvalidSuffix
+        );
+        assert_eq!(
+            Origin::new("https://example.com/#hello").unwrap_err(),
+            OriginError::InvalidSuffix
+        );
+        assert_eq!(
+            Origin::new("https://example.com#hello").unwrap_err(),
+            OriginError::InvalidSuffix
+        );
     }
 
     #[test]

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -37,7 +37,9 @@ pub enum OriginError {
     FaultyUriPartLength,
     FaultyPort,
     FaultyIp,
-    MalformedUri
+    DisallowedCharacter,
+    MalformedUri,
+    InvalidHost,
 }
 
 #[derive(PartialEq)]
@@ -80,12 +82,25 @@ impl Origin {
         }
 
         let Some(host) = uri.host() else {
-          return Err(OriginError::MalformedUri)
+            return Err(OriginError::InvalidHost)
         };
+
+        let Some((_sld, tld)) = host.rsplit_once('.') else {
+            return Err(OriginError::InvalidHost)
+        };
+
+        // This means a random . was appended to host without a tld
+        if tld == "" {
+            return Err(OriginError::InvalidHost)
+        }
 
         // Validate max host length
         if host.chars().count() > 253 {
             return Err(OriginError::FaultyUriLength)
+        }
+
+        if !host.chars().all(|c| c.is_alphanumeric() || ".:-".contains(c)) {
+            return Err(OriginError::DisallowedCharacter)
         }
 
         if host.contains("..") {
@@ -147,7 +162,9 @@ impl PartialEq for OriginError {
             | (Self::FaultyUriPartLength, Self::FaultyUriPartLength)
             | (Self::FaultyPort, Self::FaultyPort)
             | (Self::FaultyIp, Self::FaultyIp)
+            | (Self::InvalidHost, Self::InvalidHost)
             | (Self::MalformedUri, Self::MalformedUri)
+            | (Self::DisallowedCharacter, Self::DisallowedCharacter)
             => true,
             _ => false
         }
@@ -163,7 +180,9 @@ impl std::fmt::Display for OriginError {
             OriginError::FaultyUriPartLength => { "URI part length mustn't exceed 63 characters." }
             OriginError::FaultyPort => { "Port number was expected." }
             OriginError::FaultyIp => { "Ip was misformatted." }
+            OriginError::InvalidHost => { "Invalid URI for usage in Origin." }
             OriginError::MalformedUri => { "URI is malformed." }
+            OriginError::DisallowedCharacter => { "Origin URI contains a disallowed character. (Must be alphanumeric or either of -.:" }
         };
 
         write!(f, "{}", output)
@@ -175,39 +194,48 @@ mod test {
     use super::{Origin, OriginError};
 
     #[test]
+    fn origin_validate_valid_origins_ips() {
+        assert!(Origin::new("http://192.168.1.2").is_ok());
+        assert!(Origin::new("https://192.168.1.2").is_ok());
+        assert!(Origin::new("https://192.168.1.2:3000").is_ok());
+        assert!(Origin::new("https://192.168.1.2:80").is_ok());
+    }
+
+    #[test]
+    fn origin_validate_valid_origins() {
+        assert!(Origin::new("http://example.com").is_ok());
+        assert!(Origin::new("https://example.com").is_ok());
+        assert!(Origin::new("https://example.com:3000").is_ok());
+        assert!(Origin::new("https://example.com:80").is_ok());
+        assert!(Origin::new("https://sub.example.com").is_ok());
+        assert!(Origin::new("https://sub.example.com:3000").is_ok());
+    }
+
+    #[test]
     fn origin_invalid_origin_ip_invalidation() {
         assert_eq!(
-            &Origin::new("https://192.168.a.58:8080").unwrap_err(),
-            &OriginError::FaultyIp
-        )
-    }
-
-    #[test]
-    fn origin_wildcard_in_extension_invalidation() {
-        assert_eq!(
-            &Origin::new("https://test.example.*:8080").unwrap_err(),
-            &OriginError::MalformedUri
-        )
-    }
-
-    #[test]
-    fn origin_wildcard_in_sld_invalidation() {
-        assert_eq!(
-            &Origin::new("https://test.*.com:8080").unwrap_err(),
-            &OriginError::MalformedUri
-        )
-    }
-
-    #[test]
-    fn origin_faulty_wildcard_in_ip_invalidation() {
-        assert_eq!(
-            &Origin::new("https://192.*.1.15:8080").unwrap_err(),
-            &OriginError::FaultyIp
+            &Origin::new("https://192.168.a.58:8080").unwrap_err(), // TODO: Fix OK from Origin -> Err
+            &OriginError::DisallowedCharacter
         );
-
         assert_eq!(
-            &Origin::new("https://*.168.1.15:8080").unwrap_err(),
-            &OriginError::FaultyIp
+            &Origin::new("https://192.*.1.15:8080").unwrap_err(), // TODO: Fix OK from Origin -> Err
+            &OriginError::DisallowedCharacter
+        );
+        assert_eq!(
+            &Origin::new("https://*.168.1.15:8080").unwrap_err(), // TODO: Fix OK from Origin -> Err
+            &OriginError::DisallowedCharacter
+        )
+    }
+
+    #[test]
+    fn origin_host_invalidation() {
+        assert_eq!(
+            &Origin::new("https://test.example.*:8080").unwrap_err(), // TODO: Fix OK from Origin -> Err
+            &OriginError::DisallowedCharacter
+        );
+        assert_eq!(
+            &Origin::new("https://test.*.com:8080").unwrap_err(), // TODO: Fix OK from Origin -> Err
+            &OriginError::DisallowedCharacter
         )
     }
 
@@ -236,7 +264,6 @@ mod test {
     #[test]
     fn origin_invalid_ip_port_range_invalidation() {
         // Origin:new with a faulty IP should give OriginError::FaultyPort.
-        // This error cannot be compared with super::CorsOriginValue::matches(), due to it being an error.
         assert_eq!(
             Origin::new("https://192.168.1.0:80080").unwrap_err(),
             OriginError::FaultyPort
@@ -272,13 +299,18 @@ mod test {
         );
 
         assert_eq!(
-            &Origin::new("https://example/api/hello").unwrap_err(), //Todo: make this return Err
-            &OriginError::FaultyScheme
+            &Origin::new("https://example/api/hello").unwrap_err(),
+            &OriginError::InvalidHost
         );
 
         assert_eq!(
-            &Origin::new("https://sub").unwrap_err(), //Todo: make this return Err.
-            &OriginError::MalformedUri
+            &Origin::new("https://example./api/hello").unwrap_err(),
+            &OriginError::InvalidHost
+        );
+
+        assert_eq!(
+            &Origin::new("https://sub").unwrap_err(),
+            &OriginError::InvalidHost
         );
     }
 }

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -121,7 +121,16 @@ impl Origin {
             return Err(OriginError::FaultyIp)
         }
 
-        // Check if user intended to add a port to Origin, but it's parsed out by http::uri::Uri, return invalid port error
+        /* TODO: Is this validation needed? If needed, does this correctly work in IPv6
+         In the first place, for what input is this validation needed ?
+
+         Even if considering only IPv4, when an input is something meeting condition
+         `s.split_once(':') && rest.contains(':') && uri.port_u16().is_none()`,
+         it seems already rejected as InvalidUri error at the beginning of Origin::new and this validation seems never used
+         Check if user intended to add a port to Origin, but it's parsed out by http::uri::Uri, return invalid port error
+
+         Read RFC 1123 & 952 to determine whether or not this should or shouldn't be allowed
+         */
         if let Some((_, rest)) = s.split_once(':') && rest.contains(':') && uri.port_u16().is_none() {
             return Err(OriginError::FaultyPort)
         }

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -79,28 +79,28 @@ impl Origin {
             return Err(OriginError::FaultyScheme);
         }
 
-        if let Some(host) = uri.host() {
-            // Validate max host length
-            if host.chars().count() > 253 {
-                return Err(OriginError::FaultyUriLength)
-            }
+        let Some(host) = uri.host() else {
+          return Err(OriginError::MalformedUri)
+        };
 
-            if host.contains("..") {
-                return Err(OriginError::MalformedUri)
-            }
+        // Validate max host length
+        if host.chars().count() > 253 {
+            return Err(OriginError::FaultyUriLength)
+        }
 
-            let split_host: Vec<&str> = host.split('.').collect();
-
-            // Validate max part length
-            if !split_host.iter().all(|part| part.chars().count() <= 63) {
-                return Err(OriginError::FaultyUriPartLength)
-            }
-
-            if split_host.len() < 4 && host.chars().all(|c| c.is_numeric() || c == '.') {
-                return Err(OriginError::FaultyIp)
-            }
-        } else {
+        if host.contains("..") {
             return Err(OriginError::MalformedUri)
+        }
+
+        let split_host: Vec<&str> = host.split('.').collect();
+
+        // Validate max part length
+        if !split_host.iter().all(|part| part.chars().count() <= 63) {
+            return Err(OriginError::FaultyUriPartLength)
+        }
+
+        if split_host.len() < 4 && host.chars().all(|c| c.is_numeric() || c == '.') {
+            return Err(OriginError::FaultyIp)
         }
 
         // Check if user intended to add a port to Origin, but it's parsed out by http::uri::Uri, return invalid port error
@@ -124,6 +124,7 @@ impl Origin {
     }
 
     fn host(&self) -> &str {
+        // assured by `Origin::new` + .unwrap()
         self.0.host().expect("host MUST NOT be empty in Origin.")
     }
 
@@ -243,22 +244,41 @@ mod test {
     }
 
     #[test]
-    fn origin_host_invalidation() {
+    fn origin_malformed_uri_invalidation() {
         assert!(
             Origin::new("http://%example.com").is_err() //Gives InvalidUri error, which's enums aren't public so unable to directly compare.
-        )
-    }
-
-    #[test]
-    fn origin_malformed_uri_invalidation() {
-        assert_eq!(
-            &OriginError::MalformedUri,
-            &Origin::new("https://a..example.com").unwrap_err()
         );
 
         assert_eq!(
-            &OriginError::MalformedUri,
-            &Origin::new("https://..example.com").unwrap_err()
+            &Origin::new("https://a..example.com").unwrap_err(),
+            &OriginError::MalformedUri
+        );
+
+        assert_eq!(
+            &Origin::new("https://..example.com").unwrap_err(),
+            &OriginError::MalformedUri
+        );
+    }
+
+    #[test]
+    fn origin_non_existent_host_invalidation() {
+        assert_eq!(
+            &Origin::new("/api/hello").unwrap_err(),
+            &OriginError::FaultyScheme
+        );
+
+        assert!(
+            &Origin::new("https:///api/hello").is_err() // http::URI gives an InvalidUri InvalidScheme error
+        );
+
+        assert_eq!(
+            &Origin::new("https://example/api/hello").unwrap_err(), //Todo: make this return Err
+            &OriginError::FaultyScheme
+        );
+
+        assert_eq!(
+            &Origin::new("https://sub").unwrap_err(), //Todo: make this return Err.
+            &OriginError::MalformedUri
         );
     }
 }

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -50,6 +50,9 @@ pub enum Scheme {
 }
 
 impl Origin {
+    const MAX_HOST_LENGTH: usize = 253;
+    const MAX_HOST_LABEL_LENGTH: usize = 63;
+
     /// Parse string into HTTP origin.
     ///
     /// # Examples
@@ -104,7 +107,7 @@ impl Origin {
         }
 
         // Validate max host length
-        if host.chars().count() > 253 {
+        if host.chars().count() > Self::MAX_HOST_LENGTH {
             return Err(OriginError::FaultyUriLength)
         }
 
@@ -119,7 +122,7 @@ impl Origin {
         let split_host: Vec<&str> = host.split('.').collect();
 
         // Validate max part length & check if no part starts or ends with a hyphen.
-        if split_host.iter().any(|part| part.chars().count() > 63) {
+        if split_host.iter().any(|part| part.chars().count() > Self::MAX_HOST_LABEL_LENGTH) {
             return Err(OriginError::FaultyUriPartLength)
         }
 
@@ -127,7 +130,7 @@ impl Origin {
             return Err(OriginError::DisallowedCharacter)
         }
 
-        if split_host.len() < 4 && host.chars().all(|c| c.is_numeric() || c == '.') {
+        if split_host.len() < 4 && host.chars().all(|c| c.is_ascii_digit() || c == '.') {
             return Err(OriginError::FaultyIp)
         }
 
@@ -166,10 +169,11 @@ impl std::fmt::Display for Origin {
     }
 }
 
+// `http::uri::InvalidUri` doesn't implement `PartialEq`
+// (https://github.com/hyperium/http/issues/849)
 impl PartialEq for OriginError {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            // `http::uri::InvalidUri` doesn't implement `PartialEq`
             (Self::InvalidUri(a), Self::InvalidUri(b)) =>
                 a.to_string() == b.to_string(),
             | (Self::FaultyScheme, Self::FaultyScheme)

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -43,7 +43,7 @@ pub enum OriginError {
 #[derive(PartialEq)]
 pub enum Scheme {
     Http,
-    Https
+    Https,
 }
 
 impl Origin {
@@ -69,57 +69,66 @@ impl Origin {
     /// - Scheme must be either HTTP or HTTPS.
     /// - Host length mustn't exceed 253 characters in total.
     /// - Host Label parts mustn't exceed 63 characters per.
-    /// - Ports must be numeric and <= 65535 (u16::MAX).
+    /// - Ports must be numeric and <= 65535 (`u16::MAX`).
     /// - IP strings like 192.168.1.0 must adhere to their respective rules for IPv4 or IPv6.
     /// - Labels consist of only letters, digits, or hyphens. Cannot start or end with hyphens.
     ///
     fn new(s: &str) -> Result<Self, OriginError> {
-        use http::uri::{Uri, Scheme};
+        use http::uri::{Scheme, Uri};
 
-        let uri = s.parse::<Uri>()
-            .map_err(OriginError::InvalidUri)?;
+        let uri = s.parse::<Uri>().map_err(OriginError::InvalidUri)?;
 
         // Additional validation
         // Validate scheme is HTTP or HTTPS
-        if uri.scheme().is_none_or(|s| s != &Scheme::HTTP && s != &Scheme::HTTPS) {
+        if uri
+            .scheme()
+            .is_none_or(|s| s != &Scheme::HTTP && s != &Scheme::HTTPS)
+        {
             return Err(OriginError::FaultyScheme);
         }
 
         if s.split_once("://").unwrap().1.contains(['/', '?', '#']) {
             // If given Origin string contains a path, fragment or query
-            return Err(OriginError::InvalidSuffix)
+            return Err(OriginError::InvalidSuffix);
         }
 
         let Some(host) = uri.host() else {
-            return Err(OriginError::InvalidHost)
+            return Err(OriginError::InvalidHost);
         };
 
         // Validate max host length
         if host.chars().count() > Self::MAX_HOST_LENGTH {
-            return Err(OriginError::FaultyUriLength)
+            return Err(OriginError::FaultyUriLength);
         }
 
         let host_labels = host.strip_suffix('.').unwrap_or(host).split('.');
 
-        if !host_labels.clone().all(|label|
-            !label.is_empty() &&
-            label.chars().all(|c| matches!(c, | '0'..='9' | 'a'..='z' | '-')) &&
-            (label.len() <= Self::MAX_HOST_LABEL_LENGTH) &&
-            !label.starts_with('-') && !label.ends_with('-')
-        ) {
-            return Err(OriginError::InvalidHost)
+        if !host_labels.clone().all(|label| {
+            !label.is_empty()
+                && label
+                    .chars()
+                    .all(|c| matches!(c, |'0'..='9'| 'a'..='z' | '-'))
+                && (label.len() <= Self::MAX_HOST_LABEL_LENGTH)
+                && !label.starts_with('-')
+                && !label.ends_with('-')
+        }) {
+            return Err(OriginError::InvalidHost);
         }
 
         if host_labels.clone().all(|label| label.parse::<u8>().is_ok())
-            && host_labels.count() < Self::MIN_IP_PART_COUNT {
-            return Err(OriginError::FaultyIp)
+            && host_labels.count() < Self::MIN_IP_PART_COUNT
+        {
+            return Err(OriginError::FaultyIp);
         }
 
         // WORKAROUND: At now, `http::uri::Uri` silently parses with an invalid port value,
         // and then its `.port()` or `.port_u16()` just returns `None`.
         // (https://github.com/hyperium/http/issues/509)
-        if uri.authority().is_some_and(|authority| authority.as_str().contains(':') && uri.port().is_none()) {
-            return Err(OriginError::FaultyPort)
+        if uri
+            .authority()
+            .is_some_and(|authority| authority.as_str().contains(':') && uri.port().is_none())
+        {
+            return Err(OriginError::FaultyPort);
         }
 
         Ok(Self(uri))
@@ -133,6 +142,14 @@ impl Origin {
         }
     }
 
+    fn scheme_str(&self) -> &str {
+        if self.0.scheme() == Some(&http::uri::Scheme::HTTP) {
+            "http"
+        } else {
+            "https" // definitely Https because of `Self::new` parser logic
+        }
+    }
+
     fn port(&self) -> Option<u16> {
         self.0.port_u16()
     }
@@ -142,11 +159,16 @@ impl Origin {
         self.0.host().unwrap()
     }
 
+    fn authority(&self) -> &str {
+        // assured by `Origin::new` for the same reason as `host` method seen above
+        self.0.authority().unwrap().as_str()
+    }
 }
 
 impl std::fmt::Display for Origin {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+        // Both are assured due to the way Origin is parsed.
+        write!(f, "{}://{}", self.scheme_str(), self.authority())
     }
 }
 
@@ -155,31 +177,47 @@ impl std::fmt::Display for Origin {
 impl PartialEq for OriginError {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (Self::InvalidUri(a), Self::InvalidUri(b)) =>
-                a.to_string() == b.to_string(),
-            | (Self::FaultyScheme, Self::FaultyScheme)
+            (Self::InvalidUri(a), Self::InvalidUri(b)) => a.to_string() == b.to_string(),
+            (Self::FaultyScheme, Self::FaultyScheme)
             | (Self::FaultyUriLength, Self::FaultyUriLength)
             | (Self::FaultyPort, Self::FaultyPort)
             | (Self::FaultyIp, Self::FaultyIp)
             | (Self::InvalidHost, Self::InvalidHost)
-            | (Self::InvalidSuffix, Self::InvalidSuffix)
-            => true,
-            _ => false
+            | (Self::InvalidSuffix, Self::InvalidSuffix) => true,
+            _ => false,
         }
     }
 }
 
 impl std::fmt::Display for OriginError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", match self {
-            OriginError::InvalidUri(_) => { "Invalid URI." }
-            OriginError::FaultyScheme => { "Please use HTTP or HTTPS as scheme." }
-            OriginError::FaultyUriLength => { "URI length mustn't exceed 253 characters in total." }
-            OriginError::FaultyPort => { "Port number was expected." }
-            OriginError::FaultyIp => { "Ip was misformatted." }
-            OriginError::InvalidHost => { "Invalid URI for usage in Origin. (e.g. Part length mustn't exceed 63 characters, and start and end with a digit or letter)" }
-            OriginError::InvalidSuffix => { "URI should not contain a path, query or segment. (e.g. 'https://example.com/hello' should be 'https://example.com' )" }
-        })
+        write!(
+            f,
+            "{}",
+            match self {
+                OriginError::InvalidUri(_) => {
+                    "Invalid URI."
+                }
+                OriginError::FaultyScheme => {
+                    "Please use HTTP or HTTPS as scheme."
+                }
+                OriginError::FaultyUriLength => {
+                    "URI length mustn't exceed 253 characters in total."
+                }
+                OriginError::FaultyPort => {
+                    "Port number was expected."
+                }
+                OriginError::FaultyIp => {
+                    "Ip was misformatted."
+                }
+                OriginError::InvalidHost => {
+                    "Invalid URI for usage in Origin. (e.g. Part length mustn't exceed 63 characters, and start and end with a digit or letter)"
+                }
+                OriginError::InvalidSuffix => {
+                    "URI should not contain a path, query or segment. (e.g. 'https://example.com/hello' should be 'https://example.com' )"
+                }
+            }
+        )
     }
 }
 
@@ -249,9 +287,7 @@ mod test {
             OriginError::InvalidHost
         );
 
-        assert!(
-            Origin::new("https://ëxample.com:8080").is_err()
-        );
+        assert!(Origin::new("https://ëxample.com:8080").is_err());
 
         assert!(
             Origin::new("http://%example.com").is_err() //Gives InvalidUri error, which's enums aren't public so unable to directly compare.
@@ -270,17 +306,35 @@ mod test {
 
     #[test]
     fn origin_scheme_invalidation() {
-        assert_eq!(Origin::new("foobarhttp://example.com").unwrap_err(), OriginError::FaultyScheme);
-        assert_eq!(Origin::new("example.com").unwrap_err(), OriginError::FaultyScheme);
-        assert_eq!(Origin::new("sub.example.com").unwrap_err(), OriginError::FaultyScheme);
-        assert_eq!(Origin::new("192.168.1.0").unwrap_err(), OriginError::FaultyScheme);
-        assert_eq!(Origin::new("sub.example.com:8080").unwrap_err(), OriginError::FaultyScheme);
+        assert_eq!(
+            Origin::new("foobarhttp://example.com").unwrap_err(),
+            OriginError::FaultyScheme
+        );
+        assert_eq!(
+            Origin::new("example.com").unwrap_err(),
+            OriginError::FaultyScheme
+        );
+        assert_eq!(
+            Origin::new("sub.example.com").unwrap_err(),
+            OriginError::FaultyScheme
+        );
+        assert_eq!(
+            Origin::new("192.168.1.0").unwrap_err(),
+            OriginError::FaultyScheme
+        );
+        assert_eq!(
+            Origin::new("sub.example.com:8080").unwrap_err(),
+            OriginError::FaultyScheme
+        );
     }
 
     #[test]
     fn origin_length_invalidation() {
         let origin = "https://thisisaridiculouslylongurithatshoulddefinitelybeinvalidaccordingtothistest.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com";
-        assert_eq!(Origin::new(origin).unwrap_err(), OriginError::FaultyUriLength)
+        assert_eq!(
+            Origin::new(origin).unwrap_err(),
+            OriginError::FaultyUriLength
+        )
     }
 
     #[test]
@@ -291,7 +345,10 @@ mod test {
 
     #[test]
     fn origin_port_invalidation() {
-        assert_eq!(Origin::new("http://example.com:abcd").unwrap_err(), OriginError::FaultyPort)
+        assert_eq!(
+            Origin::new("http://example.com:abcd").unwrap_err(),
+            OriginError::FaultyPort
+        )
     }
 
     #[test]
@@ -358,6 +415,5 @@ mod test {
         assert!(
             Origin::new("https:///api/hello").is_err() // http::URI gives an InvalidUri InvalidScheme error
         );
-
     }
 }

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -34,12 +34,8 @@ pub enum OriginError {
     InvalidUri(http::uri::InvalidUri),
     FaultyScheme,
     FaultyUriLength,
-    FaultyUriPartLength,
     FaultyPort,
     FaultyIp,
-    FaultyTLD,
-    DisallowedCharacter,
-    MalformedUri,
     InvalidHost,
 }
 
@@ -50,6 +46,7 @@ pub enum Scheme {
 }
 
 impl Origin {
+    const MIN_IP_PART_COUNT: usize = 4;
     const MAX_HOST_LENGTH: usize = 253;
     const MAX_HOST_LABEL_LENGTH: usize = 63;
 
@@ -72,6 +69,7 @@ impl Origin {
     /// - URI parts mustn't exceed 63 characters per.
     /// - Ports must be numeric and <= 65535 (u16::MAX).
     /// - IP strings like 192.168.1.0 cannot have wildcards.
+    /// - Labels must start with a letter or digit.
     ///
     fn new(s: &str) -> Result<Self, OriginError> {
         use http::uri::{Uri, Scheme};
@@ -89,48 +87,24 @@ impl Origin {
             return Err(OriginError::InvalidHost)
         };
 
-        if host != "localhost" {
-            let Some((_sld, tld)) = host.rsplit_once('.') else {
-                return Err(OriginError::InvalidHost)
-            };
-
-            // This means a random . was appended to host without a tld
-            if tld.is_empty() {
-                return Err(OriginError::InvalidHost)
-            }
-
-            // No digits allowed in gTLDs
-            if host.chars().any(|c| !(c.is_ascii_digit() | ":.".contains(c)))
-                && !tld.chars().all(|c| c.is_ascii_alphabetic()) {
-                return Err(OriginError::FaultyTLD)
-            }
-        }
-
         // Validate max host length
         if host.chars().count() > Self::MAX_HOST_LENGTH {
             return Err(OriginError::FaultyUriLength)
         }
 
-        if !host.chars().all(|c| c.is_ascii_alphanumeric() || ".:-".contains(c)) {
-            return Err(OriginError::DisallowedCharacter)
+        let host_labels = host.strip_suffix('.').unwrap_or(host).split('.');
+
+        if !host_labels.clone().all(|label|
+            !label.is_empty() &&
+            label.chars().all(|c| matches!(c, | '0'..='9' | 'a'..='z' | '-')) &&
+            (label.len() <= Self::MAX_HOST_LABEL_LENGTH) &&
+            !label.starts_with('-') && !label.ends_with('-')
+        ) {
+            return Err(OriginError::InvalidHost)
         }
 
-        if host.contains("..") {
-            return Err(OriginError::MalformedUri)
-        }
-
-        let split_host: Vec<&str> = host.split('.').collect();
-
-        // Validate max part length & check if no part starts or ends with a hyphen.
-        if split_host.iter().any(|part| part.chars().count() > Self::MAX_HOST_LABEL_LENGTH) {
-            return Err(OriginError::FaultyUriPartLength)
-        }
-
-        if split_host.iter().any(|part| part.starts_with('-') || part.ends_with('-')) {
-            return Err(OriginError::DisallowedCharacter)
-        }
-
-        if split_host.len() < 4 && host.chars().all(|c| c.is_ascii_digit() || c == '.') {
+        if host_labels.clone().all(|label| label.parse::<u8>().is_ok())
+            && host_labels.count() < Self::MIN_IP_PART_COUNT {
             return Err(OriginError::FaultyIp)
         }
 
@@ -178,13 +152,9 @@ impl PartialEq for OriginError {
                 a.to_string() == b.to_string(),
             | (Self::FaultyScheme, Self::FaultyScheme)
             | (Self::FaultyUriLength, Self::FaultyUriLength)
-            | (Self::FaultyUriPartLength, Self::FaultyUriPartLength)
             | (Self::FaultyPort, Self::FaultyPort)
             | (Self::FaultyIp, Self::FaultyIp)
-            | (Self::FaultyTLD, Self::FaultyTLD)
             | (Self::InvalidHost, Self::InvalidHost)
-            | (Self::MalformedUri, Self::MalformedUri)
-            | (Self::DisallowedCharacter, Self::DisallowedCharacter)
             => true,
             _ => false
         }
@@ -197,13 +167,9 @@ impl std::fmt::Display for OriginError {
             OriginError::InvalidUri(_) => { "Invalid URI." }
             OriginError::FaultyScheme => { "Please use HTTP or HTTPS as scheme." }
             OriginError::FaultyUriLength => { "URI length mustn't exceed 253 characters in total." }
-            OriginError::FaultyUriPartLength => { "URI part length mustn't exceed 63 characters." }
             OriginError::FaultyPort => { "Port number was expected." }
             OriginError::FaultyIp => { "Ip was misformatted." }
-            OriginError::FaultyTLD => { "TLDs may not start with a digit." }
-            OriginError::InvalidHost => { "Invalid URI for usage in Origin." }
-            OriginError::MalformedUri => { "URI is malformed." }
-            OriginError::DisallowedCharacter => { "Origin URI contains a disallowed character. (Must be alphanumeric or either of -.: and can't start or end with a hyphen)" }
+            OriginError::InvalidHost => { "Invalid URI for usage in Origin. (e.g. Part length mustn't exceed 63 characters, start and end with a digit or letter)" }
         })
     }
 }
@@ -240,45 +206,37 @@ mod test {
         assert!(Origin::new("https://localhost").is_ok());
         assert!(Origin::new("http://localhost:3000").is_ok());
         assert!(Origin::new("https://localhost:3000").is_ok());
-    }
-
-    #[test]
-    fn origin_invalidate_invalid_origins_with_fqdn() {
-        assert!(Origin::new("http://example").is_err());
-        assert!(Origin::new("https://example").is_err());
-        assert!(Origin::new("http://example:3000").is_err());
-        assert!(Origin::new("https://example:3000").is_err());
+        assert!(Origin::new("http://example").is_ok());
+        assert!(Origin::new("https://example").is_ok());
+        assert!(Origin::new("http://example:3000").is_ok());
+        assert!(Origin::new("https://example:3000").is_ok());
+        assert!(Origin::new("http://example.").is_ok());
+        assert!(Origin::new("https://example.").is_ok());
+        assert!(Origin::new("http://example.:3000").is_ok());
+        assert!(Origin::new("https://example.:3000").is_ok());
     }
 
     #[test]
     fn origin_invalid_origin_ip_invalidation() {
         assert_eq!(
             &Origin::new("https://192.*.1.15:8080").unwrap_err(),
-            &OriginError::FaultyTLD
+            &OriginError::InvalidHost
         );
         assert_eq!(
             &Origin::new("https://*.168.1.15:8080").unwrap_err(),
-            &OriginError::FaultyTLD
+            &OriginError::InvalidHost
         );
     }
 
     #[test]
     fn origin_host_invalidation() {
         assert_eq!(
-            &Origin::new("https://192.168.a.58:8080").unwrap_err(), // Disallowed by ICANN gTLD rules, allowed by RFC 1123
-            &OriginError::FaultyTLD
-        );
-        assert_eq!(
-            &Origin::new("https://example.1bc:8080").unwrap_err(), // Disallowed by ICANN gTLD rules, allowed by RFC 1123
-            &OriginError::FaultyTLD
-        );
-        assert_eq!(
             &Origin::new("https://test.example.*:8080").unwrap_err(),
-            &OriginError::FaultyTLD
+            &OriginError::InvalidHost
         );
         assert_eq!(
             &Origin::new("https://test.*.com:8080").unwrap_err(),
-            &OriginError::DisallowedCharacter
+            &OriginError::InvalidHost
         );
         assert!(
             &Origin::new("https://ëxample.com:8080").is_err(),
@@ -299,7 +257,7 @@ mod test {
     #[test]
     fn origin_part_length_invalidation() {
         let origin = "https://www.abcdefghijklmnopqrstuvwxyzabcdefghijklmnoqrstuvwxyzabcdefghijklmnopqrstuvwxyz.com";
-        assert_eq!(Origin::new(origin).unwrap_err(), OriginError::FaultyUriPartLength)
+        assert_eq!(Origin::new(origin).unwrap_err(), OriginError::InvalidHost)
     }
 
     #[test]
@@ -324,12 +282,12 @@ mod test {
 
         assert_eq!(
             &Origin::new("https://a..example.com").unwrap_err(),
-            &OriginError::MalformedUri
+            &OriginError::InvalidHost
         );
 
         assert_eq!(
             &Origin::new("https://..example.com").unwrap_err(),
-            &OriginError::MalformedUri
+            &OriginError::InvalidHost
         );
     }
 
@@ -344,19 +302,5 @@ mod test {
             &Origin::new("https:///api/hello").is_err() // http::URI gives an InvalidUri InvalidScheme error
         );
 
-        assert_eq!(
-            &Origin::new("https://example/api/hello").unwrap_err(),
-            &OriginError::InvalidHost
-        );
-
-        assert_eq!(
-            &Origin::new("https://example./api/hello").unwrap_err(),
-            &OriginError::InvalidHost
-        );
-
-        assert_eq!(
-            &Origin::new("https://sub").unwrap_err(),
-            &OriginError::InvalidHost
-        );
     }
 }

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -85,7 +85,7 @@ impl Origin {
             return Err(OriginError::FaultyScheme);
         }
 
-        if s.split_once("://").unwrap().1.contains(&['/', '?', '#']) {
+        if s.split_once("://").unwrap().1.contains(['/', '?', '#']) {
             // If given Origin string contains a path, fragment or query
             return Err(OriginError::InvalidSuffix)
         }

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -176,7 +176,7 @@ impl std::fmt::Display for OriginError {
             OriginError::FaultyUriLength => { "URI length mustn't exceed 253 characters in total." }
             OriginError::FaultyPort => { "Port number was expected." }
             OriginError::FaultyIp => { "Ip was misformatted." }
-            OriginError::InvalidHost => { "Invalid URI for usage in Origin. (e.g. Part length mustn't exceed 63 characters, start and end with a digit or letter)" }
+            OriginError::InvalidHost => { "Invalid URI for usage in Origin. (e.g. Part length mustn't exceed 63 characters, and start and end with a digit or letter)" }
             OriginError::InvalidSuffix => { "URI should not contain a path, query or segment. (e.g. 'https://example.com/hello' should be 'https://example.com' )" }
         })
     }

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -46,6 +46,19 @@ pub enum Scheme {
     Https,
 }
 
+impl std::fmt::Display for Scheme {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Scheme::Http => "http",
+                Scheme::Https => "https",
+            }
+        )
+    }
+}
+
 impl Origin {
     const MIN_IP_PART_COUNT: usize = 4;
     const MAX_HOST_LENGTH: usize = 253;
@@ -142,14 +155,6 @@ impl Origin {
         }
     }
 
-    fn scheme_str(&self) -> &str {
-        if self.0.scheme() == Some(&http::uri::Scheme::HTTP) {
-            "http"
-        } else {
-            "https" // definitely Https because of `Self::new` parser logic
-        }
-    }
-
     fn port(&self) -> Option<u16> {
         self.0.port_u16()
     }
@@ -159,16 +164,14 @@ impl Origin {
         self.0.host().unwrap()
     }
 
-    fn authority(&self) -> &str {
-        // assured by `Origin::new` for the same reason as `host` method seen above
-        self.0.authority().unwrap().as_str()
+    fn authority(&self) -> &http::uri::Authority {
+        self.0.authority().unwrap()
     }
 }
 
 impl std::fmt::Display for Origin {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // Both are assured due to the way Origin is parsed.
-        write!(f, "{}://{}", self.scheme_str(), self.authority())
+        write!(f, "{}://{}", self.scheme(), self.authority())
     }
 }
 

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -253,7 +253,11 @@ mod test {
 
     #[test]
     fn origin_scheme_invalidation() {
-        assert_eq!(OriginError::FaultyScheme, Origin::new("foobarhttp://example.com").unwrap_err())
+        assert_eq!(OriginError::FaultyScheme, Origin::new("foobarhttp://example.com").unwrap_err());
+        assert_eq!(OriginError::FaultyScheme, Origin::new("example.com").unwrap_err());
+        assert_eq!(OriginError::FaultyScheme, Origin::new("sub.example.com").unwrap_err());
+        assert_eq!(OriginError::FaultyScheme, Origin::new("192.168.1.0").unwrap_err());
+        assert_eq!(OriginError::FaultyScheme, Origin::new("sub.example.com:8080").unwrap_err());
     }
 
     #[test]

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -64,12 +64,13 @@ impl Origin {
     /// Rules include:
     ///
     /// - Generalistic http::uri::Uri rules for URI's.
+    /// - URI must not be a path, and instead must be e.g. "sub.example.com"
     /// - Scheme must be either HTTP or HTTPS.
-    /// - URI length mustn't exceed 255 characters in total.
-    /// - URI parts mustn't exceed 63 characters per.
+    /// - Host length mustn't exceed 255 characters in total.
+    /// - Host Label parts mustn't exceed 63 characters per.
     /// - Ports must be numeric and <= 65535 (u16::MAX).
     /// - IP strings like 192.168.1.0 cannot have wildcards.
-    /// - Labels must start with a letter or digit.
+    /// - Labels consist of only letters, digits, or hyphens. Cannot start or end with hyphens.
     ///
     fn new(s: &str) -> Result<Self, OriginError> {
         use http::uri::{Uri, Scheme};

--- a/ohkami/src/fang/builtin.rs
+++ b/ohkami/src/fang/builtin.rs
@@ -67,7 +67,7 @@ impl Origin {
     /// Parse string into HTTP origin.
     ///
     /// # Examples
-    /// ```rust
+    /// ```ignore
     /// fn run() {
     ///     Origin::new("https://localhost:3000").unwrap();
     /// }

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -122,7 +122,7 @@ impl Cors {
         self.max_age = delta_seconds;
         self
     }
-    pub fn verify_origin<'a>(origin: &'a str, allow_origin: Cow<'a, str>) -> Cow<'a ,str> {
+    pub fn verify_origin<'a>(origin: &'a str, allow_origin: Cow<'a, str>) -> Cow<'a, str> {
         //Check protocol being the same and character count being within limit, if not return.
         let Some((protocol, rest)) = origin.split_once("://") else {
             return allow_origin;
@@ -153,7 +153,7 @@ impl Cors {
 
             if !allow_host.starts_with("*.") {
                 if host != allow_host {
-                    return allow_origin
+                    return allow_origin;
                 }
             }
 
@@ -165,10 +165,17 @@ impl Cors {
             //Origin host must not be empty and only contain up to 63 characters from a-Z, 0-9, '-', '*'.
             if !host.split('.').all(|part| {
                 !part.is_empty()
-                    && part.chars().all(|c| matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '-')
-                    && part.chars().count() <= 63)
+                    && part.chars().all(|c| {
+                        matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '-')
+                            && part.chars().count() <= 63
+                    })
             }) {
                 return allow_origin;
+            }
+
+            // For local development on localhost there will be nothingto split after this.
+            if allow_host == "localhost" && host == allow_host {
+                return Cow::Borrowed(origin);
             }
 
             let Some((subdomain, sld)) = host.split_once('.') else {
@@ -184,12 +191,15 @@ impl Cors {
             }
 
             //If the request is from an IP address, which cannot have a subdomain, and there's a port wildcard, return origin, otherwise default.
-            if sld.split('.').all(|part| part.chars().all(|c| c.is_numeric())) {
+            if sld
+                .split('.')
+                .all(|part| part.chars().all(|c| c.is_numeric()))
+            {
                 return if allow_port.is_some_and(|p| p == "*") && subdomain != "*" {
                     Cow::Borrowed(origin)
                 } else {
                     allow_origin
-                }
+                };
             }
 
             //If subdomain is only alphanumeric characters and there's no wildcard, the subdomain must exactly match.
@@ -200,7 +210,7 @@ impl Cors {
                     }
                     if allow_port.is_some_and(|p| p == "*") {
                         //Subdomain is valid, and port doesn't matter, return request origin
-                        return Cow::Borrowed(origin)
+                        return Cow::Borrowed(origin);
                     }
                 } else if allow_port.is_some_and(|p| p != "*") {
                     return if port == allow_port {
@@ -211,7 +221,7 @@ impl Cors {
                     };
                 } else {
                     //Subdomain is a wildcard and so is the port
-                    return Cow::Borrowed(origin)
+                    return Cow::Borrowed(origin);
                 }
             }
         }
@@ -237,7 +247,11 @@ pub struct CorsProc<Inner: FangProc> {
 impl<Inner: FangProc> FangProc for CorsProc<Inner> {
     async fn bite<'b>(&'b self, req: &'b mut Request) -> Response {
         let mut res = self.inner.bite(req).await;
-        let allow_origin = Cors::verify_origin(req.headers.origin().unwrap_or_else(|| ""), self.cors.allow_origin.get_cow()).into_owned();
+        let allow_origin = Cors::verify_origin(
+            req.headers.origin().unwrap_or_else(|| ""),
+            self.cors.allow_origin.get_cow(),
+        )
+        .into_owned();
 
         res.headers
             .set()
@@ -278,51 +292,128 @@ impl<Inner: FangProc> FangProc for CorsProc<Inner> {
 
 #[cfg(test)]
 mod test {
-
     #[test]
     fn cors_accept_regular_ip() {
-        assert_eq!("https://192.168.1.41:5173", super::Cors::verify_origin("https://192.168.1.41:5173", std::borrow::Cow::Borrowed("https://192.168.1.41:5173")))
+        assert_eq!(
+            "https://192.168.1.41:5173",
+            super::Cors::verify_origin(
+                "https://192.168.1.41:5173",
+                std::borrow::Cow::Borrowed("https://192.168.1.41:5173")
+            )
+        )
     }
 
     #[test]
     fn cors_accept_regular_domain() {
-        assert_eq!("https://example.com", super::Cors::verify_origin("https://example.com", std::borrow::Cow::Borrowed("https://example.com")));
-        assert_eq!("https://sub.example.com", super::Cors::verify_origin("https://sub.example.com", std::borrow::Cow::Borrowed("https://sub.example.com")))
+        assert_eq!(
+            "https://example.com",
+            super::Cors::verify_origin(
+                "https://example.com",
+                std::borrow::Cow::Borrowed("https://example.com")
+            )
+        );
+        assert_eq!(
+            "https://sub.example.com",
+            super::Cors::verify_origin(
+                "https://sub.example.com",
+                std::borrow::Cow::Borrowed("https://sub.example.com")
+            )
+        )
+    }
+
+    #[test]
+    fn cors_accept_localhost() {
+        assert_eq!(
+            "https://localhost:5173",
+            super::Cors::verify_origin(
+                "https://localhost:5173",
+                std::borrow::Cow::Borrowed("https://localhost:5173")
+            )
+        );
+        assert_eq!(
+            "https://localhost:5173",
+            super::Cors::verify_origin(
+                "https://localhost:5173",
+                std::borrow::Cow::Borrowed("https://localhost:*")
+            )
+        )
     }
 
     #[test]
     fn cors_accept_wildcard_in_ip_port() {
-        assert_eq!("https://192.168.1.41:5173", super::Cors::verify_origin("https://192.168.1.41:5173", std::borrow::Cow::Borrowed("https://192.168.1.41:*")))
+        assert_eq!(
+            "https://192.168.1.41:5173",
+            super::Cors::verify_origin(
+                "https://192.168.1.41:5173",
+                std::borrow::Cow::Borrowed("https://192.168.1.41:*")
+            )
+        )
     }
 
     #[test]
     fn cors_accept_wildcard_in_port() {
-        assert_eq!("https://example.com:5173", super::Cors::verify_origin("https://example.com:5173", std::borrow::Cow::Borrowed("https://example.com:*")))
+        assert_eq!(
+            "https://example.com:5173",
+            super::Cors::verify_origin(
+                "https://example.com:5173",
+                std::borrow::Cow::Borrowed("https://example.com:*")
+            )
+        )
     }
 
     #[test]
     fn cors_accept_wildcard_in_subdomain() {
-        assert_eq!("https://test.example.com", super::Cors::verify_origin("https://test.example.com", std::borrow::Cow::Borrowed("https://*.example.com")))
+        assert_eq!(
+            "https://test.example.com",
+            super::Cors::verify_origin(
+                "https://test.example.com",
+                std::borrow::Cow::Borrowed("https://*.example.com")
+            )
+        )
     }
 
     #[test]
     fn cors_deny_wildcard_in_ip_subdomain() {
-        assert_eq!("https://192.168.1.0:8080", super::Cors::verify_origin("https://192.*.1.0:8080", std::borrow::Cow::Borrowed("https://192.168.1.0:8080")))
+        assert_eq!(
+            "https://192.168.1.0:8080",
+            super::Cors::verify_origin(
+                "https://192.*.1.0:8080",
+                std::borrow::Cow::Borrowed("https://192.168.1.0:8080")
+            )
+        )
     }
 
     #[test]
     fn cors_deny_wildcard_in_sld() {
-        assert_eq!("https://test.example.com:8080", super::Cors::verify_origin("https://test.*.com:8080", std::borrow::Cow::Borrowed("https://test.example.com:8080")))
+        assert_eq!(
+            "https://test.example.com:8080",
+            super::Cors::verify_origin(
+                "https://test.*.com:8080",
+                std::borrow::Cow::Borrowed("https://test.example.com:8080")
+            )
+        )
     }
 
     #[test]
     fn cors_deny_invalid_ip() {
-        assert_eq!("https://192.168.1.0:8080", super::Cors::verify_origin("https://192.168.a.0:8080", std::borrow::Cow::Borrowed("https://192.168.1.0:8080")))
+        assert_eq!(
+            "https://192.168.1.0:8080",
+            super::Cors::verify_origin(
+                "https://192.168.a.0:8080",
+                std::borrow::Cow::Borrowed("https://192.168.1.0:8080")
+            )
+        )
     }
 
     #[test]
     fn cors_deny_invalid_ip_port_range() {
-        assert_eq!("https://192.168.1.0:8080", super::Cors::verify_origin("https://192.168.1.0:80080", std::borrow::Cow::Borrowed("https://192.168.1.0:8080")))
+        assert_eq!(
+            "https://192.168.1.0:8080",
+            super::Cors::verify_origin(
+                "https://192.168.1.0:80080",
+                std::borrow::Cow::Borrowed("https://192.168.1.0:8080")
+            )
+        )
     }
 
     #[test]
@@ -337,11 +428,15 @@ mod test {
         let _: super::Cors = super::Cors::new("https://example.com:*");
         let _: super::Cors = super::Cors::new("https://*.example.com:*");
         let _: super::Cors = super::Cors::new("http://123example.com");
-        let _: super::Cors = super::Cors::new("https://abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcde.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.com");
+        let _: super::Cors = super::Cors::new(
+            "https://abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcde.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.com",
+        );
     }
 
     #[test]
-    #[should_panic(expected = "invalid origin: 'http' or 'https' scheme is required at the start of the string.")]
+    #[should_panic(
+        expected = "invalid origin: 'http' or 'https' scheme is required at the start of the string."
+    )]
     fn cors_scheme_invalidation() {
         let _: super::Cors = super::Cors::new("foobarhttp://example.com");
     }
@@ -349,23 +444,31 @@ mod test {
     #[test]
     #[should_panic(expected = "invalid origin: maximum length 253 for domain exceeded.")]
     fn cors_length_invalidation() {
-        let _: super::Cors = super::Cors::new("https://abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcde.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com");
+        let _: super::Cors = super::Cors::new(
+            "https://abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcde.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
+        );
     }
 
     #[test]
     #[should_panic(expected = "invalid origin: invalid host.")]
     fn cors_part_length_invalidation() {
-        let _: super::Cors = super::Cors::new("https://www.abcdefghijklmnopqrstuvwxyzabcdefghijklmnoqrstuvwxyzabcdefghijklmnopqrstuvwxyz.com");
+        let _: super::Cors = super::Cors::new(
+            "https://www.abcdefghijklmnopqrstuvwxyzabcdefghijklmnoqrstuvwxyzabcdefghijklmnopqrstuvwxyz.com",
+        );
     }
 
     #[test]
-    #[should_panic(expected = "[Cors::new] invalid origin: port must be a number between 0 and 65535 or wildcard '*'.")]
+    #[should_panic(
+        expected = "[Cors::new] invalid origin: port must be a number between 0 and 65535 or wildcard '*'."
+    )]
     fn cors_port_invalidation() {
         let _: super::Cors = super::Cors::new("http://example.com:abcd");
     }
 
     #[test]
-    #[should_panic(expected = "invalid origin: host must start with an alphanumeric character or wildcard '*'.")]
+    #[should_panic(
+        expected = "invalid origin: host must start with an alphanumeric character or wildcard '*'."
+    )]
     fn cors_host_invalidation() {
         let _: super::Cors = super::Cors::new("http://%example.com");
     }

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -66,7 +66,7 @@ impl AccessControlAllowOrigin {
 
 impl Cors {
     /// Create `Cors` fang using given `origin` as `Access-Control-Allow-Origin` header value.\
-    /// (Both `"*"` and a speciffic origin are available)
+    /// (Both `"*"` and a specific origin are available)
     pub fn new(origin: impl Into<Cow<'static, str>>) -> Self {
         Self {
             allow_origin: AccessControlAllowOrigin::new(origin)
@@ -122,6 +122,101 @@ impl Cors {
         self.max_age = delta_seconds;
         self
     }
+    pub fn verify_origin<'a>(origin: &'a str, allow_origin: Cow<'a, str>) -> Cow<'a ,str> {
+        //Check protocol being the same and character count being within limit, if not return.
+        let Some((protocol, rest)) = origin.split_once("://") else {
+            return allow_origin;
+        };
+        let Some((allow_protocol, allow_rest)) = allow_origin.split_once("://") else {
+            return allow_origin;
+        };
+
+        if protocol == allow_protocol && origin.chars().count() <= 253 {
+            let (allow_host, allow_port) = allow_rest
+                .split_once(':')
+                .map_or((allow_rest, None), |(h, p)| (h, Some(p)));
+
+            //No wildcards in Cors at all, return default
+            if !allow_host.starts_with("*.") && allow_port.is_some_and(|p| p != "*") {
+                return allow_origin;
+            }
+
+            let (host, port) = rest
+                .split_once(':')
+                .map_or((rest, None), |(h, p)| (h, Some(p)));
+            //If no port wildcard in Cors, enforce similarity
+            if allow_port.is_some_and(|p| p != "*") {
+                if port != allow_port {
+                    return allow_origin;
+                }
+            }
+
+            if !allow_host.starts_with("*.") {
+                if host != allow_host {
+                    return allow_origin
+                }
+            }
+
+            //Port must be in range of u16, and must be either * or a string of numbers.
+            if port.is_some_and(|p| p.parse::<u16>().is_err()) {
+                return allow_origin;
+            }
+
+            //Origin host must not be empty and only contain up to 63 characters from a-Z, 0-9, '-', '*'.
+            if !host.split('.').all(|part| {
+                !part.is_empty()
+                    && part.chars().all(|c| matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '-')
+                    && part.chars().count() <= 63)
+            }) {
+                return allow_origin;
+            }
+
+            let Some((subdomain, sld)) = host.split_once('.') else {
+                return allow_origin;
+            };
+            let Some((allow_subdomain, allow_sld)) = allow_host.split_once('.') else {
+                return allow_origin;
+            };
+
+            //The latter parts of the host must exactly match, as there's no allowed wildcards here.
+            if sld != allow_sld {
+                return allow_origin;
+            }
+
+            //If the request is from an IP address, which cannot have a subdomain, and there's a port wildcard, return origin, otherwise default.
+            if sld.split('.').all(|part| part.chars().all(|c| c.is_numeric())) {
+                return if allow_port.is_some_and(|p| p == "*") && subdomain != "*" {
+                    Cow::Borrowed(origin)
+                } else {
+                    allow_origin
+                }
+            }
+
+            //If subdomain is only alphanumeric characters and there's no wildcard, the subdomain must exactly match.
+            if subdomain.chars().all(|c| c.is_ascii_alphanumeric()) {
+                if allow_subdomain != "*" {
+                    if subdomain != allow_subdomain {
+                        return allow_origin;
+                    }
+                    if allow_port.is_some_and(|p| p == "*") {
+                        //Subdomain is valid, and port doesn't matter, return request origin
+                        return Cow::Borrowed(origin)
+                    }
+                } else if allow_port.is_some_and(|p| p != "*") {
+                    return if port == allow_port {
+                        //Subdomain is wildcard, port is valid
+                        Cow::Borrowed(origin)
+                    } else {
+                        allow_origin
+                    };
+                } else {
+                    //Subdomain is a wildcard and so is the port
+                    return Cow::Borrowed(origin)
+                }
+            }
+        }
+        allow_origin //No wildcards
+    }
 }
 
 impl<Inner: FangProc> Fang<Inner> for Cors {
@@ -142,10 +237,11 @@ pub struct CorsProc<Inner: FangProc> {
 impl<Inner: FangProc> FangProc for CorsProc<Inner> {
     async fn bite<'b>(&'b self, req: &'b mut Request) -> Response {
         let mut res = self.inner.bite(req).await;
+        let allow_origin = Cors::verify_origin(req.headers.origin().unwrap_or_else(|| ""), self.cors.allow_origin.get_cow()).into_owned();
 
         res.headers
             .set()
-            .access_control_allow_origin(self.cors.allow_origin.get_cow())
+            .access_control_allow_origin(allow_origin)
             .vary(self.cors.allow_origin.is_any().then_some("Origin".into()))
             .access_control_allow_credentials(self.cors.allow_credentials.then_some("true".into()))
             .access_control_expose_headers(
@@ -182,10 +278,96 @@ impl<Inner: FangProc> FangProc for CorsProc<Inner> {
 
 #[cfg(test)]
 mod test {
+
+    #[test]
+    fn cors_accept_regular_ip() {
+        assert_eq!("https://192.168.1.41:5173", super::Cors::verify_origin("https://192.168.1.41:5173", std::borrow::Cow::Borrowed("https://192.168.1.41:5173")))
+    }
+
+    #[test]
+    fn cors_accept_regular_domain() {
+        assert_eq!("https://example.com", super::Cors::verify_origin("https://example.com", std::borrow::Cow::Borrowed("https://example.com")));
+        assert_eq!("https://sub.example.com", super::Cors::verify_origin("https://sub.example.com", std::borrow::Cow::Borrowed("https://sub.example.com")))
+    }
+
+    #[test]
+    fn cors_accept_wildcard_in_ip_port() {
+        assert_eq!("https://192.168.1.41:5173", super::Cors::verify_origin("https://192.168.1.41:5173", std::borrow::Cow::Borrowed("https://192.168.1.41:*")))
+    }
+
+    #[test]
+    fn cors_accept_wildcard_in_port() {
+        assert_eq!("https://example.com:5173", super::Cors::verify_origin("https://example.com:5173", std::borrow::Cow::Borrowed("https://example.com:*")))
+    }
+
+    #[test]
+    fn cors_accept_wildcard_in_subdomain() {
+        assert_eq!("https://test.example.com", super::Cors::verify_origin("https://test.example.com", std::borrow::Cow::Borrowed("https://*.example.com")))
+    }
+
+    #[test]
+    fn cors_deny_wildcard_in_ip_subdomain() {
+        assert_eq!("https://192.168.1.0:8080", super::Cors::verify_origin("https://192.*.1.0:8080", std::borrow::Cow::Borrowed("https://192.168.1.0:8080")))
+    }
+
+    #[test]
+    fn cors_deny_wildcard_in_sld() {
+        assert_eq!("https://test.example.com:8080", super::Cors::verify_origin("https://test.*.com:8080", std::borrow::Cow::Borrowed("https://test.example.com:8080")))
+    }
+
+    #[test]
+    fn cors_deny_invalid_ip() {
+        assert_eq!("https://192.168.1.0:8080", super::Cors::verify_origin("https://192.168.a.0:8080", std::borrow::Cow::Borrowed("https://192.168.1.0:8080")))
+    }
+
+    #[test]
+    fn cors_deny_invalid_ip_port_range() {
+        assert_eq!("https://192.168.1.0:8080", super::Cors::verify_origin("https://192.168.1.0:80080", std::borrow::Cow::Borrowed("https://192.168.1.0:8080")))
+    }
+
     #[test]
     fn cors_new_with_str_or_string() {
         let _: super::Cors = super::Cors::new("https://example.com");
         let _: super::Cors = super::Cors::new(String::from("https://") + "example.com");
+    }
+
+    #[test]
+    fn cors_wildcard_validation() {
+        let _: super::Cors = super::Cors::new("https://*.example.com");
+        let _: super::Cors = super::Cors::new("https://example.com:*");
+        let _: super::Cors = super::Cors::new("https://*.example.com:*");
+        let _: super::Cors = super::Cors::new("http://123example.com");
+        let _: super::Cors = super::Cors::new("https://abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcde.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.com");
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid origin: 'http' or 'https' scheme is required at the start of the string.")]
+    fn cors_scheme_invalidation() {
+        let _: super::Cors = super::Cors::new("foobarhttp://example.com");
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid origin: maximum length 253 for domain exceeded.")]
+    fn cors_length_invalidation() {
+        let _: super::Cors = super::Cors::new("https://abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcde.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com");
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid origin: invalid host.")]
+    fn cors_part_length_invalidation() {
+        let _: super::Cors = super::Cors::new("https://www.abcdefghijklmnopqrstuvwxyzabcdefghijklmnoqrstuvwxyzabcdefghijklmnopqrstuvwxyz.com");
+    }
+
+    #[test]
+    #[should_panic(expected = "[Cors::new] invalid origin: port must be a number between 0 and 65535 or wildcard '*'.")]
+    fn cors_port_invalidation() {
+        let _: super::Cors = super::Cors::new("http://example.com:abcd");
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid origin: host must start with an alphanumeric character or wildcard '*'.")]
+    fn cors_host_invalidation() {
+        let _: super::Cors = super::Cors::new("http://%example.com");
     }
 
     #[test]

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -36,11 +36,6 @@ impl std::fmt::Display for CorsOriginError {
 impl CorsOriginValue {
     /// Parse string based on the Cors origin string syntax.
     ///
-    /// # Arguments
-    /// * `s`: &str - The string that represents the URI that should be added to the Cors.
-    ///
-    /// returns: Self (CorsOriginValue)
-    ///
     /// # Examples
     /// ```rust
     /// fn run() {

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -98,26 +98,25 @@ impl CorsOriginValue {
                         return false;
                     }
 
-                    let (cors_subdomain, cors_domain) = cors_origin.base_origin.host_as_subdomain_and_domain();
-                    let (subdomain, domain) = host
-                        .split_once('.')
-                        .map_or((None, host), |(s, d)| {
-                            if d.contains('.') {
-                                (Some(s), d)
-                            } else {
-                                (None, host)
+                    if let Some(cors_host) = cors_origin.base_origin.host() {
+                        if !cors_origin.any_subdomain {
+                            // If we do not support any subdomain, we can just fully compare the two, as no additional parsing is necessary.
+                            if cors_host != host {
+                                return false;
                             }
-                        });
-
-                    // If subdomain is not a wildcard, validate
-                    if !cors_origin.any_subdomain && cors_subdomain != subdomain {
-                        return false;
+                        } else {
+                            // Subdomain is a wildcard
+                            // If they don't match, check if it's just a subdomain, or something else entirely, meaning it's invalid.
+                            if cors_host != host {
+                                // Returns None if strip fails, meaning some other unknown stuff was appended to the URI.
+                                if None == host.strip_suffix(cors_host) {
+                                    return false;
+                                }
+                            }
+                        }
                     }
+                    // If we do not support any subdomain, we can just fully compare the two, as no additional parsing is necessary.
 
-                    // Check if domain matches.
-                    if domain != cors_domain {
-                        return false;
-                    }
                     // Subdomain, domain and port match, so return true.
                     true
                 } else {

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -506,43 +506,33 @@ mod test {
     }
 
     #[test]
-    #[should_panic(
-        expected = "[Cors::new] Please use HTTP or HTTPS as scheme."
-    )]
     fn cors_scheme_invalidation() {
-        let _: super::Cors = super::Cors::new("foobarhttp://example.com");
+        let origin = "foobarhttp://example.com";
+        assert_eq!(super::CorsOriginError::InvalidOrigin(super::OriginError::FaultyScheme).to_string(), super::CorsOriginValue::new(origin).unwrap_err().to_string())
     }
 
     #[test]
-    #[should_panic(expected = "[Cors::new] URI length mustn't exceed 255 characters in total.")]
     fn cors_length_invalidation() {
-        let _: super::Cors = super::Cors::new(
-            "https://thisisaridiculouslylongurithatshoulddefinitelybeinvalidaccordingtothistest.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
-        );
+        let origin = "https://thisisaridiculouslylongurithatshoulddefinitelybeinvalidaccordingtothistest.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com";
+        assert_eq!(super::CorsOriginError::InvalidOrigin(super::OriginError::FaultyUriLength).to_string(), super::CorsOriginValue::new(origin).unwrap_err().to_string())
     }
 
     #[test]
-    #[should_panic(expected = "[Cors::new] URI part length mustn't exceed 63 characters.")]
     fn cors_part_length_invalidation() {
-        let _: super::Cors = super::Cors::new(
-            "https://www.abcdefghijklmnopqrstuvwxyzabcdefghijklmnoqrstuvwxyzabcdefghijklmnopqrstuvwxyz.com",
-        );
+        let origin = "https://www.abcdefghijklmnopqrstuvwxyzabcdefghijklmnoqrstuvwxyzabcdefghijklmnopqrstuvwxyz.com";
+        assert_eq!(super::CorsOriginError::InvalidOrigin(super::OriginError::FaultyUriPartLength).to_string(), super::CorsOriginValue::new(origin).unwrap_err().to_string())
     }
 
     #[test]
-    #[should_panic(
-        expected = "[Cors::new] Port number was expected."
-    )]
     fn cors_port_invalidation() {
-        let _: super::Cors = super::Cors::new("http://example.com:abcd");
+        let origin = "http://example.com:abcd";
+        assert_eq!(super::CorsOriginError::InvalidOrigin(super::OriginError::FaultyPort).to_string(), super::CorsOriginValue::new(origin).unwrap_err().to_string())
     }
 
     #[test]
-    #[should_panic(
-        expected = "[Cors::new] Ip was misformatted."
-    )]
     fn cors_ip_subdomain_wildcard_invalidation() {
-        let _: super::Cors = super::Cors::new("https://*.168.1.0:8080");
+        let origin = "https://*.168.1.0:8080";
+        assert_eq!(super::CorsOriginError::InvalidOrigin(super::OriginError::FaultyIp).to_string(), super::CorsOriginValue::new(origin).unwrap_err().to_string())
     }
 
     #[test]

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -84,7 +84,7 @@ impl CorsOriginValue {
     /// }
     /// ```
     #[allow(unused)]
-    fn matches_str(&self, incoming_origin: &str) -> bool {
+    fn allows_str(&self, incoming_origin: &str) -> bool {
         match self {
             CorsOriginValue::CorsOrigin(cors_origin) => {
                 if let Some(("http" | "https" , origin)) = incoming_origin.split_once("://") {
@@ -138,7 +138,7 @@ impl CorsOriginValue {
     /// }
     /// ```
     #[allow(unused)]
-    fn matches(&self, incoming_origin: &super::Origin) -> bool {
+    fn allows(&self, incoming_origin: &super::Origin) -> bool {
         match self {
             CorsOriginValue::CorsOrigin(cors_origin) => {
                 if cors_origin.base_origin.scheme() == incoming_origin.scheme() {
@@ -172,6 +172,16 @@ impl CorsOriginValue {
                 // Anything goes
                 true
             }
+        }
+    }
+
+    /// Returns the fallback access control allow origin String of this [`CorsOriginValue`].
+    fn fallback_access_control_allow_origin(&self) -> String {
+        match &self {
+            CorsOriginValue::Any => String::from("*"),
+            // `base_origin` itself is always an allowed origin.
+            CorsOriginValue::CorsOrigin(cors_origin)
+                => cors_origin.base_origin.to_string(),
         }
     }
 
@@ -293,12 +303,8 @@ impl<Inner: FangProc> FangProc for CorsProc<Inner> {
         let mut res = self.inner.bite(req).await;
         let incoming_origin = req.headers.origin().and_then(|s| super::Origin::new(s).ok());
         let access_control_allow_origin = match incoming_origin {
-            Some(incoming) if self.cors.allow_origin_config.matches(&incoming) => incoming.to_string(),
-            _ => if let CorsOriginValue::CorsOrigin(cors_origin) = &self.cors.allow_origin_config {
-                cors_origin.base_origin.to_string()
-            } else {
-                String::from("*")
-            },
+            Some(incoming) if self.cors.allow_origin_config.allows(&incoming) => incoming.to_string(),
+            _ => self.cors.allow_origin_config.fallback_access_control_allow_origin(),
         };
 
         res.headers
@@ -343,7 +349,7 @@ mod test {
     #[test]
     fn cors_accept_regular_origin_ip() {
         assert!(
-            super::CorsOriginValue::matches(
+            super::CorsOriginValue::allows(
                 &super::CorsOriginValue::new("https://192.168.1.41:5173").unwrap(),
                 &super::super::Origin::new("https://192.168.1.41:5173").unwrap(),
             )
@@ -353,13 +359,13 @@ mod test {
     #[test]
     fn cors_accept_regular_origin_domain() {
         assert!(
-            super::CorsOriginValue::matches(
+            super::CorsOriginValue::allows(
                 &super::CorsOriginValue::new("https://example.com").unwrap(),
                 &super::super::Origin::new("https://example.com").unwrap(),
             )
         );
         assert!(
-            super::CorsOriginValue::matches(
+            super::CorsOriginValue::allows(
                 &super::CorsOriginValue::new("https://sub.example.com").unwrap(),
                 &super::super::Origin::new("https://sub.example.com").unwrap(),
             )
@@ -369,13 +375,13 @@ mod test {
     #[test]
     fn cors_accept_origin_localhost() {
         assert!(
-            super::CorsOriginValue::matches(
+            super::CorsOriginValue::allows(
                 &super::CorsOriginValue::new("https://localhost:5173/").unwrap(),
                 &super::super::Origin::new("https://localhost:5173/").unwrap(),
             )
         );
         assert!(
-            super::CorsOriginValue::matches(
+            super::CorsOriginValue::allows(
                 &super::CorsOriginValue::new("https://localhost:*").unwrap(),
                 &super::super::Origin::new("https://localhost:5173/").unwrap(),
             )
@@ -385,7 +391,7 @@ mod test {
     #[test]
     fn cors_accept_wildcard_match_in_own_ip_port() {
         assert!(
-            super::CorsOriginValue::matches(
+            super::CorsOriginValue::allows(
                 &super::CorsOriginValue::new("https://192.168.1.2:*").unwrap(),
                 &super::super::Origin::new("https://192.168.1.2:5173").unwrap(),
             )
@@ -395,7 +401,7 @@ mod test {
     #[test]
     fn cors_accept_wildcard_match_in_own_port() {
         assert!(
-            super::CorsOriginValue::matches(
+            super::CorsOriginValue::allows(
                 &super::CorsOriginValue::new("https://example.com:*").unwrap(),
                 &super::super::Origin::new("https://example.com:5173").unwrap(),
             )
@@ -405,7 +411,7 @@ mod test {
     #[test]
     fn cors_accept_wildcard_match_in_own_subdomain() {
         assert!(
-            super::CorsOriginValue::matches(
+            super::CorsOriginValue::allows(
                 &super::CorsOriginValue::new("https://*.example.com").unwrap(),
                 &super::super::Origin::new("https://test.example.com").unwrap(),
             )
@@ -416,7 +422,7 @@ mod test {
     fn cors_deny_wildcard_in_origin_ip_subdomain() {
         assert_eq!(
             false,
-            super::CorsOriginValue::matches(
+            super::CorsOriginValue::allows(
                 &super::CorsOriginValue::new("https://192.168.1.15:8080").unwrap(),
                 &super::super::Origin::new("https://*.168.1.15:8080").unwrap(),
             )
@@ -427,7 +433,7 @@ mod test {
     fn cors_deny_faulty_wildcard_in_origin_ip() {
         assert_eq!(
             false,
-            super::CorsOriginValue::matches(
+            super::CorsOriginValue::allows(
                 &super::CorsOriginValue::new("https://192.168.1.15:8080").unwrap(),
                 &super::super::Origin::new("https://192.*.1.15:8080").unwrap(),
             )
@@ -438,7 +444,7 @@ mod test {
     fn cors_deny_wildcard_in_origin_sld() {
         assert_eq!(
             false,
-            super::CorsOriginValue::matches(
+            super::CorsOriginValue::allows(
                 &super::CorsOriginValue::new("https://test.example.com:8080").unwrap(),
                 &super::super::Origin::new("https://test.*.com:8080").unwrap(),
             )
@@ -449,7 +455,7 @@ mod test {
     fn cors_deny_wildcard_in_origin_extension() {
         assert_eq!(
             false,
-            super::CorsOriginValue::matches(
+            super::CorsOriginValue::allows(
                 &super::CorsOriginValue::new("https://test.example.com:8080").unwrap(),
                 &super::super::Origin::new("https://test.example.*:8080").unwrap(),
             )
@@ -460,7 +466,7 @@ mod test {
     fn cors_deny_invalid_origin_ip() {
         assert_eq!(
             false,
-            super::CorsOriginValue::matches(
+            super::CorsOriginValue::allows(
                 &super::CorsOriginValue::new("https://192.168.1.58:8080").unwrap(),
                 &super::super::Origin::new("https://192.168.a.58:8080").unwrap(),
             )

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -294,12 +294,10 @@ impl<Inner: FangProc> FangProc for CorsProc<Inner> {
         let incoming_origin = req.headers.origin().and_then(|s| super::Origin::new(s).ok());
         let access_control_allow_origin = match incoming_origin {
             Some(incoming) if self.cors.allow_origin_config.matches(&incoming) => incoming.to_string(),
-            _ => {
-                if let CorsOriginValue::CorsOrigin(cors_origin) = &self.cors.allow_origin_config {
-                    cors_origin.base_origin.to_string()
-                } else {
-                    String::from("*")
-                }
+            _ => if let CorsOriginValue::CorsOrigin(cors_origin) = &self.cors.allow_origin_config {
+                cors_origin.base_origin.to_string()
+            } else {
+                String::from("*")
             },
         };
 

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -1,4 +1,5 @@
 use crate::{Fang, FangProc, Request, Response, Status, header::append};
+use core::{clone::Clone, option::Option::Some};
 use std::borrow::Cow;
 use super::{Origin, OriginError};
 
@@ -117,12 +118,23 @@ impl AllowOriginConfig {
                         // If we do not support any subdomain, we can just fully compare the two, as no additional parsing is necessary.
                         return false;
                     } else {
-                        // If they don't match, check if it's just a subdomain, or something else entirely, meaning it's invalid.
                         if cors_origin.base_origin.host() != incoming_origin.host() { //Check if the options don't already align
                             if let (Some(cors_host), Some(host)) = (cors_origin.base_origin.host(), incoming_origin.host()) {
                                 // Returns None if host doesn't start with cors_host, meaning some other unknown stuff was appended to the URI.
-                                if !host.ends_with(cors_host) {
+                                if !host.ends_with(&cors_host) {
                                     return false;
+                                } else if host != cors_host && let Some(rest) = host.strip_suffix(cors_host) {
+                                    if !rest.contains('.') {
+                                        return false; // Deny wrong domain
+                                    } else {
+                                        if !cors_origin.any_subdomain {
+                                            return false; // Deny prepended subdomain while none are allowed.
+                                        } else {
+                                            if rest.contains("..") || rest.split('.').filter(|s| s != &"").count() >= 2 {
+                                                return false; // Deny if not a direct subdomain or any parts are ".."
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -371,6 +383,48 @@ mod test {
         assert!(
             AllowOriginConfig::new("https://*.example.com").unwrap().allows(
                 &Origin::new("https://test.example.com").unwrap()
+            )
+        );
+    }
+
+    #[test]
+    fn cors_deny_indirect_origin_subdomain() {
+        assert!(
+            !AllowOriginConfig::new("https://b.example.com").unwrap().allows(
+                &Origin::new("https://a.b.example.com").unwrap()
+            )
+        );
+
+        assert!(
+            !AllowOriginConfig::new("https://*.example.com").unwrap().allows(
+                &Origin::new("https://a.b.example.com").unwrap()
+            )
+        );
+
+        assert!(
+            !AllowOriginConfig::new("https://*.example.com").unwrap().allows(
+                &Origin::new("https://a..example.com").unwrap()
+            )
+        );
+
+        assert!(
+            !AllowOriginConfig::new("https://*.example.com").unwrap().allows(
+                &Origin::new("https://..example.com").unwrap()
+            )
+        );
+
+        assert!(
+            !AllowOriginConfig::new("https://example.com").unwrap().allows(
+                &Origin::new("https://..example.com").unwrap()
+            )
+        );
+    }
+
+    #[test]
+    fn cors_deny_wrong_domain() {
+        assert!(
+            !AllowOriginConfig::new("https://example.com").unwrap().allows(
+                &Origin::new("https://anexample.com").unwrap()
             )
         );
     }

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -1,5 +1,58 @@
 use crate::{Fang, FangProc, Request, Response, Status, header::append};
+use core::todo;
 use std::borrow::Cow;
+
+use super::OriginError;
+
+// cors.rs
+
+/* This replaces current `AccessControlAllowOrigin` */
+struct CorsOrigin {
+    base_origin: super::Origin,
+    any_port: bool,
+    any_subdomain: bool,
+}
+
+enum CorsOriginError {
+    InvalidOrigin(OriginError)
+}
+
+impl CorsOrigin {
+    /// Parse string based on the Cors origin string syntax.
+    fn new(s: &str) -> Result<Self, CorsOriginError> {
+        let mut s = Cow::Borrowed(s);
+        let mut any_port = false;
+        let mut any_subdomain = false;
+
+        if let Some(rest) = s.strip_suffix(":*") {
+            any_port = true;
+            s = Cow::Borrowed(rest);
+        }
+
+        if let Some((scheme @ ("http://" | "https://"), rest)) = s.split_once("*.") {
+            any_subdomain = true;
+            // This allocation would not be a problem because `CorsOrigin::new` is
+            // just called once in server initialization phase, not called repeatedly in request handling phases.
+            s = Cow::Owned(scheme.to_string() + rest);
+        }
+
+        let base_origin = super::Origin::new(&s)
+            .map_err(CorsOriginError::InvalidOrigin)?;
+
+        Ok(Self { base_origin, any_port, any_subdomain })
+    }
+
+    fn matches_str(&self, incoming_origin: &str) -> bool {
+        todo!("Write logic");
+        false
+    }
+
+    fn matches(&self, incoming_origin: &super::Origin) -> bool {
+        todo!("Write logic");
+        true
+        //...
+    }
+}
 
 /// # Builtin fang for CORS config
 ///
@@ -395,6 +448,17 @@ mod test {
     }
 
     #[test]
+    fn cors_deny_wildcard_in_extension() {
+        assert_eq!(
+            "https://test.example.com:8080",
+            super::Cors::verify_origin(
+                "https://test.example.*:8080",
+                std::borrow::Cow::Borrowed("https://test.example.com:8080")
+            )
+        )
+    }
+
+    #[test]
     fn cors_deny_invalid_ip() {
         assert_eq!(
             "https://192.168.1.0:8080",
@@ -435,14 +499,14 @@ mod test {
 
     #[test]
     #[should_panic(
-        expected = "invalid origin: 'http' or 'https' scheme is required at the start of the string."
+        expected = "[Cors::new] Unable to parse Uri."
     )]
     fn cors_scheme_invalidation() {
         let _: super::Cors = super::Cors::new("foobarhttp://example.com");
     }
 
     #[test]
-    #[should_panic(expected = "invalid origin: maximum length 253 for domain exceeded.")]
+    #[should_panic(expected = "[Cors::new] Unable to parse Uri.")]
     fn cors_length_invalidation() {
         let _: super::Cors = super::Cors::new(
             "https://abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcde.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
@@ -450,7 +514,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "invalid origin: invalid host.")]
+    #[should_panic(expected = "[Cors::new] Unable to parse Uri.")]
     fn cors_part_length_invalidation() {
         let _: super::Cors = super::Cors::new(
             "https://www.abcdefghijklmnopqrstuvwxyzabcdefghijklmnoqrstuvwxyzabcdefghijklmnopqrstuvwxyz.com",
@@ -459,7 +523,7 @@ mod test {
 
     #[test]
     #[should_panic(
-        expected = "[Cors::new] invalid origin: port must be a number between 0 and 65535 or wildcard '*'."
+        expected = "[Cors::new] Unable to parse Uri."
     )]
     fn cors_port_invalidation() {
         let _: super::Cors = super::Cors::new("http://example.com:abcd");
@@ -467,7 +531,7 @@ mod test {
 
     #[test]
     #[should_panic(
-        expected = "invalid origin: host must start with an alphanumeric character or wildcard '*'."
+        expected = "[Cors::new] Unable to parse Uri."
     )]
     fn cors_host_invalidation() {
         let _: super::Cors = super::Cors::new("http://%example.com");

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -15,6 +15,11 @@ pub struct CorsOrigin {
     any_subdomain: bool,
 }
 
+#[derive(Debug, PartialEq)]
+pub enum CorsOriginError {
+    InvalidOrigin(OriginError)
+}
+
 impl CorsOrigin {
     /// Parse string into [`CorsOrigin`], checks for wildcards inside the string,
     /// and if all appropriate validation succeeds inside [`Origin`] and [`CorsOrigin`] returns Self.
@@ -57,11 +62,6 @@ impl CorsOrigin {
 
         Ok(Self { base_origin, any_port, any_subdomain })
     }
-}
-
-#[derive(Debug, PartialEq)]
-pub enum CorsOriginError {
-    InvalidOrigin(OriginError)
 }
 
 impl std::fmt::Display for CorsOriginError {

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -15,6 +15,45 @@ pub struct CorsOrigin {
     any_subdomain: bool,
 }
 
+impl CorsOrigin {
+    /// Parse string into [`CorsOrigin`], checks for wildcards inside the string,
+    /// and if all appropriate validation succeeds inside [`Origin`] returns Self.
+    ///
+    /// # Examples
+    /// ```rust
+    /// fn run() {
+    ///     CorsOrigin::new("https://*.localhost:3000").unwrap(); //Gives CorsOrigin
+    ///     CorsOrigin::new("https://*.localhost:").unwrap(); //Gives CorsOriginError
+    /// }
+    /// ```
+    /// # Errors
+    /// This function will return an error if the given URI string fails the validation included in [`Origin`].
+    ///
+    fn new(s: &str) -> Result<Self, CorsOriginError> {
+        let mut any_port = false;
+        let mut any_subdomain = false;
+        let mut s = match s.strip_suffix(":*") {
+            Some(rest) => {
+                any_port = true;
+                Cow::Borrowed(rest)
+            }
+            None => Cow::Borrowed(s)
+        };
+
+        if let Some((scheme @ ("http://" | "https://"), rest)) = s.split_once("*.") {
+            any_subdomain = true;
+            // This allocation would not be a problem because `CorsOrigin::new` is
+            // just called once in server initialization phase, not called repeatedly in request handling phases.
+            s = Cow::Owned(scheme.to_string() + rest);
+        }
+
+        let base_origin = Origin::new(&s)
+            .map_err(CorsOriginError::InvalidOrigin)?;
+
+        Ok(Self { base_origin, any_port, any_subdomain })
+    }
+}
+
 #[derive(Debug)]
 pub enum CorsOriginError {
     InvalidOrigin(OriginError)
@@ -38,34 +77,13 @@ impl AllowOriginConfig {
     /// }
     /// ```
     /// # Errors
-    /// This function will return an error if the given URI string fails the validation included in [`Origin`].
+    /// This function will return an error if the given URI string fails the validation included in [`CorsOrigin`] or [`Origin`].
     ///
     fn new(s: &str) -> Result<Self, CorsOriginError> {
-        if s == "*" {
-            return Ok(Self::Any);
+        match s {
+            "*" => Ok(Self::Any),
+            _ => CorsOrigin::new(s).map(Self::CorsOrigin)
         }
-
-        let mut any_port = false;
-        let mut any_subdomain = false;
-        let mut s = match s.strip_suffix(":*") {
-            Some(rest) => {
-                any_port = true;
-                Cow::Borrowed(rest)
-            }
-            None => Cow::Borrowed(s)
-        };
-
-        if let Some((scheme @ ("http://" | "https://"), rest)) = s.split_once("*.") {
-            any_subdomain = true;
-            // This allocation would not be a problem because `CorsOrigin::new` is
-            // just called once in server initialization phase, not called repeatedly in request handling phases.
-            s = Cow::Owned(scheme.to_string() + rest);
-        }
-
-        let base_origin = Origin::new(&s)
-            .map_err(CorsOriginError::InvalidOrigin)?;
-
-        Ok(Self::CorsOrigin(CorsOrigin { base_origin, any_port, any_subdomain }) )
     }
 
     /// Checks if according to the noted rules for wildcards in this struct, the incoming origin would match.
@@ -355,7 +373,7 @@ mod test {
     #[test]
     fn cors_deny_wildcard_in_origin_ip_subdomain() {
         assert!(
-            AllowOriginConfig::new("https://192.168.1.15:8080").unwrap().allows(
+            !AllowOriginConfig::new("https://192.168.1.15:8080").unwrap().allows(
                 &Origin::new("https://*.168.1.15:8080").unwrap()
             )
         )

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -116,38 +116,39 @@ impl AllowOriginConfig {
         match self {
             AllowOriginConfig::CorsOrigin(cors_origin) => {
                 if !(cors_origin.base_origin.scheme() == incoming_origin.scheme()) {
-                    false
-                } else {
-                    // If no port wildcard, check if ports align.
-                    if !cors_origin.any_port && cors_origin.base_origin.port() != incoming_origin.port() {
-                        return false;
-                    }
+                    return false;
+                }
+                // If no port wildcard, check if ports align.
+                if !cors_origin.any_port && cors_origin.base_origin.port() != incoming_origin.port() {
+                    return false;
+                }
 
-                    if !cors_origin.any_subdomain && cors_origin.base_origin.host() != incoming_origin.host() {
-                        // If we do not support any subdomain, we can just fully compare the two, as no additional validation is necessary.
-                        return false;
-                    } else if cors_origin.base_origin.host() != incoming_origin.host() { //Check if the options don't already align
-                        if let (Some(cors_host), Some(host)) = (cors_origin.base_origin.host(), incoming_origin.host()) {
-                            if !host.ends_with(&cors_host) {
-                                return false;
-                            } else if host != cors_host && let Some(rest) = host.strip_suffix(cors_host) {
-                                if !rest.contains('.') {
-                                    return false; // Deny wrong domain
-                                } else {
-                                    if !cors_origin.any_subdomain {
-                                        return false; // Deny prepended subdomain while none are allowed.
-                                    } else {
-                                        if rest.contains("..") || rest.split('.').filter(|s| s != &"").count() >= 2 {
-                                            return false; // Deny if not a direct subdomain or any parts are ".."
-                                        }
-                                    }
-                                }
+                if !cors_origin.any_subdomain && cors_origin.base_origin.host() != incoming_origin.host() {
+                    // If we do not support any subdomain, we can just fully compare the two, as no additional validation is necessary.
+                    return false;
+                }
+
+                if cors_origin.base_origin.host() != incoming_origin.host() { //Check if the options don't already align
+                    if let (Some(cors_host), Some(host)) = (cors_origin.base_origin.host(), incoming_origin.host()) {
+                        if !host.ends_with(&cors_host) {
+                            return false;
+                        }
+
+                        if host != cors_host && let Some(rest) = host.strip_suffix(cors_host) {
+                            if !rest.contains('.') {
+                                return false; // Deny wrong domain
+                            }
+                            if !cors_origin.any_subdomain {
+                                return false; // Deny prepended subdomain while none are allowed.
+                            }
+                            if rest.contains("..") || rest.split('.').filter(|s| s != &"").count() >= 2 {
+                                return false; // Deny if not a direct subdomain or any parts are ".."
                             }
                         }
                     }
-                    // Validations passed
-                    true
                 }
+                // Validations passed
+                true
             }
             AllowOriginConfig::Any => {
                 // Anything goes

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -6,26 +6,33 @@ use super::OriginError;
 // cors.rs
 /* This replaces current `AccessControlAllowOrigin` */
 #[derive(Clone, Debug)]
-enum CorsOriginValue {
+pub enum CorsOriginValue {
     CorsOrigin(CorsOrigin),
     Any
 }
 
 #[derive(Clone, Debug)]
-struct CorsOrigin {
+pub struct CorsOrigin {
     base_origin: super::Origin,
     any_port: bool,
     any_subdomain: bool,
 }
 
+impl Display for CorsOrigin {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.base_origin)
+    }
+}
+
 #[derive(Debug)]
-enum CorsOriginError {
+pub enum CorsOriginError {
     InvalidOrigin(OriginError)
 }
 
 impl Display for CorsOriginError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self)
+        let CorsOriginError::InvalidOrigin(e) = self;
+        write!(f, "{}", e)
     }
 }
 
@@ -75,7 +82,7 @@ impl CorsOriginValue {
                         return false;
                     }
 
-                    let (cors_subdomain, cors_domain) = cors_origin.base_origin.host_as_tuple();
+                    let (cors_subdomain, cors_domain) = cors_origin.base_origin.host_as_subdomain_and_domain();
                     let (subdomain, domain) = host
                         .split_once('.')
                         .map_or((None, origin), |(s, d)| (Some(s), d));
@@ -89,13 +96,12 @@ impl CorsOriginValue {
                     if domain != cors_domain {
                         return false;
                     }
-
+                    // Subdomain, domain and port match, so return true.
                     true
                 } else {
                     // No scheme was somehow found
                     false
                 }
-
             }
             CorsOriginValue::Any => {
                 // Anything goes
@@ -104,6 +110,7 @@ impl CorsOriginValue {
         }
     }
 
+    #[allow(unused)]
     fn matches(&self, incoming_origin: &super::Origin) -> bool {
         if self.is_any() {
             return true;
@@ -123,6 +130,19 @@ impl CorsOriginValue {
     //             Self::Only(origin) => origin.clone(),
     //         }
     //     }
+}
+
+impl Display for CorsOriginValue {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CorsOriginValue::CorsOrigin(origin) => {
+                write!(f, "{}", origin)
+            }
+            CorsOriginValue::Any => {
+                write!(f, "*")
+            }
+        }
+    }
 }
 
 /// # Builtin fang for CORS config
@@ -246,107 +266,12 @@ impl Cors {
         self.max_age = delta_seconds;
         self
     }
-    pub fn verify_origin<'a>(origin: &'a str, allow_origin: Cow<'a, str>) -> Cow<'a, str> {
-        //Check protocol being the same and character count being within limit, if not return.
-        let Some((protocol, rest)) = origin.split_once("://") else {
-            return allow_origin;
-        };
-        let Some((allow_protocol, allow_rest)) = allow_origin.split_once("://") else {
-            return allow_origin;
-        };
-
-        if protocol == allow_protocol && origin.chars().count() <= 253 {
-            let (allow_host, allow_port) = allow_rest
-                .split_once(':')
-                .map_or((allow_rest, None), |(h, p)| (h, Some(p)));
-
-            //No wildcards in Cors at all, return default
-            if !allow_host.starts_with("*.") && allow_port.is_some_and(|p| p != "*") {
-                return allow_origin;
-            }
-
-            let (host, port) = rest
-                .split_once(':')
-                .map_or((rest, None), |(h, p)| (h, Some(p)));
-
-            //If no port wildcard in Cors, enforce similarity
-            if allow_port.is_some_and(|p| p != "*") && port != allow_port {
-                return allow_origin;
-            }
-
-            if !allow_host.starts_with("*.") && host != allow_host {
-                return allow_origin;
-            }
-
-            //Port must be in range of u16, and must be either * or a string of numbers.
-            if port.is_some_and(|p| p.parse::<u16>().is_err()) {
-                return allow_origin;
-            }
-
-            //Origin host must not be empty and only contain up to 63 characters from a-Z, 0-9, '-', '*'.
-            if !host.split('.').all(|part| {
-                !part.is_empty()
-                    && part.chars().all(|c| {
-                        matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '-')
-                            && part.chars().count() <= 63
-                    })
-            }) {
-                return allow_origin;
-            }
-
-            // For local development on localhost there will be nothingto split after this.
-            if allow_host == "localhost" && host == allow_host {
-                return Cow::Borrowed(origin);
-            }
-
-            let Some((subdomain, sld)) = host.split_once('.') else {
-                return allow_origin;
-            };
-            let Some((allow_subdomain, allow_sld)) = allow_host.split_once('.') else {
-                return allow_origin;
-            };
-
-            //The latter parts of the host must exactly match, as there's no allowed wildcards here.
-            if sld != allow_sld {
-                return allow_origin;
-            }
-
-            //If the request is from an IP address, which cannot have a subdomain, and there's a port wildcard, return origin, otherwise default.
-            if sld
-                .split('.')
-                .all(|part| part.chars().all(|c| c.is_numeric()))
-            {
-                return if allow_port.is_some_and(|p| p == "*") && subdomain != "*" {
-                    Cow::Borrowed(origin)
-                } else {
-                    allow_origin
-                };
-            }
-
-            //If subdomain is only alphanumeric characters and there's no wildcard, the subdomain must exactly match.
-            if subdomain.chars().all(|c| c.is_ascii_alphanumeric()) {
-                if allow_subdomain != "*" {
-                    if subdomain != allow_subdomain {
-                        return allow_origin;
-                    }
-                    if allow_port.is_some_and(|p| p == "*") {
-                        //Subdomain is valid, and port doesn't matter, return request origin
-                        return Cow::Borrowed(origin);
-                    }
-                } else if allow_port.is_some_and(|p| p != "*") {
-                    return if port == allow_port {
-                        //Subdomain is wildcard, port is valid
-                        Cow::Borrowed(origin)
-                    } else {
-                        allow_origin
-                    };
-                } else {
-                    //Subdomain is a wildcard and so is the port
-                    return Cow::Borrowed(origin);
-                }
-            }
+    pub fn verify_origin<'a>(origin: &'a str, cors_origin: &CorsOriginValue) -> Cow<'a, str> {
+        if CorsOriginValue::matches_str(cors_origin, origin) {
+            Cow::Borrowed(origin)
+        } else {
+            Cow::Owned(cors_origin.to_string())
         }
-        allow_origin //No wildcards
     }
 }
 
@@ -370,7 +295,7 @@ impl<Inner: FangProc> FangProc for CorsProc<Inner> {
         let mut res = self.inner.bite(req).await;
         let allow_origin = Cors::verify_origin(
             req.headers.origin().unwrap_or(""),
-            self.cors.allow_origin.get_cow(),
+            &self.cors.allow_origin,
         )
         .into_owned();
 
@@ -419,7 +344,7 @@ mod test {
             "https://192.168.1.41:5173",
             super::Cors::verify_origin(
                 "https://192.168.1.41:5173",
-                std::borrow::Cow::Borrowed("https://192.168.1.41:5173")
+                &super::CorsOriginValue::new("https://192.168.1.41:5173").unwrap()
             )
         )
     }
@@ -430,14 +355,14 @@ mod test {
             "https://example.com",
             super::Cors::verify_origin(
                 "https://example.com",
-                std::borrow::Cow::Borrowed("https://example.com")
+                &super::CorsOriginValue::new("https://example.com").unwrap()
             )
         );
         assert_eq!(
             "https://sub.example.com",
             super::Cors::verify_origin(
                 "https://sub.example.com",
-                std::borrow::Cow::Borrowed("https://sub.example.com")
+                &super::CorsOriginValue::new("https://sub.example.com").unwrap()
             )
         )
     }
@@ -448,14 +373,14 @@ mod test {
             "https://localhost:5173",
             super::Cors::verify_origin(
                 "https://localhost:5173",
-                std::borrow::Cow::Borrowed("https://localhost:5173")
+                &super::CorsOriginValue::new("https://localhost:5173").unwrap()
             )
         );
         assert_eq!(
             "https://localhost:5173",
             super::Cors::verify_origin(
                 "https://localhost:5173",
-                std::borrow::Cow::Borrowed("https://localhost:*")
+                &super::CorsOriginValue::new("https://localhost:*").unwrap()
             )
         )
     }
@@ -463,10 +388,10 @@ mod test {
     #[test]
     fn cors_accept_wildcard_in_ip_port() {
         assert_eq!(
-            "https://192.168.1.41:5173",
+            "https://192.168.1.2:5173",
             super::Cors::verify_origin(
-                "https://192.168.1.41:5173",
-                std::borrow::Cow::Borrowed("https://192.168.1.41:*")
+                "https://192.168.1.2:5173",
+                &super::CorsOriginValue::new("https://192.168.1.2:*").unwrap()
             )
         )
     }
@@ -477,7 +402,7 @@ mod test {
             "https://example.com:5173",
             super::Cors::verify_origin(
                 "https://example.com:5173",
-                std::borrow::Cow::Borrowed("https://example.com:*")
+                &super::CorsOriginValue::new("https://example.com:*").unwrap()
             )
         )
     }
@@ -488,7 +413,7 @@ mod test {
             "https://test.example.com",
             super::Cors::verify_origin(
                 "https://test.example.com",
-                std::borrow::Cow::Borrowed("https://*.example.com")
+                &super::CorsOriginValue::new("https://*.example.com").unwrap()
             )
         )
     }
@@ -496,10 +421,10 @@ mod test {
     #[test]
     fn cors_deny_wildcard_in_ip_subdomain() {
         assert_eq!(
-            "https://192.168.1.0:8080",
+            "https://192.168.1.15:8080",
             super::Cors::verify_origin(
-                "https://192.*.1.0:8080",
-                std::borrow::Cow::Borrowed("https://192.168.1.0:8080")
+                "https://192.*.1.15:8080",
+                &super::CorsOriginValue::new("https://192.168.1.15:8080").unwrap()
             )
         )
     }
@@ -510,7 +435,7 @@ mod test {
             "https://test.example.com:8080",
             super::Cors::verify_origin(
                 "https://test.*.com:8080",
-                std::borrow::Cow::Borrowed("https://test.example.com:8080")
+                &super::CorsOriginValue::new("https://test.example.com:8080").unwrap()
             )
         )
     }
@@ -521,7 +446,7 @@ mod test {
             "https://test.example.com:8080",
             super::Cors::verify_origin(
                 "https://test.example.*:8080",
-                std::borrow::Cow::Borrowed("https://test.example.com:8080")
+                &super::CorsOriginValue::new("https://test.example.com:8080").unwrap()
             )
         )
     }
@@ -529,10 +454,10 @@ mod test {
     #[test]
     fn cors_deny_invalid_ip() {
         assert_eq!(
-            "https://192.168.1.0:8080",
+            "https://192.168.1.58:8080",
             super::Cors::verify_origin(
-                "https://192.168.a.0:8080",
-                std::borrow::Cow::Borrowed("https://192.168.1.0:8080")
+                "https://192.168.a.58:8080",
+                &super::CorsOriginValue::new("https://192.168.1.58:8080").unwrap()
             )
         )
     }
@@ -543,7 +468,7 @@ mod test {
             "https://192.168.1.0:8080",
             super::Cors::verify_origin(
                 "https://192.168.1.0:80080",
-                std::borrow::Cow::Borrowed("https://192.168.1.0:8080")
+                &super::CorsOriginValue::new("https://192.168.1.0:8080").unwrap()
             )
         )
     }

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -344,7 +344,7 @@ impl<Inner: FangProc> FangProc for CorsProc<Inner> {
 #[cfg(test)]
 mod test {
     #[test]
-    fn cors_accept_regular_ip() {
+    fn cors_accept_regular_origin_ip() {
         assert_eq!(
             "https://192.168.1.41:5173",
             super::Cors::verify_origin(
@@ -355,7 +355,7 @@ mod test {
     }
 
     #[test]
-    fn cors_accept_regular_domain() {
+    fn cors_accept_regular_origin_domain() {
         assert_eq!(
             "https://example.com",
             super::Cors::verify_origin(
@@ -373,7 +373,7 @@ mod test {
     }
 
     #[test]
-    fn cors_accept_localhost() {
+    fn cors_accept_origin_localhost() {
         assert_eq!(
             "https://localhost:5173/",
             super::Cors::verify_origin(
@@ -391,7 +391,7 @@ mod test {
     }
 
     #[test]
-    fn cors_accept_wildcard_in_ip_port() {
+    fn cors_accept_wildcard_match_in_own_ip_port() {
         assert_eq!(
             "https://192.168.1.2:5173",
             super::Cors::verify_origin(
@@ -402,7 +402,7 @@ mod test {
     }
 
     #[test]
-    fn cors_accept_wildcard_in_port() {
+    fn cors_accept_wildcard_match_in_own_port() {
         assert_eq!(
             "https://example.com:5173",
             super::Cors::verify_origin(
@@ -413,7 +413,7 @@ mod test {
     }
 
     #[test]
-    fn cors_accept_wildcard_in_subdomain() {
+    fn cors_accept_wildcard_match_in_own_subdomain() {
         assert_eq!(
             "https://test.example.com",
             super::Cors::verify_origin(
@@ -424,7 +424,18 @@ mod test {
     }
 
     #[test]
-    fn cors_deny_wildcard_in_ip_subdomain() {
+    fn cors_deny_wildcard_in_origin_ip_subdomain() {
+        assert_eq!(
+            "https://192.168.1.15:8080/",
+            super::Cors::verify_origin(
+                "https://*.168.1.15:8080",
+                &super::CorsOriginValue::new("https://192.168.1.15:8080").unwrap()
+            )
+        )
+    }
+
+    #[test]
+    fn cors_deny_faulty_wildcard_in_origin_ip() {
         assert_eq!(
             "https://192.168.1.15:8080/",
             super::Cors::verify_origin(
@@ -435,7 +446,18 @@ mod test {
     }
 
     #[test]
-    fn cors_deny_wildcard_in_sld() {
+    fn cors_deny_faulty_wildcard_in_origin_ip_subdomain() {
+        assert_eq!(
+            "https://192.168.1.15:8080/",
+            super::Cors::verify_origin(
+                "https://*.168.1.15:8080",
+                &super::CorsOriginValue::new("https://192.168.1.15:8080").unwrap()
+            )
+        )
+    }
+
+    #[test]
+    fn cors_deny_wildcard_in_origin_sld() {
         assert_eq!(
             "https://test.example.com:8080/",
             super::Cors::verify_origin(
@@ -446,7 +468,7 @@ mod test {
     }
 
     #[test]
-    fn cors_deny_wildcard_in_extension() {
+    fn cors_deny_wildcard_in_origin_extension() {
         assert_eq!(
             "https://test.example.com:8080/",
             super::Cors::verify_origin(
@@ -457,7 +479,7 @@ mod test {
     }
 
     #[test]
-    fn cors_deny_invalid_ip() {
+    fn cors_deny_invalid_origin_ip() {
         assert_eq!(
             "https://192.168.1.58:8080/",
             super::Cors::verify_origin(
@@ -468,7 +490,7 @@ mod test {
     }
 
     #[test]
-    fn cors_deny_invalid_ip_port_range() {
+    fn cors_deny_invalid_origin_ip_port_range() {
         assert_eq!(
             "https://192.168.1.0:8080/",
             super::Cors::verify_origin(
@@ -526,6 +548,14 @@ mod test {
     )]
     fn cors_port_invalidation() {
         let _: super::Cors = super::Cors::new("http://example.com:abcd");
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "[Cors::new] Ip was misformatted."
+    )]
+    fn cors_ip_subdomain_wildcard_invalidation() {
+        let _: super::Cors = super::Cors::new("https://*.168.1.0:8080");
     }
 
     #[test]

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -182,19 +182,6 @@ impl CorsOriginValue {
 
 }
 
-impl std::fmt::Display for CorsOriginValue {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            CorsOriginValue::CorsOrigin(origin) => {
-                write!(f, "{}", origin)
-            }
-            CorsOriginValue::Any => {
-                write!(f, "*")
-            }
-        }
-    }
-}
-
 /// # Builtin fang for CORS config
 ///
 /// <br>
@@ -219,7 +206,7 @@ impl std::fmt::Display for CorsOriginValue {
 #[derive(Clone, Debug)]
 pub struct Cors {
     /* pub(crate) allow_methods: Option<String>, // owe to `Handler::default_not_found()` */
-    pub(crate) allow_origin: CorsOriginValue,
+    pub(crate) allow_origin_config: CorsOriginValue,
     pub(crate) allow_credentials: bool,
     pub(crate) allow_headers: Option<String>,
     pub(crate) expose_headers: Option<String>,
@@ -231,7 +218,7 @@ impl Cors {
     /// (Both `"*"` and a specific origin are available)
     pub fn new(origin: impl Into<Cow<'static, str>>) -> Self {
         Self {
-            allow_origin: CorsOriginValue::new(origin.into().as_ref())
+            allow_origin_config: CorsOriginValue::new(origin.into().as_ref())
                 .unwrap_or_else(|err| panic!("[Cors::new] {err}")),
             allow_credentials: false,
             allow_headers: None,
@@ -244,7 +231,7 @@ impl Cors {
     /// Creates `Cors` with any origin allowed
     pub const fn any() -> Self {
         Self {
-            allow_origin: CorsOriginValue::Any,
+            allow_origin_config: CorsOriginValue::Any,
             allow_credentials: false,
             allow_headers: None,
             expose_headers: None,
@@ -254,7 +241,7 @@ impl Cors {
 
     pub fn allow_credentials(mut self, yes: bool) -> Self {
         if yes {
-            if self.allow_origin.is_any() {
+            if self.allow_origin_config.is_any() {
                 #[cfg(debug_assertions)]
                 {
                     crate::WARNING!(
@@ -306,14 +293,20 @@ impl<Inner: FangProc> FangProc for CorsProc<Inner> {
         let mut res = self.inner.bite(req).await;
         let incoming_origin = req.headers.origin().and_then(|s| super::Origin::new(s).ok());
         let access_control_allow_origin = match incoming_origin {
-            Some(incoming) if self.cors.allow_origin.matches(&incoming) => incoming.to_string(),
-            _ => self.cors.allow_origin.to_string(),
+            Some(incoming) if self.cors.allow_origin_config.matches(&incoming) => incoming.to_string(),
+            _ => {
+                if let CorsOriginValue::CorsOrigin(cors_origin) = &self.cors.allow_origin_config {
+                    cors_origin.base_origin.to_string()
+                } else {
+                    String::from("*")
+                }
+            },
         };
 
         res.headers
             .set()
             .access_control_allow_origin(access_control_allow_origin)
-            .vary(self.cors.allow_origin.is_any().then_some("Origin".into()))
+            .vary(self.cors.allow_origin_config.is_any().then_some("Origin".into()))
             .access_control_allow_credentials(self.cors.allow_credentials.then_some("true".into()))
             .access_control_expose_headers(
                 self.cors

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -354,8 +354,7 @@ mod test {
 
     #[test]
     fn cors_deny_wildcard_in_origin_ip_subdomain() {
-        assert_eq!(
-            false,
+        assert!(
             AllowOriginConfig::new("https://192.168.1.15:8080").unwrap().allows(
                 &Origin::new("https://*.168.1.15:8080").unwrap()
             )
@@ -364,9 +363,8 @@ mod test {
 
     #[test]
     fn cors_deny_faulty_wildcard_in_origin_ip() {
-        assert_eq!(
-            false,
-            AllowOriginConfig::new("https://192.168.1.15:8080").unwrap().allows(
+        assert!(
+            !AllowOriginConfig::new("https://192.168.1.15:8080").unwrap().allows(
                 &Origin::new("https://192.*.1.15:8080").unwrap()
             )
         )
@@ -374,9 +372,8 @@ mod test {
 
     #[test]
     fn cors_deny_wildcard_in_origin_sld() {
-        assert_eq!(
-            false,
-            AllowOriginConfig::new("https://test.example.com:8080").unwrap().allows(
+        assert!(
+            !AllowOriginConfig::new("https://test.example.com:8080").unwrap().allows(
                 &Origin::new("https://test.*.com:8080").unwrap()
             )
         )

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -38,6 +38,22 @@ impl Display for CorsOriginError {
 
 impl CorsOriginValue {
     /// Parse string based on the Cors origin string syntax.
+    ///
+    /// # Arguments
+    /// * `s`: &str - The string that represents the URI that should be added to the Cors.
+    ///
+    /// returns: Self (CorsOriginValue)
+    ///
+    /// # Examples
+    /// ```rust
+    /// fn run() {
+    ///     CorsOriginValue::new("https://localhost:3000").unwrap(); //Gives CorsOriginValue::Any
+    ///     CorsOriginValue::new("*").unwrap(); //Gives CorsOriginValue::Any
+    /// }
+    /// ```
+    /// # Errors
+    /// This function will return an error if the given URI string fails the validation included in [`Origin`].
+    ///
     fn new(s: &str) -> Result<Self, CorsOriginError> {
         if s == "*" {
             return Ok(Self::Any);
@@ -66,6 +82,22 @@ impl CorsOriginValue {
         Ok(Self::CorsOrigin(CorsOrigin { base_origin, any_port, any_subdomain }) )
     }
 
+    /// Checks if according to the noted rules for wildcards in this struct, the incoming origin would match.
+    ///
+    /// # Arguments
+    ///
+    /// * `incoming_origin`: &str - The origin URI that the stored Cors needs to be compared to.
+    ///
+    /// returns: bool
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// fn run() {
+    ///     let cors = CorsOriginValue::new("*").unwrap();
+    ///     assert_eq!(true, cors.matches_str("localhost:5173")); // true
+    /// }
+    /// ```
     fn matches_str(&self, incoming_origin: &str) -> bool {
         match self {
             CorsOriginValue::CorsOrigin(cors_origin) => {
@@ -115,6 +147,23 @@ impl CorsOriginValue {
         }
     }
 
+    /// Checks if according to the noted rules for wildcards in this struct, the incoming origin would match.
+    ///
+    /// # Arguments
+    ///
+    /// * `incoming_origin`: Origin - The origin that the stored Cors needs to be compared to.
+    ///
+    /// returns: bool
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// fn run() {
+    ///     let cors = CorsOriginValue::new("*").unwrap();
+    ///     let origin = Origin::new("https://localhost:5173").unwrap();
+    ///     assert_eq!(true, cors.matches(origin)); // true
+    /// }
+    /// ```
     #[allow(unused)]
     fn matches(&self, incoming_origin: &super::Origin) -> bool {
         if self.is_any() {
@@ -123,18 +172,11 @@ impl CorsOriginValue {
         self.matches_str(incoming_origin.to_string().as_str())
     }
 
+    /// Returns if this [`CorsOriginValue`] is [`CorsOriginValue::Any`].
     fn is_any(&self) -> bool {
         matches!(self, Self::Any)
     }
 
-    //     #[inline(always)]
-    //     //This will perform expensive copy only if user provided dynamic string
-    //     pub(crate) fn get_cow(&self) -> Cow<'static, str> {
-    //         match self {
-    //             Self::Any => Cow::Borrowed("*"),
-    //             Self::Only(origin) => origin.clone(),
-    //         }
-    //     }
 }
 
 impl Display for CorsOriginValue {
@@ -180,38 +222,6 @@ pub struct Cors {
     pub(crate) expose_headers: Option<String>,
     pub(crate) max_age: Option<u32>,
 }
-
-// #[derive(Clone, Debug)]
-// pub(crate) enum AccessControlAllowOrigin {
-//     Any,
-//     // `.access_control_allow_origin(...)` in the [`bite` impl](CorsProc::bite) requires accepts `Cow<'static, str>` so
-//     // it will be cheap copy if user supplies as with static string ahead of time
-//     Only(Cow<'static, str>),
-// }
-//
-// impl AccessControlAllowOrigin {
-//     #[inline(always)]
-//     pub(crate) const fn is_any(&self) -> bool {
-//         matches!(self, Self::Any)
-//     }
-//
-//     pub(crate) fn new(s: impl Into<Cow<'static, str>>) -> Result<Self, &'static str> {
-//         let s = s.into();
-//         match s.as_ref() {
-//             "*" => Ok(Self::Any),
-//             _ => super::validate_origin(&s).map(|_| Self::Only(s)),
-//         }
-//     }
-//
-//     #[inline(always)]
-//     //This will perform expensive copy only if user provided dynamic string
-//     pub(crate) fn get_cow(&self) -> Cow<'static, str> {
-//         match self {
-//             Self::Any => Cow::Borrowed("*"),
-//             Self::Only(origin) => origin.clone(),
-//         }
-//     }
-// }
 
 impl Cors {
     /// Create `Cors` fang using given `origin` as `Access-Control-Allow-Origin` header value.\
@@ -528,10 +538,9 @@ mod test {
     #[test]
     #[should_panic(expected = "[Cors::new] URI length mustn't exceed 255 characters in total.")]
     fn cors_length_invalidation() {
-        let a: super::Cors = super::Cors::new(
+        let _: super::Cors = super::Cors::new(
             "https://thisisaridiculouslylongurithatshoulddefinitelybeinvalidaccordingtothistest.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
         );
-        println!("{}", a.allow_origin.to_string())
     }
 
     #[test]

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -83,6 +83,7 @@ impl CorsOriginValue {
     ///     assert_eq!(true, cors.matches_str("localhost:5173")); // true
     /// }
     /// ```
+    #[allow(unused)]
     fn matches_str(&self, incoming_origin: &str) -> bool {
         match self {
             CorsOriginValue::CorsOrigin(cors_origin) => {
@@ -99,23 +100,18 @@ impl CorsOriginValue {
                     }
 
                     if let Some(cors_host) = cors_origin.base_origin.host() {
-                        if !cors_origin.any_subdomain {
+                        if !cors_origin.any_subdomain && cors_host != host {
                             // If we do not support any subdomain, we can just fully compare the two, as no additional parsing is necessary.
-                            if cors_host != host {
-                                return false;
-                            }
+                            return false;
                         } else {
                             // Subdomain is a wildcard
                             // If they don't match, check if it's just a subdomain, or something else entirely, meaning it's invalid.
-                            if cors_host != host {
+                            if cors_host != host && host.strip_suffix(cors_host).is_none() {
                                 // Returns None if strip fails, meaning some other unknown stuff was appended to the URI.
-                                if None == host.strip_suffix(cors_host) {
-                                    return false;
-                                }
+                                return false;
                             }
                         }
                     }
-                    // If we do not support any subdomain, we can just fully compare the two, as no additional parsing is necessary.
 
                     // Subdomain, domain and port match, so return true.
                     true
@@ -143,10 +139,40 @@ impl CorsOriginValue {
     /// ```
     #[allow(unused)]
     fn matches(&self, incoming_origin: &super::Origin) -> bool {
-        if self.is_any() {
-            return true;
+        match self {
+            CorsOriginValue::CorsOrigin(cors_origin) => {
+                if cors_origin.base_origin.scheme() == incoming_origin.scheme() {
+                    // If no port wildcard, check if ports align.
+                    if !cors_origin.any_port && cors_origin.base_origin.port() != incoming_origin.port() {
+                        return false;
+                    }
+
+                    if !cors_origin.any_subdomain && cors_origin.base_origin.host() != incoming_origin.host() {
+                        // If we do not support any subdomain, we can just fully compare the two, as no additional parsing is necessary.
+                        return false;
+                    } else {
+                        // If they don't match, check if it's just a subdomain, or something else entirely, meaning it's invalid.
+                        if cors_origin.base_origin.host() != incoming_origin.host() { //Check if the options don't already align
+                            if let (Some(cors_host), Some(host)) = (cors_origin.base_origin.host(), incoming_origin.host()) {
+                                // Returns None if strip fails, meaning some other unknown stuff was appended to the URI.
+                                if host.strip_suffix(cors_host).is_none() {
+                                    return false;
+                                }
+                            }
+                        }
+                    }
+                    // Validations passed
+                    true
+                } else {
+                    // No scheme was found somehow
+                    false
+                }
+            }
+            CorsOriginValue::Any => {
+                // Anything goes
+                true
+            }
         }
-        self.matches_str(incoming_origin.to_string().as_str())
     }
 
     /// Returns if this [`CorsOriginValue`] is [`CorsOriginValue::Any`].
@@ -258,13 +284,6 @@ impl Cors {
         self.max_age = delta_seconds;
         self
     }
-    pub fn verify_origin<'a>(origin: &'a str, cors_origin: &CorsOriginValue) -> Cow<'a, str> {
-        if CorsOriginValue::matches_str(cors_origin, origin) {
-            Cow::Borrowed(origin)
-        } else {
-            Cow::Owned(cors_origin.to_string())
-        }
-    }
 }
 
 impl<Inner: FangProc> Fang<Inner> for Cors {
@@ -285,15 +304,15 @@ pub struct CorsProc<Inner: FangProc> {
 impl<Inner: FangProc> FangProc for CorsProc<Inner> {
     async fn bite<'b>(&'b self, req: &'b mut Request) -> Response {
         let mut res = self.inner.bite(req).await;
-        let allow_origin = Cors::verify_origin(
-            req.headers.origin().unwrap_or(""),
-            &self.cors.allow_origin,
-        )
-        .into_owned();
+        let incoming_origin = req.headers.origin().and_then(|s| super::Origin::new(s).ok());
+        let access_control_allow_origin = match incoming_origin {
+            Some(incoming) if self.cors.allow_origin.matches(&incoming) => incoming.to_string(),
+            _ => self.cors.allow_origin.to_string(),
+        };
 
         res.headers
             .set()
-            .access_control_allow_origin(allow_origin)
+            .access_control_allow_origin(access_control_allow_origin)
             .vary(self.cors.allow_origin.is_any().then_some("Origin".into()))
             .access_control_allow_credentials(self.cors.allow_credentials.then_some("true".into()))
             .access_control_expose_headers(
@@ -332,91 +351,83 @@ impl<Inner: FangProc> FangProc for CorsProc<Inner> {
 mod test {
     #[test]
     fn cors_accept_regular_origin_ip() {
-        assert_eq!(
-            "https://192.168.1.41:5173",
-            super::Cors::verify_origin(
-                "https://192.168.1.41:5173",
-                &super::CorsOriginValue::new("https://192.168.1.41:5173").unwrap()
+        assert!(
+            super::CorsOriginValue::matches(
+                &super::CorsOriginValue::new("https://192.168.1.41:5173").unwrap(),
+                &super::super::Origin::new("https://192.168.1.41:5173").unwrap(),
             )
         )
     }
 
     #[test]
     fn cors_accept_regular_origin_domain() {
-        assert_eq!(
-            "https://example.com",
-            super::Cors::verify_origin(
-                "https://example.com",
-                &super::CorsOriginValue::new("https://example.com").unwrap()
+        assert!(
+            super::CorsOriginValue::matches(
+                &super::CorsOriginValue::new("https://example.com").unwrap(),
+                &super::super::Origin::new("https://example.com").unwrap(),
             )
         );
-        assert_eq!(
-            "https://sub.example.com",
-            super::Cors::verify_origin(
-                "https://sub.example.com",
-                &super::CorsOriginValue::new("https://sub.example.com").unwrap()
+        assert!(
+            super::CorsOriginValue::matches(
+                &super::CorsOriginValue::new("https://sub.example.com").unwrap(),
+                &super::super::Origin::new("https://sub.example.com").unwrap(),
             )
-        )
+        );
     }
 
     #[test]
     fn cors_accept_origin_localhost() {
-        assert_eq!(
-            "https://localhost:5173/",
-            super::Cors::verify_origin(
-                "https://localhost:5173/",
-                &super::CorsOriginValue::new("https://localhost:5173/").unwrap()
+        assert!(
+            super::CorsOriginValue::matches(
+                &super::CorsOriginValue::new("https://localhost:5173/").unwrap(),
+                &super::super::Origin::new("https://localhost:5173/").unwrap(),
             )
         );
-        assert_eq!(
-            "https://localhost:5173",
-            super::Cors::verify_origin(
-                "https://localhost:5173",
-                &super::CorsOriginValue::new("https://localhost:*").unwrap()
+        assert!(
+            super::CorsOriginValue::matches(
+                &super::CorsOriginValue::new("https://localhost:*").unwrap(),
+                &super::super::Origin::new("https://localhost:5173/").unwrap(),
             )
-        )
+        );
     }
 
     #[test]
     fn cors_accept_wildcard_match_in_own_ip_port() {
-        assert_eq!(
-            "https://192.168.1.2:5173",
-            super::Cors::verify_origin(
-                "https://192.168.1.2:5173",
-                &super::CorsOriginValue::new("https://192.168.1.2:*").unwrap()
+        assert!(
+            super::CorsOriginValue::matches(
+                &super::CorsOriginValue::new("https://192.168.1.2:*").unwrap(),
+                &super::super::Origin::new("https://192.168.1.2:5173").unwrap(),
             )
-        )
+        );
     }
 
     #[test]
     fn cors_accept_wildcard_match_in_own_port() {
-        assert_eq!(
-            "https://example.com:5173",
-            super::Cors::verify_origin(
-                "https://example.com:5173",
-                &super::CorsOriginValue::new("https://example.com:*").unwrap()
+        assert!(
+            super::CorsOriginValue::matches(
+                &super::CorsOriginValue::new("https://example.com:*").unwrap(),
+                &super::super::Origin::new("https://example.com:5173").unwrap(),
             )
-        )
+        );
     }
 
     #[test]
     fn cors_accept_wildcard_match_in_own_subdomain() {
-        assert_eq!(
-            "https://test.example.com",
-            super::Cors::verify_origin(
-                "https://test.example.com",
-                &super::CorsOriginValue::new("https://*.example.com").unwrap()
+        assert!(
+            super::CorsOriginValue::matches(
+                &super::CorsOriginValue::new("https://*.example.com").unwrap(),
+                &super::super::Origin::new("https://test.example.com").unwrap(),
             )
-        )
+        );
     }
 
     #[test]
     fn cors_deny_wildcard_in_origin_ip_subdomain() {
         assert_eq!(
-            "https://192.168.1.15:8080/",
-            super::Cors::verify_origin(
-                "https://*.168.1.15:8080",
-                &super::CorsOriginValue::new("https://192.168.1.15:8080").unwrap()
+            false,
+            super::CorsOriginValue::matches(
+                &super::CorsOriginValue::new("https://192.168.1.15:8080").unwrap(),
+                &super::super::Origin::new("https://*.168.1.15:8080").unwrap(),
             )
         )
     }
@@ -424,21 +435,10 @@ mod test {
     #[test]
     fn cors_deny_faulty_wildcard_in_origin_ip() {
         assert_eq!(
-            "https://192.168.1.15:8080/",
-            super::Cors::verify_origin(
-                "https://192.*.1.15:8080",
-                &super::CorsOriginValue::new("https://192.168.1.15:8080").unwrap()
-            )
-        )
-    }
-
-    #[test]
-    fn cors_deny_faulty_wildcard_in_origin_ip_subdomain() {
-        assert_eq!(
-            "https://192.168.1.15:8080/",
-            super::Cors::verify_origin(
-                "https://*.168.1.15:8080",
-                &super::CorsOriginValue::new("https://192.168.1.15:8080").unwrap()
+            false,
+            super::CorsOriginValue::matches(
+                &super::CorsOriginValue::new("https://192.168.1.15:8080").unwrap(),
+                &super::super::Origin::new("https://192.*.1.15:8080").unwrap(),
             )
         )
     }
@@ -446,10 +446,10 @@ mod test {
     #[test]
     fn cors_deny_wildcard_in_origin_sld() {
         assert_eq!(
-            "https://test.example.com:8080/",
-            super::Cors::verify_origin(
-                "https://test.*.com:8080",
-                &super::CorsOriginValue::new("https://test.example.com:8080").unwrap()
+            false,
+            super::CorsOriginValue::matches(
+                &super::CorsOriginValue::new("https://test.example.com:8080").unwrap(),
+                &super::super::Origin::new("https://test.*.com:8080").unwrap(),
             )
         )
     }
@@ -457,10 +457,10 @@ mod test {
     #[test]
     fn cors_deny_wildcard_in_origin_extension() {
         assert_eq!(
-            "https://test.example.com:8080/",
-            super::Cors::verify_origin(
-                "https://test.example.*:8080",
-                &super::CorsOriginValue::new("https://test.example.com:8080").unwrap()
+            false,
+            super::CorsOriginValue::matches(
+                &super::CorsOriginValue::new("https://test.example.com:8080").unwrap(),
+                &super::super::Origin::new("https://test.example.*:8080").unwrap(),
             )
         )
     }
@@ -468,22 +468,20 @@ mod test {
     #[test]
     fn cors_deny_invalid_origin_ip() {
         assert_eq!(
-            "https://192.168.1.58:8080/",
-            super::Cors::verify_origin(
-                "https://192.168.a.58:8080",
-                &super::CorsOriginValue::new("https://192.168.1.58:8080").unwrap()
+            false,
+            super::CorsOriginValue::matches(
+                &super::CorsOriginValue::new("https://192.168.1.58:8080").unwrap(),
+                &super::super::Origin::new("https://192.168.a.58:8080").unwrap(),
             )
         )
     }
 
     #[test]
     fn cors_deny_invalid_origin_ip_port_range() {
+        // Origin:new with a faulty IP should give OriginError::FaultyPort. This error cannot be compared with super::CorsOriginValue::matches(), due to it being an error.
         assert_eq!(
-            "https://192.168.1.0:8080/",
-            super::Cors::verify_origin(
-                "https://192.168.1.0:80080",
-                &super::CorsOriginValue::new("https://192.168.1.0:8080").unwrap()
-            )
+            super::CorsOriginError::InvalidOrigin(super::OriginError::FaultyPort).to_string(),
+            super::super::Origin::new("https://192.168.1.0:80080").unwrap_err().to_string(),
         )
     }
 

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -1,5 +1,4 @@
 use crate::{Fang, FangProc, Request, Response, Status, header::append};
-use core::{clone::Clone, option::Option::Some};
 use std::borrow::Cow;
 use super::{Origin, OriginError};
 
@@ -73,6 +72,16 @@ impl std::fmt::Display for CorsOriginError {
 }
 
 impl AllowOriginConfig {
+    /// Returns a fallback Access-Control-Allow-Origin String of this [`AllowOriginConfig`].
+    fn fallback_access_control_allow_origin(&self) -> String {
+        match &self {
+            AllowOriginConfig::Any => String::from("*"),
+            // `base_origin` itself is always an allowed origin.
+            AllowOriginConfig::CorsOrigin(cors_origin)
+            => cors_origin.base_origin.to_string(),
+        }
+    }
+
     /// Parse string based on the Cors origin string syntax.
     ///
     /// # Examples
@@ -102,8 +111,8 @@ impl AllowOriginConfig {
     ///     assert!(cors.allows(origin)); // true
     /// }
     /// ```
-    #[allow(unused)]
-    fn allows(&self, incoming_origin: &super::Origin) -> bool {
+    ///
+    fn allows(&self, incoming_origin: &Origin) -> bool {
         match self {
             AllowOriginConfig::CorsOrigin(cors_origin) => {
                 if !(cors_origin.base_origin.scheme() == incoming_origin.scheme()) {
@@ -146,16 +155,6 @@ impl AllowOriginConfig {
                 // Anything goes
                 true
             }
-        }
-    }
-
-    /// Returns the fallback access control allow origin String of this [`AllowOriginConfig`].
-    fn fallback_access_control_allow_origin(&self) -> String {
-        match &self {
-            AllowOriginConfig::Any => String::from("*"),
-            // `base_origin` itself is always an allowed origin.
-            AllowOriginConfig::CorsOrigin(cors_origin)
-                => cors_origin.base_origin.to_string(),
         }
     }
 
@@ -275,7 +274,7 @@ pub struct CorsProc<Inner: FangProc> {
 impl<Inner: FangProc> FangProc for CorsProc<Inner> {
     async fn bite<'b>(&'b self, req: &'b mut Request) -> Response {
         let mut res = self.inner.bite(req).await;
-        let incoming_origin = req.headers.origin().and_then(|s| super::Origin::new(s).ok());
+        let incoming_origin = req.headers.origin().and_then(|s| Origin::new(s).ok());
         let access_control_allow_origin = match incoming_origin {
             Some(incoming) if self.cors.allow_origin_config.allows(&incoming) => incoming.to_string(),
             _ => self.cors.allow_origin_config.fallback_access_control_allow_origin(),
@@ -320,6 +319,7 @@ impl<Inner: FangProc> FangProc for CorsProc<Inner> {
 
 #[cfg(test)]
 mod test {
+    use crate::fang::OriginError;
     use super::{AllowOriginConfig, CorsOriginError, Origin};
 
     #[test]
@@ -493,7 +493,7 @@ mod test {
     #[test]
     fn cors_ip_subdomain_wildcard_invalidation() {
         let origin = "https://*.168.1.0:8080";
-        assert_eq!(CorsOriginError::InvalidOrigin(super::OriginError::FaultyIp), AllowOriginConfig::new(origin).unwrap_err())
+        assert_eq!(CorsOriginError::InvalidOrigin(OriginError::FaultyIp), AllowOriginConfig::new(origin).unwrap_err())
     }
 
     #[test]

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -129,21 +129,20 @@ impl AllowOriginConfig {
                 }
 
                 if cors_origin.base_origin.host() != incoming_origin.host() { //Check if the options don't already align
-                    if let (Some(cors_host), Some(host)) = (cors_origin.base_origin.host(), incoming_origin.host()) {
-                        if !host.ends_with(&cors_host) {
-                            return false;
-                        }
+                    if !incoming_origin.host().ends_with(&cors_origin.base_origin.host()) {
+                        return false;
+                    }
 
-                        if host != cors_host && let Some(rest) = host.strip_suffix(cors_host) {
-                            if !rest.contains('.') {
-                                return false; // Deny wrong domain
-                            }
-                            if !cors_origin.any_subdomain {
-                                return false; // Deny prepended subdomain while none are allowed.
-                            }
-                            if rest.contains("..") || rest.split('.').filter(|s| s != &"").count() >= 2 {
-                                return false; // Deny if not a direct subdomain
-                            }
+                    if incoming_origin.host() != cors_origin.base_origin.host()
+                        && let Some(rest) = incoming_origin.host().strip_suffix(cors_origin.base_origin.host()) {
+                        if !rest.contains('.') {
+                            return false; // Deny wrong domain
+                        }
+                        if !cors_origin.any_subdomain {
+                            return false; // Deny prepended subdomain while none are allowed.
+                        }
+                        if rest.contains("..") || rest.split('.').filter(|s| s != &"").count() >= 2 {
+                            return false; // Deny if not a direct subdomain
                         }
                     }
                 }

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -120,7 +120,6 @@ impl AllowOriginConfig {
                     } else {
                         if cors_origin.base_origin.host() != incoming_origin.host() { //Check if the options don't already align
                             if let (Some(cors_host), Some(host)) = (cors_origin.base_origin.host(), incoming_origin.host()) {
-                                // Returns None if host doesn't start with cors_host, meaning some other unknown stuff was appended to the URI.
                                 if !host.ends_with(&cors_host) {
                                     return false;
                                 } else if host != cors_host && let Some(rest) = host.strip_suffix(cors_host) {

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -59,7 +59,7 @@ impl CorsOrigin {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum CorsOriginError {
     InvalidOrigin(OriginError)
 }
@@ -424,8 +424,8 @@ mod test {
     fn cors_deny_invalid_origin_ip_port_range() {
         // Origin:new with a faulty IP should give OriginError::FaultyPort. This error cannot be compared with super::CorsOriginValue::matches(), due to it being an error.
         assert_eq!(
-            CorsOriginError::InvalidOrigin(super::OriginError::FaultyPort).to_string(),
-            Origin::new("https://192.168.1.0:80080").unwrap_err().to_string(),
+            super::OriginError::FaultyPort,
+            Origin::new("https://192.168.1.0:80080").unwrap_err(),
         )
     }
 
@@ -449,31 +449,31 @@ mod test {
     #[test]
     fn cors_scheme_invalidation() {
         let origin = "foobarhttp://example.com";
-        assert_eq!(CorsOriginError::InvalidOrigin(super::OriginError::FaultyScheme).to_string(), super::AllowOriginConfig::new(origin).unwrap_err().to_string())
+        assert_eq!(super::OriginError::FaultyScheme, Origin::new(origin).unwrap_err())
     }
 
     #[test]
     fn cors_length_invalidation() {
         let origin = "https://thisisaridiculouslylongurithatshoulddefinitelybeinvalidaccordingtothistest.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com";
-        assert_eq!(CorsOriginError::InvalidOrigin(super::OriginError::FaultyUriLength).to_string(), super::AllowOriginConfig::new(origin).unwrap_err().to_string())
+        assert_eq!(super::OriginError::FaultyUriLength, Origin::new(origin).unwrap_err())
     }
 
     #[test]
     fn cors_part_length_invalidation() {
         let origin = "https://www.abcdefghijklmnopqrstuvwxyzabcdefghijklmnoqrstuvwxyzabcdefghijklmnopqrstuvwxyz.com";
-        assert_eq!(CorsOriginError::InvalidOrigin(super::OriginError::FaultyUriPartLength).to_string(), super::AllowOriginConfig::new(origin).unwrap_err().to_string())
+        assert_eq!(super::OriginError::FaultyUriPartLength, Origin::new(origin).unwrap_err())
     }
 
     #[test]
     fn cors_port_invalidation() {
         let origin = "http://example.com:abcd";
-        assert_eq!(CorsOriginError::InvalidOrigin(super::OriginError::FaultyPort).to_string(), super::AllowOriginConfig::new(origin).unwrap_err().to_string())
+        assert_eq!(super::OriginError::FaultyPort, Origin::new(origin).unwrap_err())
     }
 
     #[test]
     fn cors_ip_subdomain_wildcard_invalidation() {
         let origin = "https://*.168.1.0:8080";
-        assert_eq!(CorsOriginError::InvalidOrigin(super::OriginError::FaultyIp).to_string(), super::AllowOriginConfig::new(origin).unwrap_err().to_string())
+        assert_eq!(CorsOriginError::InvalidOrigin(super::OriginError::FaultyIp), AllowOriginConfig::new(origin).unwrap_err())
     }
 
     #[test]

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -1,25 +1,41 @@
 use crate::{Fang, FangProc, Request, Response, Status, header::append};
-use core::option::Option::Some;
 use std::borrow::Cow;
-
+use std::fmt::{Display, Formatter};
 use super::OriginError;
 
 // cors.rs
-
 /* This replaces current `AccessControlAllowOrigin` */
+#[derive(Clone, Debug)]
+enum CorsOriginValue {
+    CorsOrigin(CorsOrigin),
+    Any
+}
+
+#[derive(Clone, Debug)]
 struct CorsOrigin {
     base_origin: super::Origin,
     any_port: bool,
     any_subdomain: bool,
 }
 
+#[derive(Debug)]
 enum CorsOriginError {
     InvalidOrigin(OriginError)
 }
 
-impl CorsOrigin {
+impl Display for CorsOriginError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl CorsOriginValue {
     /// Parse string based on the Cors origin string syntax.
     fn new(s: &str) -> Result<Self, CorsOriginError> {
+        if s == "*" {
+            return Ok(Self::Any);
+        }
+
         let mut any_port = false;
         let mut any_subdomain = false;
         let mut s = match s.strip_suffix(":*") {
@@ -40,48 +56,73 @@ impl CorsOrigin {
         let base_origin = super::Origin::new(&s)
             .map_err(CorsOriginError::InvalidOrigin)?;
 
-        Ok(Self { base_origin, any_port, any_subdomain })
+        Ok(Self::CorsOrigin(CorsOrigin { base_origin, any_port, any_subdomain }) )
     }
 
     fn matches_str(&self, incoming_origin: &str) -> bool {
-        if let Some(("http://" | "https://", origin)) = incoming_origin.split_once("://") {
-            let (host, port) = origin
-                .split_once(':')
-                .map_or((origin, None), |(h, p)| (h, Some(p)));
+        match self {
+            CorsOriginValue::CorsOrigin(cors_origin) => {
+                if let Some(("http://" | "https://", origin)) = incoming_origin.split_once("://") {
+                    let (host, port) = origin
+                        .split_once(':')
+                        .map_or((origin, None), |(h, p)| (h, Some(p)));
 
-            // Check port if not wildcard, validate
-            if !self.any_port
-                && let Some(cors_port) = self.base_origin.port()
-                && Some(format!("{}", cors_port).as_str()) != port {
+                    // Check port if not wildcard, validate
+                    if !cors_origin.any_port
+                        && let Some(cors_port) = cors_origin.base_origin.port()
+                        && Some(format!("{}", cors_port).as_str()) != port {
 
-                return false;
+                        return false;
+                    }
+
+                    let (cors_subdomain, cors_domain) = cors_origin.base_origin.host_as_tuple();
+                    let (subdomain, domain) = host
+                        .split_once('.')
+                        .map_or((None, origin), |(s, d)| (Some(s), d));
+
+                    // If subdomain is not a wildcard, validate
+                    if !cors_origin.any_subdomain && cors_subdomain != subdomain {
+                        return false;
+                    }
+
+                    // Check if domain matches.
+                    if domain != cors_domain {
+                        return false;
+                    }
+
+                    true
+                } else {
+                    // No scheme was somehow found
+                    false
+                }
+
             }
-
-            let (cors_subdomain, cors_domain) = self.base_origin.host_as_tuple();
-            let (subdomain, domain) = host
-                .split_once('.')
-                .map_or((None, origin), |(s, d)| (Some(s), d));
-
-            // If subdomain is not a wildcard, validate
-            if !self.any_subdomain && cors_subdomain != subdomain {
-                return false;
+            CorsOriginValue::Any => {
+                // Anything goes
+                true
             }
-
-            // Check if domain matches.
-            if domain != cors_domain {
-                return false;
-            }
-
-            true
-        } else {
-            // No scheme was somehow found
-            false
         }
     }
 
     fn matches(&self, incoming_origin: &super::Origin) -> bool {
+        if self.is_any() {
+            return true;
+        }
         self.matches_str(incoming_origin.to_string().as_str())
     }
+
+    fn is_any(&self) -> bool {
+        matches!(self, Self::Any)
+    }
+
+    //     #[inline(always)]
+    //     //This will perform expensive copy only if user provided dynamic string
+    //     pub(crate) fn get_cow(&self) -> Cow<'static, str> {
+    //         match self {
+    //             Self::Any => Cow::Borrowed("*"),
+    //             Self::Only(origin) => origin.clone(),
+    //         }
+    //     }
 }
 
 /// # Builtin fang for CORS config
@@ -108,51 +149,51 @@ impl CorsOrigin {
 #[derive(Clone, Debug)]
 pub struct Cors {
     /* pub(crate) allow_methods: Option<String>, // owe to `Handler::default_not_found()` */
-    pub(crate) allow_origin: AccessControlAllowOrigin,
+    pub(crate) allow_origin: CorsOriginValue,
     pub(crate) allow_credentials: bool,
     pub(crate) allow_headers: Option<String>,
     pub(crate) expose_headers: Option<String>,
     pub(crate) max_age: Option<u32>,
 }
 
-#[derive(Clone, Debug)]
-pub(crate) enum AccessControlAllowOrigin {
-    Any,
-    // `.access_control_allow_origin(...)` in the [`bite` impl](CorsProc::bite) requires accepts `Cow<'static, str>` so
-    // it will be cheap copy if user supplies as with static string ahead of time
-    Only(Cow<'static, str>),
-}
-
-impl AccessControlAllowOrigin {
-    #[inline(always)]
-    pub(crate) const fn is_any(&self) -> bool {
-        matches!(self, Self::Any)
-    }
-
-    pub(crate) fn new(s: impl Into<Cow<'static, str>>) -> Result<Self, &'static str> {
-        let s = s.into();
-        match s.as_ref() {
-            "*" => Ok(Self::Any),
-            _ => super::validate_origin(&s).map(|_| Self::Only(s)),
-        }
-    }
-
-    #[inline(always)]
-    //This will perform expensive copy only if user provided dynamic string
-    pub(crate) fn get_cow(&self) -> Cow<'static, str> {
-        match self {
-            Self::Any => Cow::Borrowed("*"),
-            Self::Only(origin) => origin.clone(),
-        }
-    }
-}
+// #[derive(Clone, Debug)]
+// pub(crate) enum AccessControlAllowOrigin {
+//     Any,
+//     // `.access_control_allow_origin(...)` in the [`bite` impl](CorsProc::bite) requires accepts `Cow<'static, str>` so
+//     // it will be cheap copy if user supplies as with static string ahead of time
+//     Only(Cow<'static, str>),
+// }
+//
+// impl AccessControlAllowOrigin {
+//     #[inline(always)]
+//     pub(crate) const fn is_any(&self) -> bool {
+//         matches!(self, Self::Any)
+//     }
+//
+//     pub(crate) fn new(s: impl Into<Cow<'static, str>>) -> Result<Self, &'static str> {
+//         let s = s.into();
+//         match s.as_ref() {
+//             "*" => Ok(Self::Any),
+//             _ => super::validate_origin(&s).map(|_| Self::Only(s)),
+//         }
+//     }
+//
+//     #[inline(always)]
+//     //This will perform expensive copy only if user provided dynamic string
+//     pub(crate) fn get_cow(&self) -> Cow<'static, str> {
+//         match self {
+//             Self::Any => Cow::Borrowed("*"),
+//             Self::Only(origin) => origin.clone(),
+//         }
+//     }
+// }
 
 impl Cors {
     /// Create `Cors` fang using given `origin` as `Access-Control-Allow-Origin` header value.\
     /// (Both `"*"` and a specific origin are available)
     pub fn new(origin: impl Into<Cow<'static, str>>) -> Self {
         Self {
-            allow_origin: AccessControlAllowOrigin::new(origin)
+            allow_origin: CorsOriginValue::new(origin.into().as_ref())
                 .unwrap_or_else(|err| panic!("[Cors::new] {err}")),
             allow_credentials: false,
             allow_headers: None,
@@ -165,7 +206,7 @@ impl Cors {
     /// Creates `Cors` with any origin allowed
     pub const fn any() -> Self {
         Self {
-            allow_origin: AccessControlAllowOrigin::Any,
+            allow_origin: CorsOriginValue::Any,
             allow_credentials: false,
             allow_headers: None,
             expose_headers: None,

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -1,6 +1,6 @@
 use crate::{Fang, FangProc, Request, Response, Status, header::append};
 use std::borrow::Cow;
-use super::OriginError;
+use super::{Origin, OriginError};
 
 #[derive(Clone, Debug)]
 pub enum AllowOriginConfig {
@@ -10,15 +10,9 @@ pub enum AllowOriginConfig {
 
 #[derive(Clone, Debug)]
 pub struct CorsOrigin {
-    base_origin: super::Origin,
+    base_origin: Origin,
     any_port: bool,
     any_subdomain: bool,
-}
-
-impl std::fmt::Display for CorsOrigin {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.base_origin)
-    }
 }
 
 #[derive(Debug)]
@@ -39,8 +33,8 @@ impl AllowOriginConfig {
     /// # Examples
     /// ```rust
     /// fn run() {
-    ///     CorsOriginValue::new("https://localhost:3000").unwrap(); //Gives CorsOriginValue::CorsOrigin
-    ///     CorsOriginValue::new("*").unwrap(); //Gives CorsOriginValue::Any
+    ///     AllowOriginConfig::new("https://localhost:3000").unwrap(); //Gives AllowOriginConfig::CorsOrigin
+    ///     AllowOriginConfig::new("*").unwrap(); //Gives AllowOriginConfig::Any
     /// }
     /// ```
     /// # Errors
@@ -68,7 +62,7 @@ impl AllowOriginConfig {
             s = Cow::Owned(scheme.to_string() + rest);
         }
 
-        let base_origin = super::Origin::new(&s)
+        let base_origin = Origin::new(&s)
             .map_err(CorsOriginError::InvalidOrigin)?;
 
         Ok(Self::CorsOrigin(CorsOrigin { base_origin, any_port, any_subdomain }) )
@@ -79,69 +73,18 @@ impl AllowOriginConfig {
     /// # Examples
     /// ```
     /// fn run() {
-    ///     let cors = CorsOriginValue::new("*").unwrap();
-    ///     assert_eq!(true, cors.matches_str("localhost:5173")); // true
-    /// }
-    /// ```
-    #[allow(unused)]
-    fn allows_str(&self, incoming_origin: &str) -> bool {
-        match self {
-            AllowOriginConfig::CorsOrigin(cors_origin) => {
-                if let Some(("http" | "https" , origin)) = incoming_origin.split_once("://") {
-                    let (host, port) = origin
-                        .split_once(':')
-                        .map_or((origin, None), |(h, p)| (h, Some(p)));
-
-                    // Check port if not wildcard, validate
-                    if !cors_origin.any_port
-                        && let Some(cors_port) = cors_origin.base_origin.port()
-                        && Some(format!("{}", cors_port).as_str()) != port {
-                        return false;
-                    }
-
-                    if let Some(cors_host) = cors_origin.base_origin.host() {
-                        if !cors_origin.any_subdomain && cors_host != host {
-                            // If we do not support any subdomain, we can just fully compare the two, as no additional parsing is necessary.
-                            return false;
-                        } else {
-                            // Subdomain is a wildcard
-                            // If they don't match, check if it's just a subdomain, or something else entirely, meaning it's invalid.
-                            if cors_host != host && host.strip_suffix(cors_host).is_none() {
-                                // Returns None if strip fails, meaning some other unknown stuff was appended to the URI.
-                                return false;
-                            }
-                        }
-                    }
-
-                    // Subdomain, domain and port match, so return true.
-                    true
-                } else {
-                    // No scheme was somehow found
-                    false
-                }
-            }
-            AllowOriginConfig::Any => {
-                // Anything goes
-                true
-            }
-        }
-    }
-
-    /// Checks if according to the noted rules for wildcards in this struct, the incoming origin would match.
-    ///
-    /// # Examples
-    /// ```
-    /// fn run() {
-    ///     let cors = CorsOriginValue::new("*").unwrap();
+    ///     let cors = AllowOriginConfig::new("*").unwrap();
     ///     let origin = Origin::new("https://localhost:5173").unwrap();
-    ///     assert_eq!(true, cors.matches(origin)); // true
+    ///     assert!(cors.allows(origin)); // true
     /// }
     /// ```
     #[allow(unused)]
     fn allows(&self, incoming_origin: &super::Origin) -> bool {
         match self {
             AllowOriginConfig::CorsOrigin(cors_origin) => {
-                if cors_origin.base_origin.scheme() == incoming_origin.scheme() {
+                if !(cors_origin.base_origin.scheme() == incoming_origin.scheme()) {
+                    false
+                } else {
                     // If no port wildcard, check if ports align.
                     if !cors_origin.any_port && cors_origin.base_origin.port() != incoming_origin.port() {
                         return false;
@@ -154,8 +97,8 @@ impl AllowOriginConfig {
                         // If they don't match, check if it's just a subdomain, or something else entirely, meaning it's invalid.
                         if cors_origin.base_origin.host() != incoming_origin.host() { //Check if the options don't already align
                             if let (Some(cors_host), Some(host)) = (cors_origin.base_origin.host(), incoming_origin.host()) {
-                                // Returns None if strip fails, meaning some other unknown stuff was appended to the URI.
-                                if host.strip_suffix(cors_host).is_none() {
+                                // Returns None if host doesn't start with cors_host, meaning some other unknown stuff was appended to the URI.
+                                if !host.ends_with(cors_host) {
                                     return false;
                                 }
                             }
@@ -163,9 +106,6 @@ impl AllowOriginConfig {
                     }
                     // Validations passed
                     true
-                } else {
-                    // No scheme was found somehow
-                    false
                 }
             }
             AllowOriginConfig::Any => {
@@ -346,12 +286,13 @@ impl<Inner: FangProc> FangProc for CorsProc<Inner> {
 
 #[cfg(test)]
 mod test {
+    use super::{AllowOriginConfig, CorsOriginError, Origin};
+
     #[test]
     fn cors_accept_regular_origin_ip() {
         assert!(
-            super::AllowOriginConfig::allows(
-                &super::AllowOriginConfig::new("https://192.168.1.41:5173").unwrap(),
-                &super::super::Origin::new("https://192.168.1.41:5173").unwrap(),
+            AllowOriginConfig::new("https://192.168.1.41:5173").unwrap().allows(
+                &Origin::new("https://192.168.1.41:5173").unwrap()
             )
         )
     }
@@ -359,15 +300,13 @@ mod test {
     #[test]
     fn cors_accept_regular_origin_domain() {
         assert!(
-            super::AllowOriginConfig::allows(
-                &super::AllowOriginConfig::new("https://example.com").unwrap(),
-                &super::super::Origin::new("https://example.com").unwrap(),
+            AllowOriginConfig::new("https://example.com").unwrap().allows(
+                &Origin::new("https://example.com").unwrap()
             )
         );
         assert!(
-            super::AllowOriginConfig::allows(
-                &super::AllowOriginConfig::new("https://sub.example.com").unwrap(),
-                &super::super::Origin::new("https://sub.example.com").unwrap(),
+            AllowOriginConfig::new("https://sub.example.com").unwrap().allows(
+                &Origin::new("https://sub.example.com").unwrap()
             )
         );
     }
@@ -375,15 +314,13 @@ mod test {
     #[test]
     fn cors_accept_origin_localhost() {
         assert!(
-            super::AllowOriginConfig::allows(
-                &super::AllowOriginConfig::new("https://localhost:5173/").unwrap(),
-                &super::super::Origin::new("https://localhost:5173/").unwrap(),
+            AllowOriginConfig::new("https://localhost:5173/").unwrap().allows(
+                &Origin::new("https://localhost:5173/").unwrap()
             )
         );
         assert!(
-            super::AllowOriginConfig::allows(
-                &super::AllowOriginConfig::new("https://localhost:*").unwrap(),
-                &super::super::Origin::new("https://localhost:5173/").unwrap(),
+            AllowOriginConfig::new("https://localhost:*").unwrap().allows(
+                &Origin::new("https://localhost:5173/").unwrap()
             )
         );
     }
@@ -391,9 +328,8 @@ mod test {
     #[test]
     fn cors_accept_wildcard_match_in_own_ip_port() {
         assert!(
-            super::AllowOriginConfig::allows(
-                &super::AllowOriginConfig::new("https://192.168.1.2:*").unwrap(),
-                &super::super::Origin::new("https://192.168.1.2:5173").unwrap(),
+            AllowOriginConfig::new("https://192.168.1.2:*").unwrap().allows(
+                &Origin::new("https://192.168.1.2:5173").unwrap()
             )
         );
     }
@@ -401,9 +337,8 @@ mod test {
     #[test]
     fn cors_accept_wildcard_match_in_own_port() {
         assert!(
-            super::AllowOriginConfig::allows(
-                &super::AllowOriginConfig::new("https://example.com:*").unwrap(),
-                &super::super::Origin::new("https://example.com:5173").unwrap(),
+            AllowOriginConfig::new("https://example.com:*").unwrap().allows(
+                &Origin::new("https://example.com:5173").unwrap()
             )
         );
     }
@@ -411,9 +346,8 @@ mod test {
     #[test]
     fn cors_accept_wildcard_match_in_own_subdomain() {
         assert!(
-            super::AllowOriginConfig::allows(
-                &super::AllowOriginConfig::new("https://*.example.com").unwrap(),
-                &super::super::Origin::new("https://test.example.com").unwrap(),
+            AllowOriginConfig::new("https://*.example.com").unwrap().allows(
+                &Origin::new("https://test.example.com").unwrap()
             )
         );
     }
@@ -422,9 +356,8 @@ mod test {
     fn cors_deny_wildcard_in_origin_ip_subdomain() {
         assert_eq!(
             false,
-            super::AllowOriginConfig::allows(
-                &super::AllowOriginConfig::new("https://192.168.1.15:8080").unwrap(),
-                &super::super::Origin::new("https://*.168.1.15:8080").unwrap(),
+            AllowOriginConfig::new("https://192.168.1.15:8080").unwrap().allows(
+                &Origin::new("https://*.168.1.15:8080").unwrap()
             )
         )
     }
@@ -433,9 +366,8 @@ mod test {
     fn cors_deny_faulty_wildcard_in_origin_ip() {
         assert_eq!(
             false,
-            super::AllowOriginConfig::allows(
-                &super::AllowOriginConfig::new("https://192.168.1.15:8080").unwrap(),
-                &super::super::Origin::new("https://192.*.1.15:8080").unwrap(),
+            AllowOriginConfig::new("https://192.168.1.15:8080").unwrap().allows(
+                &Origin::new("https://192.*.1.15:8080").unwrap()
             )
         )
     }
@@ -444,31 +376,26 @@ mod test {
     fn cors_deny_wildcard_in_origin_sld() {
         assert_eq!(
             false,
-            super::AllowOriginConfig::allows(
-                &super::AllowOriginConfig::new("https://test.example.com:8080").unwrap(),
-                &super::super::Origin::new("https://test.*.com:8080").unwrap(),
+            AllowOriginConfig::new("https://test.example.com:8080").unwrap().allows(
+                &Origin::new("https://test.*.com:8080").unwrap()
             )
         )
     }
 
     #[test]
     fn cors_deny_wildcard_in_origin_extension() {
-        assert_eq!(
-            false,
-            super::AllowOriginConfig::allows(
-                &super::AllowOriginConfig::new("https://test.example.com:8080").unwrap(),
-                &super::super::Origin::new("https://test.example.*:8080").unwrap(),
+        assert!(
+            !AllowOriginConfig::new("https://test.example.com:8080").unwrap().allows(
+                &Origin::new("https://test.example.*:8080").unwrap()
             )
         )
     }
 
     #[test]
     fn cors_deny_invalid_origin_ip() {
-        assert_eq!(
-            false,
-            super::AllowOriginConfig::allows(
-                &super::AllowOriginConfig::new("https://192.168.1.58:8080").unwrap(),
-                &super::super::Origin::new("https://192.168.a.58:8080").unwrap(),
+        assert!(
+            !AllowOriginConfig::new("https://192.168.1.58:8080").unwrap().allows(
+                &Origin::new("https://192.168.a.58:8080").unwrap()
             )
         )
     }
@@ -477,8 +404,8 @@ mod test {
     fn cors_deny_invalid_origin_ip_port_range() {
         // Origin:new with a faulty IP should give OriginError::FaultyPort. This error cannot be compared with super::CorsOriginValue::matches(), due to it being an error.
         assert_eq!(
-            super::CorsOriginError::InvalidOrigin(super::OriginError::FaultyPort).to_string(),
-            super::super::Origin::new("https://192.168.1.0:80080").unwrap_err().to_string(),
+            CorsOriginError::InvalidOrigin(super::OriginError::FaultyPort).to_string(),
+            Origin::new("https://192.168.1.0:80080").unwrap_err().to_string(),
         )
     }
 
@@ -502,31 +429,31 @@ mod test {
     #[test]
     fn cors_scheme_invalidation() {
         let origin = "foobarhttp://example.com";
-        assert_eq!(super::CorsOriginError::InvalidOrigin(super::OriginError::FaultyScheme).to_string(), super::AllowOriginConfig::new(origin).unwrap_err().to_string())
+        assert_eq!(CorsOriginError::InvalidOrigin(super::OriginError::FaultyScheme).to_string(), super::AllowOriginConfig::new(origin).unwrap_err().to_string())
     }
 
     #[test]
     fn cors_length_invalidation() {
         let origin = "https://thisisaridiculouslylongurithatshoulddefinitelybeinvalidaccordingtothistest.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com";
-        assert_eq!(super::CorsOriginError::InvalidOrigin(super::OriginError::FaultyUriLength).to_string(), super::AllowOriginConfig::new(origin).unwrap_err().to_string())
+        assert_eq!(CorsOriginError::InvalidOrigin(super::OriginError::FaultyUriLength).to_string(), super::AllowOriginConfig::new(origin).unwrap_err().to_string())
     }
 
     #[test]
     fn cors_part_length_invalidation() {
         let origin = "https://www.abcdefghijklmnopqrstuvwxyzabcdefghijklmnoqrstuvwxyzabcdefghijklmnopqrstuvwxyz.com";
-        assert_eq!(super::CorsOriginError::InvalidOrigin(super::OriginError::FaultyUriPartLength).to_string(), super::AllowOriginConfig::new(origin).unwrap_err().to_string())
+        assert_eq!(CorsOriginError::InvalidOrigin(super::OriginError::FaultyUriPartLength).to_string(), super::AllowOriginConfig::new(origin).unwrap_err().to_string())
     }
 
     #[test]
     fn cors_port_invalidation() {
         let origin = "http://example.com:abcd";
-        assert_eq!(super::CorsOriginError::InvalidOrigin(super::OriginError::FaultyPort).to_string(), super::AllowOriginConfig::new(origin).unwrap_err().to_string())
+        assert_eq!(CorsOriginError::InvalidOrigin(super::OriginError::FaultyPort).to_string(), super::AllowOriginConfig::new(origin).unwrap_err().to_string())
     }
 
     #[test]
     fn cors_ip_subdomain_wildcard_invalidation() {
         let origin = "https://*.168.1.0:8080";
-        assert_eq!(super::CorsOriginError::InvalidOrigin(super::OriginError::FaultyIp).to_string(), super::AllowOriginConfig::new(origin).unwrap_err().to_string())
+        assert_eq!(CorsOriginError::InvalidOrigin(super::OriginError::FaultyIp).to_string(), super::AllowOriginConfig::new(origin).unwrap_err().to_string())
     }
 
     #[test]

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -421,15 +421,6 @@ mod test {
     }
 
     #[test]
-    fn cors_deny_invalid_origin_ip_port_range() {
-        // Origin:new with a faulty IP should give OriginError::FaultyPort. This error cannot be compared with super::CorsOriginValue::matches(), due to it being an error.
-        assert_eq!(
-            super::OriginError::FaultyPort,
-            Origin::new("https://192.168.1.0:80080").unwrap_err(),
-        )
-    }
-
-    #[test]
     fn cors_new_with_str_or_string() {
         let _: super::Cors = super::Cors::new("https://example.com");
         let _: super::Cors = super::Cors::new(String::from("https://") + "example.com");
@@ -447,41 +438,9 @@ mod test {
     }
 
     #[test]
-    fn cors_scheme_invalidation() {
-        let origin = "foobarhttp://example.com";
-        assert_eq!(super::OriginError::FaultyScheme, Origin::new(origin).unwrap_err())
-    }
-
-    #[test]
-    fn cors_length_invalidation() {
-        let origin = "https://thisisaridiculouslylongurithatshoulddefinitelybeinvalidaccordingtothistest.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com";
-        assert_eq!(super::OriginError::FaultyUriLength, Origin::new(origin).unwrap_err())
-    }
-
-    #[test]
-    fn cors_part_length_invalidation() {
-        let origin = "https://www.abcdefghijklmnopqrstuvwxyzabcdefghijklmnoqrstuvwxyzabcdefghijklmnopqrstuvwxyz.com";
-        assert_eq!(super::OriginError::FaultyUriPartLength, Origin::new(origin).unwrap_err())
-    }
-
-    #[test]
-    fn cors_port_invalidation() {
-        let origin = "http://example.com:abcd";
-        assert_eq!(super::OriginError::FaultyPort, Origin::new(origin).unwrap_err())
-    }
-
-    #[test]
     fn cors_ip_subdomain_wildcard_invalidation() {
         let origin = "https://*.168.1.0:8080";
         assert_eq!(CorsOriginError::InvalidOrigin(super::OriginError::FaultyIp), AllowOriginConfig::new(origin).unwrap_err())
-    }
-
-    #[test]
-    #[should_panic(
-        expected = "[Cors::new] Invalid URI."
-    )]
-    fn cors_host_invalidation() {
-        let _: super::Cors = super::Cors::new("http://%example.com");
     }
 
     #[test]

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -341,7 +341,7 @@ mod test {
     #[test]
     fn cors_accept_regular_ip() {
         assert_eq!(
-            "https://192.168.1.41:5173",
+            "https://192.168.1.41:5173/",
             super::Cors::verify_origin(
                 "https://192.168.1.41:5173",
                 &super::CorsOriginValue::new("https://192.168.1.41:5173").unwrap()
@@ -352,14 +352,14 @@ mod test {
     #[test]
     fn cors_accept_regular_domain() {
         assert_eq!(
-            "https://example.com",
+            "https://example.com/",
             super::Cors::verify_origin(
                 "https://example.com",
                 &super::CorsOriginValue::new("https://example.com").unwrap()
             )
         );
         assert_eq!(
-            "https://sub.example.com",
+            "https://sub.example.com/",
             super::Cors::verify_origin(
                 "https://sub.example.com",
                 &super::CorsOriginValue::new("https://sub.example.com").unwrap()
@@ -370,14 +370,14 @@ mod test {
     #[test]
     fn cors_accept_localhost() {
         assert_eq!(
-            "https://localhost:5173",
+            "https://localhost:5173/",
             super::Cors::verify_origin(
                 "https://localhost:5173",
                 &super::CorsOriginValue::new("https://localhost:5173").unwrap()
             )
         );
         assert_eq!(
-            "https://localhost:5173",
+            "https://localhost:5173/",
             super::Cors::verify_origin(
                 "https://localhost:5173",
                 &super::CorsOriginValue::new("https://localhost:*").unwrap()
@@ -388,7 +388,7 @@ mod test {
     #[test]
     fn cors_accept_wildcard_in_ip_port() {
         assert_eq!(
-            "https://192.168.1.2:5173",
+            "https://192.168.1.2:5173/",
             super::Cors::verify_origin(
                 "https://192.168.1.2:5173",
                 &super::CorsOriginValue::new("https://192.168.1.2:*").unwrap()
@@ -399,7 +399,7 @@ mod test {
     #[test]
     fn cors_accept_wildcard_in_port() {
         assert_eq!(
-            "https://example.com:5173",
+            "https://example.com:5173/",
             super::Cors::verify_origin(
                 "https://example.com:5173",
                 &super::CorsOriginValue::new("https://example.com:*").unwrap()
@@ -410,7 +410,7 @@ mod test {
     #[test]
     fn cors_accept_wildcard_in_subdomain() {
         assert_eq!(
-            "https://test.example.com",
+            "https://test.example.com/",
             super::Cors::verify_origin(
                 "https://test.example.com",
                 &super::CorsOriginValue::new("https://*.example.com").unwrap()
@@ -421,7 +421,7 @@ mod test {
     #[test]
     fn cors_deny_wildcard_in_ip_subdomain() {
         assert_eq!(
-            "https://192.168.1.15:8080",
+            "https://192.168.1.15:8080/",
             super::Cors::verify_origin(
                 "https://192.*.1.15:8080",
                 &super::CorsOriginValue::new("https://192.168.1.15:8080").unwrap()
@@ -432,7 +432,7 @@ mod test {
     #[test]
     fn cors_deny_wildcard_in_sld() {
         assert_eq!(
-            "https://test.example.com:8080",
+            "https://test.example.com:8080/",
             super::Cors::verify_origin(
                 "https://test.*.com:8080",
                 &super::CorsOriginValue::new("https://test.example.com:8080").unwrap()
@@ -443,7 +443,7 @@ mod test {
     #[test]
     fn cors_deny_wildcard_in_extension() {
         assert_eq!(
-            "https://test.example.com:8080",
+            "https://test.example.com:8080/",
             super::Cors::verify_origin(
                 "https://test.example.*:8080",
                 &super::CorsOriginValue::new("https://test.example.com:8080").unwrap()
@@ -454,7 +454,7 @@ mod test {
     #[test]
     fn cors_deny_invalid_ip() {
         assert_eq!(
-            "https://192.168.1.58:8080",
+            "https://192.168.1.58:8080/",
             super::Cors::verify_origin(
                 "https://192.168.a.58:8080",
                 &super::CorsOriginValue::new("https://192.168.1.58:8080").unwrap()
@@ -465,7 +465,7 @@ mod test {
     #[test]
     fn cors_deny_invalid_ip_port_range() {
         assert_eq!(
-            "https://192.168.1.0:8080",
+            "https://192.168.1.0:8080/",
             super::Cors::verify_origin(
                 "https://192.168.1.0:80080",
                 &super::CorsOriginValue::new("https://192.168.1.0:8080").unwrap()
@@ -492,22 +492,23 @@ mod test {
 
     #[test]
     #[should_panic(
-        expected = "[Cors::new] Unable to parse Uri."
+        expected = "[Cors::new] Please use HTTP or HTTPS as scheme."
     )]
     fn cors_scheme_invalidation() {
         let _: super::Cors = super::Cors::new("foobarhttp://example.com");
     }
 
     #[test]
-    #[should_panic(expected = "[Cors::new] Unable to parse Uri.")]
+    #[should_panic(expected = "[Cors::new] URI length mustn't exceed 255 characters in total.")]
     fn cors_length_invalidation() {
-        let _: super::Cors = super::Cors::new(
-            "https://abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcde.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
+        let a: super::Cors = super::Cors::new(
+            "https://thisisaridiculouslylongurithatshoulddefinitelybeinvalidaccordingtothistest.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com",
         );
+        println!("{}", a.allow_origin.to_string())
     }
 
     #[test]
-    #[should_panic(expected = "[Cors::new] Unable to parse Uri.")]
+    #[should_panic(expected = "[Cors::new] URI part length mustn't exceed 63 characters.")]
     fn cors_part_length_invalidation() {
         let _: super::Cors = super::Cors::new(
             "https://www.abcdefghijklmnopqrstuvwxyzabcdefghijklmnoqrstuvwxyzabcdefghijklmnopqrstuvwxyz.com",
@@ -516,7 +517,7 @@ mod test {
 
     #[test]
     #[should_panic(
-        expected = "[Cors::new] Unable to parse Uri."
+        expected = "[Cors::new] Port number was expected."
     )]
     fn cors_port_invalidation() {
         let _: super::Cors = super::Cors::new("http://example.com:abcd");
@@ -524,7 +525,7 @@ mod test {
 
     #[test]
     #[should_panic(
-        expected = "[Cors::new] Unable to parse Uri."
+        expected = "[Cors::new] Invalid URI."
     )]
     fn cors_host_invalidation() {
         let _: super::Cors = super::Cors::new("http://%example.com");

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -389,32 +389,17 @@ mod test {
     #[test]
     fn cors_deny_indirect_origin_subdomain() {
         assert!(
+            !AllowOriginConfig::new("https://*.example.com").unwrap().allows(
+                &Origin::new("https://a.b.example.com").unwrap()
+            )
+        );
+    }
+
+    #[test]
+    fn cors_deny_wrong_origin_subdomain() {
+        assert!(
             !AllowOriginConfig::new("https://b.example.com").unwrap().allows(
                 &Origin::new("https://a.b.example.com").unwrap()
-            )
-        );
-
-        assert!(
-            !AllowOriginConfig::new("https://*.example.com").unwrap().allows(
-                &Origin::new("https://a.b.example.com").unwrap()
-            )
-        );
-
-        assert!(
-            !AllowOriginConfig::new("https://*.example.com").unwrap().allows(
-                &Origin::new("https://a..example.com").unwrap()
-            )
-        );
-
-        assert!(
-            !AllowOriginConfig::new("https://*.example.com").unwrap().allows(
-                &Origin::new("https://..example.com").unwrap()
-            )
-        );
-
-        assert!(
-            !AllowOriginConfig::new("https://example.com").unwrap().allows(
-                &Origin::new("https://..example.com").unwrap()
             )
         );
     }
@@ -426,51 +411,6 @@ mod test {
                 &Origin::new("https://anexample.com").unwrap()
             )
         );
-    }
-
-    #[test]
-    fn cors_deny_wildcard_in_origin_ip_subdomain() {
-        assert!(
-            !AllowOriginConfig::new("https://192.168.1.15:8080").unwrap().allows(
-                &Origin::new("https://*.168.1.15:8080").unwrap()
-            )
-        )
-    }
-
-    #[test]
-    fn cors_deny_faulty_wildcard_in_origin_ip() {
-        assert!(
-            !AllowOriginConfig::new("https://192.168.1.15:8080").unwrap().allows(
-                &Origin::new("https://192.*.1.15:8080").unwrap()
-            )
-        )
-    }
-
-    #[test]
-    fn cors_deny_wildcard_in_origin_sld() {
-        assert!(
-            !AllowOriginConfig::new("https://test.example.com:8080").unwrap().allows(
-                &Origin::new("https://test.*.com:8080").unwrap()
-            )
-        )
-    }
-
-    #[test]
-    fn cors_deny_wildcard_in_origin_extension() {
-        assert!(
-            !AllowOriginConfig::new("https://test.example.com:8080").unwrap().allows(
-                &Origin::new("https://test.example.*:8080").unwrap()
-            )
-        )
-    }
-
-    #[test]
-    fn cors_deny_invalid_origin_ip() {
-        assert!(
-            !AllowOriginConfig::new("https://192.168.1.58:8080").unwrap().allows(
-                &Origin::new("https://192.168.a.58:8080").unwrap()
-            )
-        )
     }
 
     #[test]
@@ -492,8 +432,7 @@ mod test {
 
     #[test]
     fn cors_ip_subdomain_wildcard_invalidation() {
-        let origin = "https://*.168.1.0:8080";
-        assert_eq!(CorsOriginError::InvalidOrigin(OriginError::FaultyIp), AllowOriginConfig::new(origin).unwrap_err())
+        assert_eq!(AllowOriginConfig::new("https://*.168.1.0:8080").unwrap_err(), CorsOriginError::InvalidOrigin(OriginError::FaultyIp))
     }
 
     #[test]

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -1,4 +1,5 @@
 use crate::{Fang, FangProc, Request, Response, Status, header::append};
+use core::option::Option::Some;
 use std::borrow::Cow;
 use super::{Origin, OriginError};
 
@@ -39,22 +40,21 @@ impl CorsOrigin {
     fn new(s: &str) -> Result<Self, CorsOriginError> {
         let mut any_port = false;
         let mut any_subdomain = false;
-        let mut s = match s.strip_suffix(":*") {
-            Some(rest) => {
-                if rest.chars().all(|c| c.is_numeric() || ":.*".contains(c)) {
-                    return Err(CorsOriginError::InvalidOrigin(OriginError::FaultyIp))
-                }
-                any_port = true;
-                Cow::Borrowed(rest)
-            }
-            None => Cow::Borrowed(s)
-        };
+
+        let mut s = Cow::Borrowed(s);
+
+        if let Some(rest) = s.strip_suffix(":*") {
+            any_port = true;
+            s = Cow::Owned(rest.to_string());
+        }
 
         if let Some((scheme @ ("http://" | "https://"), rest)) = s.split_once("*.") {
             any_subdomain = true;
-            // This allocation would not be a problem because `CorsOrigin::new` is
-            // just called once in server initialization phase, not called repeatedly in request handling phases.
             s = Cow::Owned(scheme.to_string() + rest);
+        }
+
+        if s.chars().all(|c| c.is_numeric() || ":.*".contains(c)) {
+            return Err(CorsOriginError::InvalidOrigin(OriginError::FaultyIp))
         }
 
         let base_origin = Origin::new(&s)

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use super::OriginError;
 
 #[derive(Clone, Debug)]
-pub enum CorsOriginValue {
+pub enum AllowOriginConfig {
     CorsOrigin(CorsOrigin),
     Any
 }
@@ -33,7 +33,7 @@ impl std::fmt::Display for CorsOriginError {
     }
 }
 
-impl CorsOriginValue {
+impl AllowOriginConfig {
     /// Parse string based on the Cors origin string syntax.
     ///
     /// # Examples
@@ -86,7 +86,7 @@ impl CorsOriginValue {
     #[allow(unused)]
     fn allows_str(&self, incoming_origin: &str) -> bool {
         match self {
-            CorsOriginValue::CorsOrigin(cors_origin) => {
+            AllowOriginConfig::CorsOrigin(cors_origin) => {
                 if let Some(("http" | "https" , origin)) = incoming_origin.split_once("://") {
                     let (host, port) = origin
                         .split_once(':')
@@ -120,7 +120,7 @@ impl CorsOriginValue {
                     false
                 }
             }
-            CorsOriginValue::Any => {
+            AllowOriginConfig::Any => {
                 // Anything goes
                 true
             }
@@ -140,7 +140,7 @@ impl CorsOriginValue {
     #[allow(unused)]
     fn allows(&self, incoming_origin: &super::Origin) -> bool {
         match self {
-            CorsOriginValue::CorsOrigin(cors_origin) => {
+            AllowOriginConfig::CorsOrigin(cors_origin) => {
                 if cors_origin.base_origin.scheme() == incoming_origin.scheme() {
                     // If no port wildcard, check if ports align.
                     if !cors_origin.any_port && cors_origin.base_origin.port() != incoming_origin.port() {
@@ -168,24 +168,24 @@ impl CorsOriginValue {
                     false
                 }
             }
-            CorsOriginValue::Any => {
+            AllowOriginConfig::Any => {
                 // Anything goes
                 true
             }
         }
     }
 
-    /// Returns the fallback access control allow origin String of this [`CorsOriginValue`].
+    /// Returns the fallback access control allow origin String of this [`AllowOriginConfig`].
     fn fallback_access_control_allow_origin(&self) -> String {
         match &self {
-            CorsOriginValue::Any => String::from("*"),
+            AllowOriginConfig::Any => String::from("*"),
             // `base_origin` itself is always an allowed origin.
-            CorsOriginValue::CorsOrigin(cors_origin)
+            AllowOriginConfig::CorsOrigin(cors_origin)
                 => cors_origin.base_origin.to_string(),
         }
     }
 
-    /// Returns if this [`CorsOriginValue`] is [`CorsOriginValue::Any`].
+    /// Returns if this [`AllowOriginConfig`] is [`AllowOriginConfig::Any`].
     fn is_any(&self) -> bool {
         matches!(self, Self::Any)
     }
@@ -216,7 +216,7 @@ impl CorsOriginValue {
 #[derive(Clone, Debug)]
 pub struct Cors {
     /* pub(crate) allow_methods: Option<String>, // owe to `Handler::default_not_found()` */
-    pub(crate) allow_origin_config: CorsOriginValue,
+    pub(crate) allow_origin_config: AllowOriginConfig,
     pub(crate) allow_credentials: bool,
     pub(crate) allow_headers: Option<String>,
     pub(crate) expose_headers: Option<String>,
@@ -228,7 +228,7 @@ impl Cors {
     /// (Both `"*"` and a specific origin are available)
     pub fn new(origin: impl Into<Cow<'static, str>>) -> Self {
         Self {
-            allow_origin_config: CorsOriginValue::new(origin.into().as_ref())
+            allow_origin_config: AllowOriginConfig::new(origin.into().as_ref())
                 .unwrap_or_else(|err| panic!("[Cors::new] {err}")),
             allow_credentials: false,
             allow_headers: None,
@@ -241,7 +241,7 @@ impl Cors {
     /// Creates `Cors` with any origin allowed
     pub const fn any() -> Self {
         Self {
-            allow_origin_config: CorsOriginValue::Any,
+            allow_origin_config: AllowOriginConfig::Any,
             allow_credentials: false,
             allow_headers: None,
             expose_headers: None,
@@ -349,8 +349,8 @@ mod test {
     #[test]
     fn cors_accept_regular_origin_ip() {
         assert!(
-            super::CorsOriginValue::allows(
-                &super::CorsOriginValue::new("https://192.168.1.41:5173").unwrap(),
+            super::AllowOriginConfig::allows(
+                &super::AllowOriginConfig::new("https://192.168.1.41:5173").unwrap(),
                 &super::super::Origin::new("https://192.168.1.41:5173").unwrap(),
             )
         )
@@ -359,14 +359,14 @@ mod test {
     #[test]
     fn cors_accept_regular_origin_domain() {
         assert!(
-            super::CorsOriginValue::allows(
-                &super::CorsOriginValue::new("https://example.com").unwrap(),
+            super::AllowOriginConfig::allows(
+                &super::AllowOriginConfig::new("https://example.com").unwrap(),
                 &super::super::Origin::new("https://example.com").unwrap(),
             )
         );
         assert!(
-            super::CorsOriginValue::allows(
-                &super::CorsOriginValue::new("https://sub.example.com").unwrap(),
+            super::AllowOriginConfig::allows(
+                &super::AllowOriginConfig::new("https://sub.example.com").unwrap(),
                 &super::super::Origin::new("https://sub.example.com").unwrap(),
             )
         );
@@ -375,14 +375,14 @@ mod test {
     #[test]
     fn cors_accept_origin_localhost() {
         assert!(
-            super::CorsOriginValue::allows(
-                &super::CorsOriginValue::new("https://localhost:5173/").unwrap(),
+            super::AllowOriginConfig::allows(
+                &super::AllowOriginConfig::new("https://localhost:5173/").unwrap(),
                 &super::super::Origin::new("https://localhost:5173/").unwrap(),
             )
         );
         assert!(
-            super::CorsOriginValue::allows(
-                &super::CorsOriginValue::new("https://localhost:*").unwrap(),
+            super::AllowOriginConfig::allows(
+                &super::AllowOriginConfig::new("https://localhost:*").unwrap(),
                 &super::super::Origin::new("https://localhost:5173/").unwrap(),
             )
         );
@@ -391,8 +391,8 @@ mod test {
     #[test]
     fn cors_accept_wildcard_match_in_own_ip_port() {
         assert!(
-            super::CorsOriginValue::allows(
-                &super::CorsOriginValue::new("https://192.168.1.2:*").unwrap(),
+            super::AllowOriginConfig::allows(
+                &super::AllowOriginConfig::new("https://192.168.1.2:*").unwrap(),
                 &super::super::Origin::new("https://192.168.1.2:5173").unwrap(),
             )
         );
@@ -401,8 +401,8 @@ mod test {
     #[test]
     fn cors_accept_wildcard_match_in_own_port() {
         assert!(
-            super::CorsOriginValue::allows(
-                &super::CorsOriginValue::new("https://example.com:*").unwrap(),
+            super::AllowOriginConfig::allows(
+                &super::AllowOriginConfig::new("https://example.com:*").unwrap(),
                 &super::super::Origin::new("https://example.com:5173").unwrap(),
             )
         );
@@ -411,8 +411,8 @@ mod test {
     #[test]
     fn cors_accept_wildcard_match_in_own_subdomain() {
         assert!(
-            super::CorsOriginValue::allows(
-                &super::CorsOriginValue::new("https://*.example.com").unwrap(),
+            super::AllowOriginConfig::allows(
+                &super::AllowOriginConfig::new("https://*.example.com").unwrap(),
                 &super::super::Origin::new("https://test.example.com").unwrap(),
             )
         );
@@ -422,8 +422,8 @@ mod test {
     fn cors_deny_wildcard_in_origin_ip_subdomain() {
         assert_eq!(
             false,
-            super::CorsOriginValue::allows(
-                &super::CorsOriginValue::new("https://192.168.1.15:8080").unwrap(),
+            super::AllowOriginConfig::allows(
+                &super::AllowOriginConfig::new("https://192.168.1.15:8080").unwrap(),
                 &super::super::Origin::new("https://*.168.1.15:8080").unwrap(),
             )
         )
@@ -433,8 +433,8 @@ mod test {
     fn cors_deny_faulty_wildcard_in_origin_ip() {
         assert_eq!(
             false,
-            super::CorsOriginValue::allows(
-                &super::CorsOriginValue::new("https://192.168.1.15:8080").unwrap(),
+            super::AllowOriginConfig::allows(
+                &super::AllowOriginConfig::new("https://192.168.1.15:8080").unwrap(),
                 &super::super::Origin::new("https://192.*.1.15:8080").unwrap(),
             )
         )
@@ -444,8 +444,8 @@ mod test {
     fn cors_deny_wildcard_in_origin_sld() {
         assert_eq!(
             false,
-            super::CorsOriginValue::allows(
-                &super::CorsOriginValue::new("https://test.example.com:8080").unwrap(),
+            super::AllowOriginConfig::allows(
+                &super::AllowOriginConfig::new("https://test.example.com:8080").unwrap(),
                 &super::super::Origin::new("https://test.*.com:8080").unwrap(),
             )
         )
@@ -455,8 +455,8 @@ mod test {
     fn cors_deny_wildcard_in_origin_extension() {
         assert_eq!(
             false,
-            super::CorsOriginValue::allows(
-                &super::CorsOriginValue::new("https://test.example.com:8080").unwrap(),
+            super::AllowOriginConfig::allows(
+                &super::AllowOriginConfig::new("https://test.example.com:8080").unwrap(),
                 &super::super::Origin::new("https://test.example.*:8080").unwrap(),
             )
         )
@@ -466,8 +466,8 @@ mod test {
     fn cors_deny_invalid_origin_ip() {
         assert_eq!(
             false,
-            super::CorsOriginValue::allows(
-                &super::CorsOriginValue::new("https://192.168.1.58:8080").unwrap(),
+            super::AllowOriginConfig::allows(
+                &super::AllowOriginConfig::new("https://192.168.1.58:8080").unwrap(),
                 &super::super::Origin::new("https://192.168.a.58:8080").unwrap(),
             )
         )
@@ -502,31 +502,31 @@ mod test {
     #[test]
     fn cors_scheme_invalidation() {
         let origin = "foobarhttp://example.com";
-        assert_eq!(super::CorsOriginError::InvalidOrigin(super::OriginError::FaultyScheme).to_string(), super::CorsOriginValue::new(origin).unwrap_err().to_string())
+        assert_eq!(super::CorsOriginError::InvalidOrigin(super::OriginError::FaultyScheme).to_string(), super::AllowOriginConfig::new(origin).unwrap_err().to_string())
     }
 
     #[test]
     fn cors_length_invalidation() {
         let origin = "https://thisisaridiculouslylongurithatshoulddefinitelybeinvalidaccordingtothistest.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl.com";
-        assert_eq!(super::CorsOriginError::InvalidOrigin(super::OriginError::FaultyUriLength).to_string(), super::CorsOriginValue::new(origin).unwrap_err().to_string())
+        assert_eq!(super::CorsOriginError::InvalidOrigin(super::OriginError::FaultyUriLength).to_string(), super::AllowOriginConfig::new(origin).unwrap_err().to_string())
     }
 
     #[test]
     fn cors_part_length_invalidation() {
         let origin = "https://www.abcdefghijklmnopqrstuvwxyzabcdefghijklmnoqrstuvwxyzabcdefghijklmnopqrstuvwxyz.com";
-        assert_eq!(super::CorsOriginError::InvalidOrigin(super::OriginError::FaultyUriPartLength).to_string(), super::CorsOriginValue::new(origin).unwrap_err().to_string())
+        assert_eq!(super::CorsOriginError::InvalidOrigin(super::OriginError::FaultyUriPartLength).to_string(), super::AllowOriginConfig::new(origin).unwrap_err().to_string())
     }
 
     #[test]
     fn cors_port_invalidation() {
         let origin = "http://example.com:abcd";
-        assert_eq!(super::CorsOriginError::InvalidOrigin(super::OriginError::FaultyPort).to_string(), super::CorsOriginValue::new(origin).unwrap_err().to_string())
+        assert_eq!(super::CorsOriginError::InvalidOrigin(super::OriginError::FaultyPort).to_string(), super::AllowOriginConfig::new(origin).unwrap_err().to_string())
     }
 
     #[test]
     fn cors_ip_subdomain_wildcard_invalidation() {
         let origin = "https://*.168.1.0:8080";
-        assert_eq!(super::CorsOriginError::InvalidOrigin(super::OriginError::FaultyIp).to_string(), super::CorsOriginValue::new(origin).unwrap_err().to_string())
+        assert_eq!(super::CorsOriginError::InvalidOrigin(super::OriginError::FaultyIp).to_string(), super::AllowOriginConfig::new(origin).unwrap_err().to_string())
     }
 
     #[test]

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -17,7 +17,7 @@ pub struct CorsOrigin {
 
 impl CorsOrigin {
     /// Parse string into [`CorsOrigin`], checks for wildcards inside the string,
-    /// and if all appropriate validation succeeds inside [`Origin`] returns Self.
+    /// and if all appropriate validation succeeds inside [`Origin`] and [`CorsOrigin`] returns Self.
     ///
     /// # Examples
     /// ```rust
@@ -27,13 +27,18 @@ impl CorsOrigin {
     /// }
     /// ```
     /// # Errors
-    /// This function will return an error if the given URI string fails the validation included in [`Origin`].
+    /// This function returns an error if the given string fails either of the following criteria:
+    /// - If an IP-address is using a subdomain wildcard.
+    /// - If the validation included in [`Origin`] fails.
     ///
     fn new(s: &str) -> Result<Self, CorsOriginError> {
         let mut any_port = false;
         let mut any_subdomain = false;
         let mut s = match s.strip_suffix(":*") {
             Some(rest) => {
+                if rest.chars().all(|c| c.is_numeric() || ":.*".contains(c)) {
+                    return Err(CorsOriginError::InvalidOrigin(OriginError::FaultyIp))
+                }
                 any_port = true;
                 Cow::Borrowed(rest)
             }

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -78,32 +78,33 @@ impl CorsOriginValue {
                     if !cors_origin.any_port
                         && let Some(cors_port) = cors_origin.base_origin.port()
                         && Some(format!("{}", cors_port).as_str()) != port {
-
-                        println!("No exact port match");
                         return false;
                     }
 
                     let (cors_subdomain, cors_domain) = cors_origin.base_origin.host_as_subdomain_and_domain();
                     let (subdomain, domain) = host
                         .split_once('.')
-                        .map_or((None, host), |(s, d)| (Some(s), d));
+                        .map_or((None, host), |(s, d)| {
+                            if d.contains('.') {
+                                (Some(s), d)
+                            } else {
+                                (None, host)
+                            }
+                        });
 
                     // If subdomain is not a wildcard, validate
                     if !cors_origin.any_subdomain && cors_subdomain != subdomain {
-                        println!("No exact subdomain match");
                         return false;
                     }
 
                     // Check if domain matches.
                     if domain != cors_domain {
-                        println!("No exact domain match {domain}, {cors_domain}");
                         return false;
                     }
                     // Subdomain, domain and port match, so return true.
                     true
                 } else {
                     // No scheme was somehow found
-                    println!("No scheme found");
                     false
                 }
             }
@@ -272,10 +273,8 @@ impl Cors {
     }
     pub fn verify_origin<'a>(origin: &'a str, cors_origin: &CorsOriginValue) -> Cow<'a, str> {
         if CorsOriginValue::matches_str(cors_origin, origin) {
-            println!("{origin} matches {cors_origin}");
             Cow::Borrowed(origin)
         } else {
-            println!("{origin} didn't match {cors_origin}");
             Cow::Owned(cors_origin.to_string())
         }
     }

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -124,23 +124,21 @@ impl AllowOriginConfig {
                     }
 
                     if !cors_origin.any_subdomain && cors_origin.base_origin.host() != incoming_origin.host() {
-                        // If we do not support any subdomain, we can just fully compare the two, as no additional parsing is necessary.
+                        // If we do not support any subdomain, we can just fully compare the two, as no additional validation is necessary.
                         return false;
-                    } else {
-                        if cors_origin.base_origin.host() != incoming_origin.host() { //Check if the options don't already align
-                            if let (Some(cors_host), Some(host)) = (cors_origin.base_origin.host(), incoming_origin.host()) {
-                                if !host.ends_with(&cors_host) {
-                                    return false;
-                                } else if host != cors_host && let Some(rest) = host.strip_suffix(cors_host) {
-                                    if !rest.contains('.') {
-                                        return false; // Deny wrong domain
+                    } else if cors_origin.base_origin.host() != incoming_origin.host() { //Check if the options don't already align
+                        if let (Some(cors_host), Some(host)) = (cors_origin.base_origin.host(), incoming_origin.host()) {
+                            if !host.ends_with(&cors_host) {
+                                return false;
+                            } else if host != cors_host && let Some(rest) = host.strip_suffix(cors_host) {
+                                if !rest.contains('.') {
+                                    return false; // Deny wrong domain
+                                } else {
+                                    if !cors_origin.any_subdomain {
+                                        return false; // Deny prepended subdomain while none are allowed.
                                     } else {
-                                        if !cors_origin.any_subdomain {
-                                            return false; // Deny prepended subdomain while none are allowed.
-                                        } else {
-                                            if rest.contains("..") || rest.split('.').filter(|s| s != &"").count() >= 2 {
-                                                return false; // Deny if not a direct subdomain or any parts are ".."
-                                            }
+                                        if rest.contains("..") || rest.split('.').filter(|s| s != &"").count() >= 2 {
+                                            return false; // Deny if not a direct subdomain or any parts are ".."
                                         }
                                     }
                                 }

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -1,5 +1,5 @@
 use crate::{Fang, FangProc, Request, Response, Status, header::append};
-use core::todo;
+use core::option::Option::Some;
 use std::borrow::Cow;
 
 use super::OriginError;
@@ -20,14 +20,15 @@ enum CorsOriginError {
 impl CorsOrigin {
     /// Parse string based on the Cors origin string syntax.
     fn new(s: &str) -> Result<Self, CorsOriginError> {
-        let mut s = Cow::Borrowed(s);
         let mut any_port = false;
         let mut any_subdomain = false;
-
-        if let Some(rest) = s.strip_suffix(":*") {
-            any_port = true;
-            s = Cow::Borrowed(rest);
-        }
+        let mut s = match s.strip_suffix(":*") {
+            Some(rest) => {
+                any_port = true;
+                Cow::Borrowed(rest)
+            }
+            None => Cow::Borrowed(s)
+        };
 
         if let Some((scheme @ ("http://" | "https://"), rest)) = s.split_once("*.") {
             any_subdomain = true;
@@ -43,14 +44,43 @@ impl CorsOrigin {
     }
 
     fn matches_str(&self, incoming_origin: &str) -> bool {
-        todo!("Write logic");
-        false
+        if let Some(("http://" | "https://", origin)) = incoming_origin.split_once("://") {
+            let (host, port) = origin
+                .split_once(':')
+                .map_or((origin, None), |(h, p)| (h, Some(p)));
+
+            // Check port if not wildcard, validate
+            if !self.any_port
+                && let Some(cors_port) = self.base_origin.port()
+                && Some(format!("{}", cors_port).as_str()) != port {
+
+                return false;
+            }
+
+            let (cors_subdomain, cors_domain) = self.base_origin.host_as_tuple();
+            let (subdomain, domain) = host
+                .split_once('.')
+                .map_or((None, origin), |(s, d)| (Some(s), d));
+
+            // If subdomain is not a wildcard, validate
+            if !self.any_subdomain && cors_subdomain != subdomain {
+                return false;
+            }
+
+            // Check if domain matches.
+            if domain != cors_domain {
+                return false;
+            }
+
+            true
+        } else {
+            // No scheme was somehow found
+            false
+        }
     }
 
     fn matches(&self, incoming_origin: &super::Origin) -> bool {
-        todo!("Write logic");
-        true
-        //...
+        self.matches_str(incoming_origin.to_string().as_str())
     }
 }
 
@@ -197,17 +227,14 @@ impl Cors {
             let (host, port) = rest
                 .split_once(':')
                 .map_or((rest, None), |(h, p)| (h, Some(p)));
+
             //If no port wildcard in Cors, enforce similarity
-            if allow_port.is_some_and(|p| p != "*") {
-                if port != allow_port {
-                    return allow_origin;
-                }
+            if allow_port.is_some_and(|p| p != "*") && port != allow_port {
+                return allow_origin;
             }
 
-            if !allow_host.starts_with("*.") {
-                if host != allow_host {
-                    return allow_origin;
-                }
+            if !allow_host.starts_with("*.") && host != allow_host {
+                return allow_origin;
             }
 
             //Port must be in range of u16, and must be either * or a string of numbers.
@@ -301,7 +328,7 @@ impl<Inner: FangProc> FangProc for CorsProc<Inner> {
     async fn bite<'b>(&'b self, req: &'b mut Request) -> Response {
         let mut res = self.inner.bite(req).await;
         let allow_origin = Cors::verify_origin(
-            req.headers.origin().unwrap_or_else(|| ""),
+            req.headers.origin().unwrap_or(""),
             self.cors.allow_origin.get_cow(),
         )
         .into_owned();

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -69,7 +69,7 @@ impl CorsOriginValue {
     fn matches_str(&self, incoming_origin: &str) -> bool {
         match self {
             CorsOriginValue::CorsOrigin(cors_origin) => {
-                if let Some(("http://" | "https://", origin)) = incoming_origin.split_once("://") {
+                if let Some(("http" | "https" , origin)) = incoming_origin.split_once("://") {
                     let (host, port) = origin
                         .split_once(':')
                         .map_or((origin, None), |(h, p)| (h, Some(p)));
@@ -79,27 +79,31 @@ impl CorsOriginValue {
                         && let Some(cors_port) = cors_origin.base_origin.port()
                         && Some(format!("{}", cors_port).as_str()) != port {
 
+                        println!("No exact port match");
                         return false;
                     }
 
                     let (cors_subdomain, cors_domain) = cors_origin.base_origin.host_as_subdomain_and_domain();
                     let (subdomain, domain) = host
                         .split_once('.')
-                        .map_or((None, origin), |(s, d)| (Some(s), d));
+                        .map_or((None, host), |(s, d)| (Some(s), d));
 
                     // If subdomain is not a wildcard, validate
                     if !cors_origin.any_subdomain && cors_subdomain != subdomain {
+                        println!("No exact subdomain match");
                         return false;
                     }
 
                     // Check if domain matches.
                     if domain != cors_domain {
+                        println!("No exact domain match {domain}, {cors_domain}");
                         return false;
                     }
                     // Subdomain, domain and port match, so return true.
                     true
                 } else {
                     // No scheme was somehow found
+                    println!("No scheme found");
                     false
                 }
             }
@@ -268,8 +272,10 @@ impl Cors {
     }
     pub fn verify_origin<'a>(origin: &'a str, cors_origin: &CorsOriginValue) -> Cow<'a, str> {
         if CorsOriginValue::matches_str(cors_origin, origin) {
+            println!("{origin} matches {cors_origin}");
             Cow::Borrowed(origin)
         } else {
+            println!("{origin} didn't match {cors_origin}");
             Cow::Owned(cors_origin.to_string())
         }
     }
@@ -341,7 +347,7 @@ mod test {
     #[test]
     fn cors_accept_regular_ip() {
         assert_eq!(
-            "https://192.168.1.41:5173/",
+            "https://192.168.1.41:5173",
             super::Cors::verify_origin(
                 "https://192.168.1.41:5173",
                 &super::CorsOriginValue::new("https://192.168.1.41:5173").unwrap()
@@ -352,14 +358,14 @@ mod test {
     #[test]
     fn cors_accept_regular_domain() {
         assert_eq!(
-            "https://example.com/",
+            "https://example.com",
             super::Cors::verify_origin(
                 "https://example.com",
                 &super::CorsOriginValue::new("https://example.com").unwrap()
             )
         );
         assert_eq!(
-            "https://sub.example.com/",
+            "https://sub.example.com",
             super::Cors::verify_origin(
                 "https://sub.example.com",
                 &super::CorsOriginValue::new("https://sub.example.com").unwrap()
@@ -372,12 +378,12 @@ mod test {
         assert_eq!(
             "https://localhost:5173/",
             super::Cors::verify_origin(
-                "https://localhost:5173",
-                &super::CorsOriginValue::new("https://localhost:5173").unwrap()
+                "https://localhost:5173/",
+                &super::CorsOriginValue::new("https://localhost:5173/").unwrap()
             )
         );
         assert_eq!(
-            "https://localhost:5173/",
+            "https://localhost:5173",
             super::Cors::verify_origin(
                 "https://localhost:5173",
                 &super::CorsOriginValue::new("https://localhost:*").unwrap()
@@ -388,7 +394,7 @@ mod test {
     #[test]
     fn cors_accept_wildcard_in_ip_port() {
         assert_eq!(
-            "https://192.168.1.2:5173/",
+            "https://192.168.1.2:5173",
             super::Cors::verify_origin(
                 "https://192.168.1.2:5173",
                 &super::CorsOriginValue::new("https://192.168.1.2:*").unwrap()
@@ -399,7 +405,7 @@ mod test {
     #[test]
     fn cors_accept_wildcard_in_port() {
         assert_eq!(
-            "https://example.com:5173/",
+            "https://example.com:5173",
             super::Cors::verify_origin(
                 "https://example.com:5173",
                 &super::CorsOriginValue::new("https://example.com:*").unwrap()
@@ -410,7 +416,7 @@ mod test {
     #[test]
     fn cors_accept_wildcard_in_subdomain() {
         assert_eq!(
-            "https://test.example.com/",
+            "https://test.example.com",
             super::Cors::verify_origin(
                 "https://test.example.com",
                 &super::CorsOriginValue::new("https://*.example.com").unwrap()

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -1,10 +1,7 @@
 use crate::{Fang, FangProc, Request, Response, Status, header::append};
 use std::borrow::Cow;
-use std::fmt::{Display, Formatter};
 use super::OriginError;
 
-// cors.rs
-/* This replaces current `AccessControlAllowOrigin` */
 #[derive(Clone, Debug)]
 pub enum CorsOriginValue {
     CorsOrigin(CorsOrigin),
@@ -18,8 +15,8 @@ pub struct CorsOrigin {
     any_subdomain: bool,
 }
 
-impl Display for CorsOrigin {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl std::fmt::Display for CorsOrigin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.base_origin)
     }
 }
@@ -29,8 +26,8 @@ pub enum CorsOriginError {
     InvalidOrigin(OriginError)
 }
 
-impl Display for CorsOriginError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl std::fmt::Display for CorsOriginError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let CorsOriginError::InvalidOrigin(e) = self;
         write!(f, "{}", e)
     }
@@ -47,7 +44,7 @@ impl CorsOriginValue {
     /// # Examples
     /// ```rust
     /// fn run() {
-    ///     CorsOriginValue::new("https://localhost:3000").unwrap(); //Gives CorsOriginValue::Any
+    ///     CorsOriginValue::new("https://localhost:3000").unwrap(); //Gives CorsOriginValue::CorsOrigin
     ///     CorsOriginValue::new("*").unwrap(); //Gives CorsOriginValue::Any
     /// }
     /// ```
@@ -84,14 +81,7 @@ impl CorsOriginValue {
 
     /// Checks if according to the noted rules for wildcards in this struct, the incoming origin would match.
     ///
-    /// # Arguments
-    ///
-    /// * `incoming_origin`: &str - The origin URI that the stored Cors needs to be compared to.
-    ///
-    /// returns: bool
-    ///
     /// # Examples
-    ///
     /// ```
     /// fn run() {
     ///     let cors = CorsOriginValue::new("*").unwrap();
@@ -149,14 +139,7 @@ impl CorsOriginValue {
 
     /// Checks if according to the noted rules for wildcards in this struct, the incoming origin would match.
     ///
-    /// # Arguments
-    ///
-    /// * `incoming_origin`: Origin - The origin that the stored Cors needs to be compared to.
-    ///
-    /// returns: bool
-    ///
     /// # Examples
-    ///
     /// ```
     /// fn run() {
     ///     let cors = CorsOriginValue::new("*").unwrap();
@@ -179,8 +162,8 @@ impl CorsOriginValue {
 
 }
 
-impl Display for CorsOriginValue {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl std::fmt::Display for CorsOriginValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             CorsOriginValue::CorsOrigin(origin) => {
                 write!(f, "{}", origin)

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -142,7 +142,7 @@ impl AllowOriginConfig {
                                 return false; // Deny prepended subdomain while none are allowed.
                             }
                             if rest.contains("..") || rest.split('.').filter(|s| s != &"").count() >= 2 {
-                                return false; // Deny if not a direct subdomain or any parts are ".."
+                                return false; // Deny if not a direct subdomain
                             }
                         }
                     }

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -26,7 +26,7 @@ impl CorsOrigin {
     /// and if all appropriate validation succeeds inside [`Origin`] and [`CorsOrigin`] returns Self.
     ///
     /// # Examples
-    /// ```rust
+    /// ```ignore
     /// fn run() {
     ///     CorsOrigin::new("https://*.localhost:3000").unwrap(); //Gives CorsOrigin
     ///     CorsOrigin::new("https://*.localhost:").unwrap(); //Gives CorsOriginError
@@ -94,7 +94,7 @@ impl AllowOriginConfig {
     /// Parse string based on the Cors origin string syntax.
     ///
     /// # Examples
-    /// ```rust
+    /// ```ignore
     /// fn run() {
     ///     AllowOriginConfig::new("https://localhost:3000").unwrap(); //Gives AllowOriginConfig::CorsOrigin
     ///     AllowOriginConfig::new("*").unwrap(); //Gives AllowOriginConfig::Any
@@ -113,7 +113,7 @@ impl AllowOriginConfig {
     /// Checks if according to the noted rules for wildcards in this struct, the incoming origin would match.
     ///
     /// # Examples
-    /// ```
+    /// ```ignore
     /// fn run() {
     ///     let cors = AllowOriginConfig::new("*").unwrap();
     ///     let origin = Origin::new("https://localhost:5173").unwrap();

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -1,5 +1,5 @@
 use crate::{Fang, FangProc, Request, Response, Status, header::append};
-use core::option::Option::Some;
+use core::convert::Into;
 use std::borrow::Cow;
 use super::{Origin, OriginError};
 
@@ -18,7 +18,8 @@ pub struct CorsOrigin {
 
 #[derive(Debug, PartialEq)]
 pub enum CorsOriginError {
-    InvalidOrigin(OriginError)
+    InvalidOrigin(OriginError),
+    FaultyWildcardInIp,
 }
 
 impl CorsOrigin {
@@ -48,9 +49,13 @@ impl CorsOrigin {
             s = Cow::Owned(rest.to_string());
         }
 
-        if let Some((scheme @ ("http://" | "https://"), rest)) = s.split_once("*.") {
-            any_subdomain = true;
-            s = Cow::Owned(scheme.to_string() + rest);
+        if let Some((scheme @ ("http://" | "https://"), host)) = s.split_once("*.") {
+            if let Ok(_) = host.parse::<core::net::IpAddr>() {
+                return Err(CorsOriginError::FaultyWildcardInIp)
+            } else {
+                any_subdomain = true;
+                s = Cow::Owned(scheme.to_string() + host);
+            };
         }
 
         let base_origin = Origin::new(&s)
@@ -62,8 +67,11 @@ impl CorsOrigin {
 
 impl std::fmt::Display for CorsOriginError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let CorsOriginError::InvalidOrigin(e) = self;
-        write!(f, "{}", e)
+        let output= match self {
+            CorsOriginError::InvalidOrigin(e) => e.to_string(),
+            CorsOriginError::FaultyWildcardInIp => String::from("Found invalid wildcard in IP address")
+        };
+        write!(f, "{}", output)
     }
 }
 
@@ -121,7 +129,7 @@ impl AllowOriginConfig {
 
                 // If we do not support any subdomain, we can just fully compare the two, as no additional validation is necessary.
                 if !cors_origin.any_subdomain {
-                    return cors_origin.base_origin.host() != incoming_origin.host();
+                    return cors_origin.base_origin.host() == incoming_origin.host();
                 }
 
                 if cors_origin.base_origin.host() != incoming_origin.host() { //Check if the options don't already align

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -50,7 +50,7 @@ impl CorsOrigin {
         }
 
         if let Some((scheme @ ("http://" | "https://"), host)) = s.split_once("*.") {
-            if let Ok(_) = host.parse::<core::net::IpAddr>() {
+            if host.parse::<core::net::IpAddr>().is_ok() {
                 return Err(CorsOriginError::FaultyWildcardInIp)
             }
             any_subdomain = true;

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -123,9 +123,9 @@ impl AllowOriginConfig {
                     return false;
                 }
 
-                if !cors_origin.any_subdomain && cors_origin.base_origin.host() != incoming_origin.host() {
-                    // If we do not support any subdomain, we can just fully compare the two, as no additional validation is necessary.
-                    return false;
+                // If we do not support any subdomain, we can just fully compare the two, as no additional validation is necessary.
+                if !cors_origin.any_subdomain {
+                    return cors_origin.base_origin.host() != incoming_origin.host();
                 }
 
                 if cors_origin.base_origin.host() != incoming_origin.host() { //Check if the options don't already align
@@ -138,15 +138,11 @@ impl AllowOriginConfig {
                         if !rest.contains('.') {
                             return false; // Deny wrong domain
                         }
-                        if !cors_origin.any_subdomain {
-                            return false; // Deny prepended subdomain while none are allowed.
-                        }
                         if rest.contains("..") || rest.split('.').filter(|s| s != &"").count() >= 2 {
                             return false; // Deny if not a direct subdomain
                         }
                     }
                 }
-                // Validations passed
                 true
             }
             AllowOriginConfig::Any => {

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -1,5 +1,4 @@
 use crate::{Fang, FangProc, Request, Response, Status, header::append};
-use core::convert::Into;
 use std::borrow::Cow;
 use super::{Origin, OriginError};
 
@@ -50,9 +49,12 @@ impl CorsOrigin {
         }
 
         if let Some((scheme @ ("http://" | "https://"), host)) = s.split_once("*.") {
-            if host.parse::<core::net::IpAddr>().is_ok() {
-                return Err(CorsOriginError::FaultyWildcardInIp)
+            if let Some((ip, _port)) =  host.rsplit_once(":") {
+                if ip.parse::<core::net::IpAddr>().is_ok() {
+                    return Err(CorsOriginError::FaultyWildcardInIp)
+                }
             }
+
             any_subdomain = true;
             s = Cow::Owned(scheme.to_string() + host);
         }
@@ -427,7 +429,8 @@ mod test {
 
     #[test]
     fn cors_ip_subdomain_wildcard_invalidation() {
-        assert_eq!(AllowOriginConfig::new("https://*.168.1.0:8080").unwrap_err(), CorsOriginError::InvalidOrigin(OriginError::FaultyIp))
+        assert_eq!(AllowOriginConfig::new("https://*.168.1.0:8080").unwrap_err(), CorsOriginError::InvalidOrigin(OriginError::FaultyIp));
+        assert_eq!(AllowOriginConfig::new("https://*.192.168.1.0:8080").unwrap_err(), CorsOriginError::FaultyWildcardInIp)
     }
 
     #[test]

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -53,10 +53,6 @@ impl CorsOrigin {
             s = Cow::Owned(scheme.to_string() + rest);
         }
 
-        if s.chars().all(|c| c.is_numeric() || ":.*".contains(c)) {
-            return Err(CorsOriginError::InvalidOrigin(OriginError::FaultyIp))
-        }
-
         let base_origin = Origin::new(&s)
             .map_err(CorsOriginError::InvalidOrigin)?;
 
@@ -133,14 +129,12 @@ impl AllowOriginConfig {
                         return false;
                     }
 
-                    if incoming_origin.host() != cors_origin.base_origin.host()
-                        && let Some(rest) = incoming_origin.host().strip_suffix(cors_origin.base_origin.host()) {
-                        if !rest.contains('.') {
-                            return false; // Deny wrong domain
-                        }
-                        if rest.contains("..") || rest.split('.').filter(|s| s != &"").count() >= 2 {
-                            return false; // Deny if not a direct subdomain
-                        }
+                    let rest = incoming_origin.host().strip_suffix(cors_origin.base_origin.host()).expect("Incoming origin should end with CORS origin's base origin host.");
+                    if !rest.contains('.') {
+                        return false; // Deny wrong domain
+                    }
+                    if rest.contains("..") || rest.split('.').filter(|s| s != &"").count() >= 2 {
+                        return false; // Deny if not a direct subdomain
                     }
                 }
                 true

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -52,10 +52,9 @@ impl CorsOrigin {
         if let Some((scheme @ ("http://" | "https://"), host)) = s.split_once("*.") {
             if let Ok(_) = host.parse::<core::net::IpAddr>() {
                 return Err(CorsOriginError::FaultyWildcardInIp)
-            } else {
-                any_subdomain = true;
-                s = Cow::Owned(scheme.to_string() + host);
-            };
+            }
+            any_subdomain = true;
+            s = Cow::Owned(scheme.to_string() + host);
         }
 
         let base_origin = Origin::new(&s)
@@ -69,7 +68,7 @@ impl std::fmt::Display for CorsOriginError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let output= match self {
             CorsOriginError::InvalidOrigin(e) => e.to_string(),
-            CorsOriginError::FaultyWildcardInIp => String::from("Found invalid wildcard in IP address")
+            CorsOriginError::FaultyWildcardInIp => String::from("Found invalid wildcard in IP address.")
         };
         write!(f, "{}", output)
     }

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -49,10 +49,9 @@ impl CorsOrigin {
         }
 
         if let Some((scheme @ ("http://" | "https://"), host)) = s.split_once("*.") {
-            if let Some((ip, _port)) =  host.rsplit_once(":") {
-                if ip.parse::<core::net::IpAddr>().is_ok() {
+            if let Some((ip, _port)) =  host.rsplit_once(":") &&
+                ip.parse::<core::net::IpAddr>().is_ok() {
                     return Err(CorsOriginError::FaultyWildcardInIp)
-                }
             }
 
             any_subdomain = true;

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -348,13 +348,13 @@ mod test {
     #[test]
     fn cors_accept_origin_localhost() {
         assert!(
-            AllowOriginConfig::new("https://localhost:5173/").unwrap().allows(
-                &Origin::new("https://localhost:5173/").unwrap()
+            AllowOriginConfig::new("https://localhost:5173").unwrap().allows(
+                &Origin::new("https://localhost:5173").unwrap()
             )
         );
         assert!(
             AllowOriginConfig::new("https://localhost:*").unwrap().allows(
-                &Origin::new("https://localhost:5173/").unwrap()
+                &Origin::new("https://localhost:5173").unwrap()
             )
         );
     }

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -1,11 +1,11 @@
+use super::{Origin, OriginError};
 use crate::{Fang, FangProc, Request, Response, Status, header::append};
 use std::borrow::Cow;
-use super::{Origin, OriginError};
 
 #[derive(Clone, Debug)]
 pub enum AllowOriginConfig {
     CorsOrigin(CorsOrigin),
-    Any
+    Any,
 }
 
 #[derive(Clone, Debug)]
@@ -49,27 +49,33 @@ impl CorsOrigin {
         }
 
         if let Some((scheme @ ("http://" | "https://"), host)) = s.split_once("*.") {
-            if let Some((ip, _port)) =  host.rsplit_once(":") &&
-                ip.parse::<core::net::IpAddr>().is_ok() {
-                    return Err(CorsOriginError::FaultyWildcardInIp)
+            if let Some((ip, _port)) = host.rsplit_once(":")
+                && ip.parse::<core::net::IpAddr>().is_ok()
+            {
+                return Err(CorsOriginError::FaultyWildcardInIp);
             }
 
             any_subdomain = true;
             s = Cow::Owned(scheme.to_string() + host);
         }
 
-        let base_origin = Origin::new(&s)
-            .map_err(CorsOriginError::InvalidOrigin)?;
+        let base_origin = Origin::new(&s).map_err(CorsOriginError::InvalidOrigin)?;
 
-        Ok(Self { base_origin, any_port, any_subdomain })
+        Ok(Self {
+            base_origin,
+            any_port,
+            any_subdomain,
+        })
     }
 }
 
 impl std::fmt::Display for CorsOriginError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let output= match self {
+        let output = match self {
             CorsOriginError::InvalidOrigin(e) => e.to_string(),
-            CorsOriginError::FaultyWildcardInIp => String::from("Found invalid wildcard in IP address.")
+            CorsOriginError::FaultyWildcardInIp => {
+                String::from("Found invalid wildcard in IP address.")
+            }
         };
         write!(f, "{}", output)
     }
@@ -81,8 +87,7 @@ impl AllowOriginConfig {
         match &self {
             AllowOriginConfig::Any => String::from("*"),
             // `base_origin` itself is always an allowed origin.
-            AllowOriginConfig::CorsOrigin(cors_origin)
-            => cors_origin.base_origin.to_string(),
+            AllowOriginConfig::CorsOrigin(cors_origin) => cors_origin.base_origin.to_string(),
         }
     }
 
@@ -101,7 +106,7 @@ impl AllowOriginConfig {
     fn new(s: &str) -> Result<Self, CorsOriginError> {
         match s {
             "*" => Ok(Self::Any),
-            _ => CorsOrigin::new(s).map(Self::CorsOrigin)
+            _ => CorsOrigin::new(s).map(Self::CorsOrigin),
         }
     }
 
@@ -123,7 +128,8 @@ impl AllowOriginConfig {
                     return false;
                 }
                 // If no port wildcard, check if ports align.
-                if !cors_origin.any_port && cors_origin.base_origin.port() != incoming_origin.port() {
+                if !cors_origin.any_port && cors_origin.base_origin.port() != incoming_origin.port()
+                {
                     return false;
                 }
 
@@ -134,7 +140,8 @@ impl AllowOriginConfig {
 
                 if cors_origin.base_origin.host() == incoming_origin.host() {
                     true
-                } else { //Check if the options don't already align
+                } else {
+                    //Check if the options don't already align
                     incoming_origin
                         .host()
                         .split_once('.')
@@ -152,7 +159,6 @@ impl AllowOriginConfig {
     fn is_any(&self) -> bool {
         matches!(self, Self::Any)
     }
-
 }
 
 /// # Builtin fang for CORS config
@@ -266,14 +272,24 @@ impl<Inner: FangProc> FangProc for CorsProc<Inner> {
         let mut res = self.inner.bite(req).await;
         let incoming_origin = req.headers.origin().and_then(|s| Origin::new(s).ok());
         let access_control_allow_origin = match incoming_origin {
-            Some(incoming) if self.cors.allow_origin_config.allows(&incoming) => incoming.to_string(),
-            _ => self.cors.allow_origin_config.fallback_access_control_allow_origin(),
+            Some(incoming) if self.cors.allow_origin_config.allows(&incoming) => {
+                incoming.to_string()
+            }
+            _ => self
+                .cors
+                .allow_origin_config
+                .fallback_access_control_allow_origin(),
         };
 
         res.headers
             .set()
             .access_control_allow_origin(access_control_allow_origin)
-            .vary(self.cors.allow_origin_config.is_any().then_some("Origin".into()))
+            .vary(
+                self.cors
+                    .allow_origin_config
+                    .is_any()
+                    .then_some("Origin".into()),
+            )
             .access_control_allow_credentials(self.cors.allow_credentials.then_some("true".into()))
             .access_control_expose_headers(
                 self.cors
@@ -309,127 +325,127 @@ impl<Inner: FangProc> FangProc for CorsProc<Inner> {
 
 #[cfg(test)]
 mod test {
-    use crate::fang::OriginError;
     use super::{AllowOriginConfig, CorsOriginError, Origin};
+    use crate::fang::OriginError;
 
     #[test]
     fn cors_accept_regular_origin_ip() {
         assert!(
-            AllowOriginConfig::new("https://192.168.1.41:5173").unwrap().allows(
-                &Origin::new("https://192.168.1.41:5173").unwrap()
-            )
+            AllowOriginConfig::new("https://192.168.1.41:5173")
+                .unwrap()
+                .allows(&Origin::new("https://192.168.1.41:5173").unwrap())
         )
     }
 
     #[test]
     fn cors_accept_regular_origin_domain() {
         assert!(
-            AllowOriginConfig::new("https://example.com").unwrap().allows(
-                &Origin::new("https://example.com").unwrap()
-            )
+            AllowOriginConfig::new("https://example.com")
+                .unwrap()
+                .allows(&Origin::new("https://example.com").unwrap())
         );
         assert!(
-            AllowOriginConfig::new("https://example.co.uk").unwrap().allows(
-                &Origin::new("https://example.co.uk").unwrap()
-            )
+            AllowOriginConfig::new("https://example.co.uk")
+                .unwrap()
+                .allows(&Origin::new("https://example.co.uk").unwrap())
         );
         assert!(
-            AllowOriginConfig::new("https://sub.example.com").unwrap().allows(
-                &Origin::new("https://sub.example.com").unwrap()
-            )
+            AllowOriginConfig::new("https://sub.example.com")
+                .unwrap()
+                .allows(&Origin::new("https://sub.example.com").unwrap())
         );
         assert!(
-            AllowOriginConfig::new("https://sub.example.co.uk").unwrap().allows(
-                &Origin::new("https://sub.example.co.uk").unwrap()
-            )
+            AllowOriginConfig::new("https://sub.example.co.uk")
+                .unwrap()
+                .allows(&Origin::new("https://sub.example.co.uk").unwrap())
         );
     }
 
     #[test]
     fn cors_accept_origin_localhost() {
         assert!(
-            AllowOriginConfig::new("https://localhost:5173").unwrap().allows(
-                &Origin::new("https://localhost:5173").unwrap()
-            )
+            AllowOriginConfig::new("https://localhost:5173")
+                .unwrap()
+                .allows(&Origin::new("https://localhost:5173").unwrap())
         );
         assert!(
-            AllowOriginConfig::new("https://localhost:*").unwrap().allows(
-                &Origin::new("https://localhost:5173").unwrap()
-            )
+            AllowOriginConfig::new("https://localhost:*")
+                .unwrap()
+                .allows(&Origin::new("https://localhost:5173").unwrap())
         );
     }
 
     #[test]
     fn cors_accept_wildcard_match_in_own_ip_port() {
         assert!(
-            AllowOriginConfig::new("https://192.168.1.2:*").unwrap().allows(
-                &Origin::new("https://192.168.1.2:5173").unwrap()
-            )
+            AllowOriginConfig::new("https://192.168.1.2:*")
+                .unwrap()
+                .allows(&Origin::new("https://192.168.1.2:5173").unwrap())
         );
     }
 
     #[test]
     fn cors_accept_wildcard_match_in_own_port() {
         assert!(
-            AllowOriginConfig::new("https://example.com:*").unwrap().allows(
-                &Origin::new("https://example.com:5173").unwrap()
-            )
+            AllowOriginConfig::new("https://example.com:*")
+                .unwrap()
+                .allows(&Origin::new("https://example.com:5173").unwrap())
         );
         assert!(
-            AllowOriginConfig::new("https://example.co.uk:*").unwrap().allows(
-                &Origin::new("https://example.co.uk:5173").unwrap()
-            )
+            AllowOriginConfig::new("https://example.co.uk:*")
+                .unwrap()
+                .allows(&Origin::new("https://example.co.uk:5173").unwrap())
         );
     }
 
     #[test]
     fn cors_accept_wildcard_match_in_own_subdomain() {
         assert!(
-            AllowOriginConfig::new("https://*.example.com").unwrap().allows(
-                &Origin::new("https://test.example.com").unwrap()
-            )
+            AllowOriginConfig::new("https://*.example.com")
+                .unwrap()
+                .allows(&Origin::new("https://test.example.com").unwrap())
         );
         assert!(
-            AllowOriginConfig::new("https://*.example.co.uk").unwrap().allows(
-                &Origin::new("https://test.example.co.uk").unwrap()
-            )
+            AllowOriginConfig::new("https://*.example.co.uk")
+                .unwrap()
+                .allows(&Origin::new("https://test.example.co.uk").unwrap())
         );
     }
 
     #[test]
     fn cors_deny_indirect_origin_subdomain() {
         assert!(
-            !AllowOriginConfig::new("https://*.example.com").unwrap().allows(
-                &Origin::new("https://a.b.example.com").unwrap()
-            )
+            !AllowOriginConfig::new("https://*.example.com")
+                .unwrap()
+                .allows(&Origin::new("https://a.b.example.com").unwrap())
         );
     }
 
     #[test]
     fn cors_deny_wrong_origin_subdomain() {
         assert!(
-            !AllowOriginConfig::new("https://b.example.com").unwrap().allows(
-                &Origin::new("https://a.b.example.com").unwrap()
-            )
+            !AllowOriginConfig::new("https://b.example.com")
+                .unwrap()
+                .allows(&Origin::new("https://a.b.example.com").unwrap())
         );
     }
 
     #[test]
     fn cors_deny_wrong_domain() {
         assert!(
-            !AllowOriginConfig::new("https://example.com").unwrap().allows(
-                &Origin::new("https://anexample.com").unwrap()
-            )
+            !AllowOriginConfig::new("https://example.com")
+                .unwrap()
+                .allows(&Origin::new("https://anexample.com").unwrap())
         );
         assert!(
-            !AllowOriginConfig::new("https://example.co.uk").unwrap().allows(
-                &Origin::new("https://example.uk").unwrap()
-            )
+            !AllowOriginConfig::new("https://example.co.uk")
+                .unwrap()
+                .allows(&Origin::new("https://example.uk").unwrap())
         );
         assert!(
-            !AllowOriginConfig::new("https://example.co.uk").unwrap().allows(
-                &Origin::new("https://example.co").unwrap()
-            )
+            !AllowOriginConfig::new("https://example.co.uk")
+                .unwrap()
+                .allows(&Origin::new("https://example.co").unwrap())
         );
     }
 
@@ -452,8 +468,14 @@ mod test {
 
     #[test]
     fn cors_ip_subdomain_wildcard_invalidation() {
-        assert_eq!(AllowOriginConfig::new("https://*.168.1.0:8080").unwrap_err(), CorsOriginError::InvalidOrigin(OriginError::FaultyIp));
-        assert_eq!(AllowOriginConfig::new("https://*.192.168.1.0:8080").unwrap_err(), CorsOriginError::FaultyWildcardInIp)
+        assert_eq!(
+            AllowOriginConfig::new("https://*.168.1.0:8080").unwrap_err(),
+            CorsOriginError::InvalidOrigin(OriginError::FaultyIp)
+        );
+        assert_eq!(
+            AllowOriginConfig::new("https://*.192.168.1.0:8080").unwrap_err(),
+            CorsOriginError::FaultyWildcardInIp
+        )
     }
 
     #[test]

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -138,7 +138,9 @@ impl AllowOriginConfig {
                         return false;
                     }
 
-                    let rest = incoming_origin.host().strip_suffix(cors_origin.base_origin.host()).expect("Incoming origin should end with CORS origin's base origin host.");
+                    let Some(rest) = incoming_origin.host().strip_suffix(cors_origin.base_origin.host()) else {
+                        return false; // If incoming origin doesn't end with Cors base origin, deny.
+                    };
                     if !rest.contains('.') {
                         return false; // Deny wrong domain
                     }

--- a/ohkami/src/fang/builtin/cors.rs
+++ b/ohkami/src/fang/builtin/cors.rs
@@ -133,22 +133,14 @@ impl AllowOriginConfig {
                     return cors_origin.base_origin.host() == incoming_origin.host();
                 }
 
-                if cors_origin.base_origin.host() != incoming_origin.host() { //Check if the options don't already align
-                    if !incoming_origin.host().ends_with(&cors_origin.base_origin.host()) {
-                        return false;
-                    }
-
-                    let Some(rest) = incoming_origin.host().strip_suffix(cors_origin.base_origin.host()) else {
-                        return false; // If incoming origin doesn't end with Cors base origin, deny.
-                    };
-                    if !rest.contains('.') {
-                        return false; // Deny wrong domain
-                    }
-                    if rest.contains("..") || rest.split('.').filter(|s| s != &"").count() >= 2 {
-                        return false; // Deny if not a direct subdomain
-                    }
+                if cors_origin.base_origin.host() == incoming_origin.host() {
+                    true
+                } else { //Check if the options don't already align
+                    incoming_origin
+                        .host()
+                        .split_once('.')
+                        .is_some_and(|(_, h)| h == cors_origin.base_origin.host())
                 }
-                true
             }
             AllowOriginConfig::Any => {
                 // Anything goes
@@ -338,8 +330,18 @@ mod test {
             )
         );
         assert!(
+            AllowOriginConfig::new("https://example.co.uk").unwrap().allows(
+                &Origin::new("https://example.co.uk").unwrap()
+            )
+        );
+        assert!(
             AllowOriginConfig::new("https://sub.example.com").unwrap().allows(
                 &Origin::new("https://sub.example.com").unwrap()
+            )
+        );
+        assert!(
+            AllowOriginConfig::new("https://sub.example.co.uk").unwrap().allows(
+                &Origin::new("https://sub.example.co.uk").unwrap()
             )
         );
     }
@@ -374,6 +376,11 @@ mod test {
                 &Origin::new("https://example.com:5173").unwrap()
             )
         );
+        assert!(
+            AllowOriginConfig::new("https://example.co.uk:*").unwrap().allows(
+                &Origin::new("https://example.co.uk:5173").unwrap()
+            )
+        );
     }
 
     #[test]
@@ -381,6 +388,11 @@ mod test {
         assert!(
             AllowOriginConfig::new("https://*.example.com").unwrap().allows(
                 &Origin::new("https://test.example.com").unwrap()
+            )
+        );
+        assert!(
+            AllowOriginConfig::new("https://*.example.co.uk").unwrap().allows(
+                &Origin::new("https://test.example.co.uk").unwrap()
             )
         );
     }
@@ -408,6 +420,16 @@ mod test {
         assert!(
             !AllowOriginConfig::new("https://example.com").unwrap().allows(
                 &Origin::new("https://anexample.com").unwrap()
+            )
+        );
+        assert!(
+            !AllowOriginConfig::new("https://example.co.uk").unwrap().allows(
+                &Origin::new("https://example.uk").unwrap()
+            )
+        );
+        assert!(
+            !AllowOriginConfig::new("https://example.co.uk").unwrap().allows(
+                &Origin::new("https://example.co").unwrap()
             )
         );
     }

--- a/ohkami/src/fang/builtin/csrf.rs
+++ b/ohkami/src/fang/builtin/csrf.rs
@@ -76,8 +76,8 @@ impl Csrf {
             .collect::<Vec<_>>();
 
         for origin in &trusted_origins {
-            super::validate_origin(origin)
-                .unwrap_or_else(|err| panic!("[Csrf::with_trusted_origins] {err}"))
+            super::Origin::new(origin)
+                .unwrap_or_else(|err| panic!("[Csrf::with_trusted_origins] {err}"));
         }
 
         Csrf {

--- a/ohkami/src/fang/builtin/enamel.rs
+++ b/ohkami/src/fang/builtin/enamel.rs
@@ -43,7 +43,7 @@ struct EnamelFields {
     content_security_policy: Option<CSP>,
     content_security_policy_report_only: Option<CSP>,
     cross_origin_embedder_policy: &'static str,
-    corss_origin_resource_policy: &'static str,
+    cross_origin_resource_policy: &'static str,
     referrer_policy: &'static str,
     strict_transport_security: &'static str,
     x_content_type_options: &'static str,
@@ -56,7 +56,7 @@ const _: () = {
                 content_security_policy: None,
                 content_security_policy_report_only: None,
                 cross_origin_embedder_policy: "require-corp",
-                corss_origin_resource_policy: "same-origin",
+                cross_origin_resource_policy: "same-origin",
                 referrer_policy: "no-referrer",
                 strict_transport_security: "max-age=15552000; includeSubDomains",
                 x_content_type_options: "nosniff",
@@ -95,11 +95,11 @@ const _: () = {
         /// default: `"same-origin"`
         ///
         /// set to `""` ( empty string ) for disabling the header
-        pub fn corss_origin_resource_policy(
+        pub fn cross_origin_resource_policy(
             mut self,
-            corss_origin_resource_policy: &'static str,
+            cross_origin_resource_policy: &'static str,
         ) -> Self {
-            inner_mut(&mut self).corss_origin_resource_policy = corss_origin_resource_policy;
+            inner_mut(&mut self).cross_origin_resource_policy = cross_origin_resource_policy;
             self
         }
         /// default: `"no-referrer"`
@@ -150,10 +150,10 @@ const _: () = {
                     .set()
                     .cross_origin_embedder_policy(self.0.cross_origin_embedder_policy);
             }
-            if !self.0.corss_origin_resource_policy.is_empty() {
+            if !self.0.cross_origin_resource_policy.is_empty() {
                 res.headers
                     .set()
-                    .cross_origin_resource_policy(self.0.corss_origin_resource_policy);
+                    .cross_origin_resource_policy(self.0.cross_origin_resource_policy);
             }
             if !self.0.referrer_policy.is_empty() {
                 res.headers.set().referrer_policy(self.0.referrer_policy);
@@ -754,7 +754,7 @@ mod test {
         let t = Ohkami::new((
             Enamel::default()
                 .cross_origin_embedder_policy("")
-                .corss_origin_resource_policy(""),
+                .cross_origin_resource_policy(""),
             "/hello".GET(|| async { "Hello, enamel!" }),
         ))
         .test();

--- a/ohkami/src/response/mod.rs
+++ b/ohkami/src/response/mod.rs
@@ -141,17 +141,14 @@ impl Response {
                 }
             }
             #[cfg(feature = "sse")]
-            (Content::Stream(_), _) => {
-                if self.headers.content_length().is_some() {
-                    self.headers.set().content_length(None);
-                }
+            (Content::Stream(_), _) if self.headers.content_length().is_some() => {
+                self.headers.set().content_length(None);
             }
+
             #[cfg(not(feature="rt_lambda"/* currently */))]
             #[cfg(all(feature = "ws", feature = "__rt__"))]
-            (Content::WebSocket(_), _) => {
-                if self.headers.content_length().is_some() {
-                    self.headers.set().content_length(None);
-                }
+            (Content::WebSocket(_), _) if self.headers.content_length().is_some() => {
+                self.headers.set().content_length(None);
             }
             _ => (/* let it go by user's responsibility */),
         }


### PR DESCRIPTION
This pull request adds the following for #542:

 1.   `Cors` now allows alphanumeric characters in the verify function, so IP-addresses are supported.
  2. `Cors` now allows wildcards for subdomains and ports: `*`.
  3.  `Enamel::corss_origin_resource_policy` has been renamed to `Enamel::cross_origin_resource_policy` and will have to be renamed in projects using this fang.

Please let me know if you have any suggestions or ideas on things that might be missing or not as intended