### PR TITLE
fix(ohkami_lib): `Command::new` with `date` instead of `/usr/bin/date` for better portability

### DIFF
--- a/ohkami_lib/src/time.rs
+++ b/ohkami_lib/src/time.rs
@@ -489,7 +489,7 @@ mod test {
     #[test]
     fn test_now() {
         fn correct_now() -> String {
-            let mut output_bytes = std::process::Command::new("/usr/bin/date")
+            let mut output_bytes = std::process::Command::new("date")
                 .env("LANG", "en_US")
                 .arg("+'%a, %d %b %Y %H:%M:%S GMT'")
                 .arg("-u")


### PR DESCRIPTION
On NixOS, for example, `/usr/bin/date` does not exist, while `date` command does