### PR TITLE
chore: bump `worker` 0.7 -> 0.8

### DIFF
--- a/ohkami/Cargo.toml
+++ b/ohkami/Cargo.toml
@@ -37,7 +37,7 @@ glommio        = { version = "0.9",  optional = true }
 monoio         = { version = "0.2",  optional = true, features = ["signal"] }
 monoio-compat  = { version = "0.2",  optional = true }
 compio         = { version = "0.18", optional = true, features = ["io-compat", "time"] }
-worker         = { version = "0.7",  optional = true }
+worker         = { version = "0.8",  optional = true }
 lambda_runtime = { version = "1.1", optional = true }
 
 # encoding / crypto

--- a/samples/worker-bindings-jsonc/Cargo.toml
+++ b/samples/worker-bindings-jsonc/Cargo.toml
@@ -9,5 +9,5 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 # set `default-features = false` to assure "DEBUG" feature be off even when DEBUGing `../ohkami`
 ohkami = { path = "../../ohkami", default-features = false, features = ["rt_worker"] }
-worker = { version = "0.7", features = ["queue", "d1"] }
+worker = { version = "0.8", features = ["queue", "d1"] }
 console_error_panic_hook = "0.1"

--- a/samples/worker-bindings/Cargo.toml
+++ b/samples/worker-bindings/Cargo.toml
@@ -9,5 +9,5 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 # set `default-features = false` to assure "DEBUG" feature be off even when DEBUGing `../ohkami`
 ohkami = { path = "../../ohkami", default-features = false, features = ["rt_worker"] }
-worker = { version = "0.7", features = ["queue", "d1"] }
+worker = { version = "0.8", features = ["queue", "d1"] }
 console_error_panic_hook = "0.1"

--- a/samples/worker-durable-websocket/Cargo.toml
+++ b/samples/worker-durable-websocket/Cargo.toml
@@ -9,4 +9,4 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 # set `default-features = false` to assure "DEBUG" feature be off even when DEBUGing `../ohkami`
 ohkami = { path = "../../ohkami", default-features = false, features = ["rt_worker", "ws"] }
-worker = { version = "0.7" }
+worker = { version = "0.8" }

--- a/samples/worker-with-global-bindings/Cargo.toml
+++ b/samples/worker-with-global-bindings/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 # set `default-features = false` to assure "DEBUG" feature be off even when DEBUGing `../ohkami`
 ohkami = { path = "../../ohkami", default-features = false, features = ["rt_worker"] }
-worker = { version = "0.7", features = ["d1"] }
+worker = { version = "0.8", features = ["d1"] }
 thiserror = "1.0"
 console_error_panic_hook = "0.1"
 

--- a/samples/worker-with-openapi/Cargo.toml
+++ b/samples/worker-with-openapi/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 # set `default-features = false` to assure "DEBUG" feature be off even when DEBUGing `../ohkami`
 ohkami = { path = "../../ohkami", default-features = false, features = ["rt_worker"] }
-worker = { version = "0.7", features = ["d1"] }
+worker = { version = "0.8", features = ["d1"] }
 thiserror = "1.0"
 console_error_panic_hook = "0.1"
 


### PR DESCRIPTION
At least during v0, `ohkami` will follow updates of actively-developed runtime crates, including `worker`, in patch releases like this.